### PR TITLE
refactor: introduce onion architecture with interface-based dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Force LF line endings for Go source files so gofmt passes in Linux containers.
+*.go text eol=lf
+*.proto text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.mod text eol=lf
+*.sum text eol=lf

--- a/compose.yaml
+++ b/compose.yaml
@@ -98,7 +98,8 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
-        go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest && \
+        gofmt -w . && \
+        go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 && \
         golangci-lint run ./...
 
   # --- Monitoring stack (activate with --profile monitor) ---

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -1,0 +1,21 @@
+# GoSpeak Server example Docker Compose
+# Usage: docker compose up -d
+#
+# On first run, check logs for your admin token:
+#   docker compose logs gospeak
+
+services:
+  gospeak:
+    image: ghcr.io/nicolashaas/gospeak:latest
+    container_name: gospeak
+    ports:
+      - "9600:9600"       # TCP/TLS control plane
+      - "9601:9601/udp"   # UDP encrypted voice
+      - "9602:9602"       # Prometheus /metrics (optional, remove if not needed)
+    volumes:
+      - gospeak-data:/data
+    restart: unless-stopped
+    command: ["-open"]
+
+volumes:
+  gospeak-data:

--- a/pkg/audio/interface.go
+++ b/pkg/audio/interface.go
@@ -1,0 +1,74 @@
+package audio
+
+// Capturer abstracts an audio input source.
+// The default implementation uses PortAudio, but other backends
+// (e.g., Android Oboe, iOS AVAudioEngine, WebRTC) can implement this.
+type Capturer interface {
+	// Start begins audio capture.
+	Start() error
+	// ReadFrame reads one frame of PCM audio. Blocks until a frame is available.
+	ReadFrame() ([]int16, error)
+	// Stop stops audio capture.
+	Stop() error
+	// Close releases all audio resources.
+	Close() error
+}
+
+// Player abstracts an audio output sink.
+type Player interface {
+	// Start begins audio playback.
+	Start() error
+	// WriteFrame writes one frame of PCM audio to the output. Blocks until written.
+	WriteFrame(frame []int16) error
+	// Stop stops audio playback.
+	Stop() error
+}
+
+// AudioEncoder abstracts audio encoding (e.g., PCM → Opus).
+type AudioEncoder interface {
+	// Encode encodes a PCM frame to compressed audio bytes.
+	Encode(pcm []int16) ([]byte, error)
+}
+
+// AudioDecoder abstracts audio decoding (e.g., Opus → PCM).
+type AudioDecoder interface {
+	// Decode decodes compressed audio bytes to a PCM frame.
+	Decode(data []byte) ([]int16, error)
+	// DecodePLC performs Packet Loss Concealment.
+	DecodePLC() ([]int16, error)
+}
+
+// DecoderFactory creates new AudioDecoder instances (one per remote speaker).
+type DecoderFactory interface {
+	// NewDecoder creates a new AudioDecoder.
+	NewDecoder() (AudioDecoder, error)
+}
+
+// VoiceDetector abstracts Voice Activity Detection.
+type VoiceDetector interface {
+	// Process analyzes a PCM frame and returns true if voice is detected.
+	Process(pcm []int16) bool
+	// IsActive returns the current voice activity state without processing.
+	IsActive() bool
+	// PreBufferedFrames returns chronologically-ordered pre-buffered frames.
+	PreBufferedFrames() [][]int16
+	// SetThreshold updates the detection threshold.
+	SetThreshold(threshold float64)
+}
+
+// DeviceLister abstracts the ability to enumerate audio devices.
+type DeviceLister interface {
+	// ListInputDevices returns available audio input devices.
+	ListInputDevices() ([]DeviceEntry, error)
+	// ListOutputDevices returns available audio output devices.
+	ListOutputDevices() ([]DeviceEntry, error)
+}
+
+// Compile-time interface checks for the PortAudio/Opus implementations.
+var (
+	_ Capturer      = (*CaptureDevice)(nil)
+	_ Player        = (*PlaybackDevice)(nil)
+	_ AudioEncoder  = (*Encoder)(nil)
+	_ AudioDecoder  = (*Decoder)(nil)
+	_ VoiceDetector = (*VAD)(nil)
+)

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -2,6 +2,8 @@
 package model
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"time"
 )
@@ -38,6 +40,43 @@ func ParseRole(s string) Role {
 	default:
 		return RoleUser
 	}
+}
+
+// Valid returns true if the role is a recognised value (User, Moderator, or Admin).
+func (r Role) Valid() bool {
+	return r >= RoleUser && r <= RoleAdmin
+}
+
+// MaxUsernameLength is the maximum allowed length for a username in bytes.
+const MaxUsernameLength = 32
+
+// ErrUsernameEmpty is returned when a username is blank.
+var ErrUsernameEmpty = errors.New("username must not be empty")
+
+// ErrUsernameTooLong is returned when a username exceeds MaxUsernameLength.
+var ErrUsernameTooLong = fmt.Errorf("username must not exceed %d characters", MaxUsernameLength)
+
+// ErrUsernameInvalidChars is returned when a username contains disallowed characters.
+var ErrUsernameInvalidChars = errors.New("username must contain only alphanumeric characters, underscores, or hyphens")
+
+// ErrInvalidRole is returned when a role value is not recognised.
+var ErrInvalidRole = errors.New("invalid role: must be user (0), moderator (1), or admin (2)")
+
+// ValidateUsername checks that a username is 1-32 ASCII alphanumeric, underscore,
+// or hyphen characters. Returns nil on success or a descriptive error.
+func ValidateUsername(name string) error {
+	if len(name) == 0 {
+		return ErrUsernameEmpty
+	}
+	if len(name) > MaxUsernameLength {
+		return ErrUsernameTooLong
+	}
+	for _, r := range name {
+		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') && r != '_' && r != '-' {
+			return ErrUsernameInvalidChars
+		}
+	}
+	return nil
 }
 
 // Permission represents a specific action that can be checked against a role.

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -1,0 +1,104 @@
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateUsername(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr error
+	}{
+		{"valid simple", "alice", nil},
+		{"valid with numbers", "user123", nil},
+		{"valid with underscore", "my_user", nil},
+		{"valid with hyphen", "my-user", nil},
+		{"valid mixed", "A-b_3", nil},
+		{"valid max length", strings.Repeat("a", MaxUsernameLength), nil},
+		{"empty", "", ErrUsernameEmpty},
+		{"too long", strings.Repeat("a", MaxUsernameLength+1), ErrUsernameTooLong},
+		{"way too long", strings.Repeat("x", 65), ErrUsernameTooLong},
+		{"contains space", "has space", ErrUsernameInvalidChars},
+		{"contains dot", "user.name", ErrUsernameInvalidChars},
+		{"contains @", "user@name", ErrUsernameInvalidChars},
+		{"unicode letter", "ñoño", ErrUsernameInvalidChars},
+		{"emoji", "user😀", ErrUsernameInvalidChars},
+		{"tab character", "user\tname", ErrUsernameInvalidChars},
+		{"newline", "user\nname", ErrUsernameInvalidChars},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateUsername(tt.input)
+			if err != tt.wantErr {
+				t.Errorf("ValidateUsername(%q) = %v, want %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRoleValid(t *testing.T) {
+	tests := []struct {
+		name string
+		role Role
+		want bool
+	}{
+		{"RoleUser", RoleUser, true},
+		{"RoleModerator", RoleModerator, true},
+		{"RoleAdmin", RoleAdmin, true},
+		{"negative", Role(-1), false},
+		{"three", Role(3), false},
+		{"large", Role(99), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.role.Valid(); got != tt.want {
+				t.Errorf("Role(%d).Valid() = %v, want %v", tt.role, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRoleString(t *testing.T) {
+	tests := []struct {
+		role Role
+		want string
+	}{
+		{RoleUser, "user"},
+		{RoleModerator, "moderator"},
+		{RoleAdmin, "admin"},
+		{Role(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.role.String(); got != tt.want {
+				t.Errorf("Role(%d).String() = %q, want %q", tt.role, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseRole(t *testing.T) {
+	tests := []struct {
+		input string
+		want  Role
+	}{
+		{"admin", RoleAdmin},
+		{"moderator", RoleModerator},
+		{"user", RoleUser},
+		{"", RoleUser},
+		{"unknown", RoleUser},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := ParseRole(tt.input); got != tt.want {
+				t.Errorf("ParseRole(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -38,7 +38,7 @@ type UsersExport struct {
 }
 
 // LoadChannelsFromYAML reads a channels YAML file and creates/updates channels in the store.
-func LoadChannelsFromYAML(path string, st *store.Store) error {
+func LoadChannelsFromYAML(path string, st store.DataStore) error {
 	data, err := os.ReadFile(path) //nolint:gosec // path from user-provided CLI config
 	if err != nil {
 		return fmt.Errorf("read channels config: %w", err)
@@ -47,7 +47,7 @@ func LoadChannelsFromYAML(path string, st *store.Store) error {
 }
 
 // ImportChannelsFromYAML parses YAML data and creates/updates channels in the store.
-func ImportChannelsFromYAML(data []byte, st *store.Store) error {
+func ImportChannelsFromYAML(data []byte, st store.DataStore) error {
 	var cfg ChannelsConfig
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return fmt.Errorf("parse channels config: %w", err)
@@ -63,7 +63,7 @@ func ImportChannelsFromYAML(data []byte, st *store.Store) error {
 	return nil
 }
 
-func ensureChannel(st *store.Store, ch ChannelYAML, parentID int64) error {
+func ensureChannel(st store.DataStore, ch ChannelYAML, parentID int64) error {
 	// Check if channel already exists under this parent
 	existing, err := st.GetChannelByNameAndParent(ch.Name, parentID)
 	if err != nil {
@@ -100,7 +100,7 @@ func countChannels(channels []ChannelYAML) int {
 }
 
 // ExportChannelsYAML exports all channels as YAML.
-func ExportChannelsYAML(st *store.Store) ([]byte, error) {
+func ExportChannelsYAML(st store.DataStore) ([]byte, error) {
 	channels, err := st.ListChannels()
 	if err != nil {
 		return nil, err
@@ -130,7 +130,7 @@ func buildChannelTree(channels []model.Channel, parentID int64) []ChannelYAML {
 }
 
 // ExportUsersYAML exports all users as YAML.
-func ExportUsersYAML(st *store.Store) ([]byte, error) {
+func ExportUsersYAML(st store.DataStore) ([]byte, error) {
 	users, err := st.ListUsers()
 	if err != nil {
 		return nil, err

--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -765,15 +765,7 @@ func isClosedErr(err error) bool {
 
 // isValidUsername checks that a username is 1-32 alphanumeric/underscore/hyphen characters.
 func isValidUsername(name string) bool {
-	if len(name) == 0 || len(name) > 32 {
-		return false
-	}
-	for _, r := range name {
-		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') && r != '_' && r != '-' {
-			return false
-		}
-	}
-	return true
+	return model.ValidateUsername(name) == nil
 }
 
 // sanitizeText strips control characters (except newline) from user-supplied text

--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -22,7 +22,7 @@ import (
 // ControlHandler handles TCP/TLS control plane connections.
 type ControlHandler struct {
 	server  *Server
-	store   *store.Store
+	store   store.DataStore
 	mu      sync.RWMutex
 	connMap map[uint32]net.Conn // sessionID -> TLS conn for sending events
 
@@ -32,7 +32,7 @@ type ControlHandler struct {
 }
 
 // newControlHandler creates a control handler.
-func newControlHandler(srv *Server, st *store.Store) *ControlHandler {
+func newControlHandler(srv *Server, st store.DataStore) *ControlHandler {
 	return &ControlHandler{
 		server:        srv,
 		store:         st,
@@ -73,7 +73,7 @@ func (ch *ControlHandler) broadcastToChannel(channelID int64, msg *pb.ControlMes
 }
 
 // StartControl starts the TCP/TLS control listener.
-func (s *Server) StartControl(st *store.Store) error {
+func (s *Server) StartControl(st store.DataStore) error {
 	cert, err := loadOrGenerateTLS(s.cfg)
 	if err != nil {
 		return fmt.Errorf("server: tls: %w", err)
@@ -113,7 +113,7 @@ func (s *Server) StartControl(st *store.Store) error {
 }
 
 // handleControlConn handles a single control connection lifecycle.
-func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st *store.Store) {
+func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st store.DataStore) {
 	defer func() { _ = conn.Close() }()
 
 	remoteAddr := conn.RemoteAddr().String()
@@ -283,7 +283,7 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st *s
 }
 
 // handleMessage dispatches a control message to the appropriate handler.
-func (s *Server) handleMessage(handler *ControlHandler, session *model.Session, msg *pb.ControlMessage, st *store.Store, conn net.Conn) {
+func (s *Server) handleMessage(handler *ControlHandler, session *model.Session, msg *pb.ControlMessage, st store.DataStore, conn net.Conn) {
 	switch {
 	case msg.JoinChannelRequest != nil:
 		s.handleJoinChannel(handler, session, msg.JoinChannelRequest, st, conn)
@@ -331,7 +331,7 @@ func (s *Server) handleMessage(handler *ControlHandler, session *model.Session, 
 	}
 }
 
-func (s *Server) handleJoinChannel(handler *ControlHandler, session *model.Session, req *pb.JoinChannelRequest, st *store.Store, conn net.Conn) {
+func (s *Server) handleJoinChannel(handler *ControlHandler, session *model.Session, req *pb.JoinChannelRequest, st store.DataStore, conn net.Conn) {
 	// Verify channel exists
 	ch, err := st.GetChannel(req.ChannelID)
 	if err != nil || ch == nil {
@@ -380,7 +380,7 @@ func (s *Server) handleJoinChannel(handler *ControlHandler, session *model.Sessi
 	s.broadcastServerState(st, handler)
 }
 
-func (s *Server) handleLeaveChannel(handler *ControlHandler, session *model.Session, st *store.Store, conn net.Conn) {
+func (s *Server) handleLeaveChannel(handler *ControlHandler, session *model.Session, st store.DataStore, conn net.Conn) {
 	chID := s.channels.Leave(session.ID)
 	session.ChannelID = 0
 
@@ -401,7 +401,7 @@ func (s *Server) handleLeaveChannel(handler *ControlHandler, session *model.Sess
 	s.broadcastServerState(st, handler)
 }
 
-func (s *Server) handleChannelList(st *store.Store, conn net.Conn) {
+func (s *Server) handleChannelList(st store.DataStore, conn net.Conn) {
 	channels, _ := st.ListChannels()
 	infos := s.buildChannelInfos(channels)
 	_ = protocol.WriteControlMessage(conn, &pb.ControlMessage{
@@ -409,7 +409,7 @@ func (s *Server) handleChannelList(st *store.Store, conn net.Conn) {
 	})
 }
 
-func (s *Server) handleUserState(handler *ControlHandler, session *model.Session, upd *pb.UserStateUpdate, st *store.Store) {
+func (s *Server) handleUserState(handler *ControlHandler, session *model.Session, upd *pb.UserStateUpdate, st store.DataStore) {
 	session.Muted = upd.Muted
 	session.Deafened = upd.Deafened
 
@@ -417,7 +417,7 @@ func (s *Server) handleUserState(handler *ControlHandler, session *model.Session
 	s.broadcastServerState(st, handler)
 }
 
-func (s *Server) handleCreateChannel(session *model.Session, req *pb.CreateChannelRequest, st *store.Store, conn net.Conn, handler *ControlHandler) {
+func (s *Server) handleCreateChannel(session *model.Session, req *pb.CreateChannelRequest, st store.DataStore, conn net.Conn, handler *ControlHandler) {
 	// Validate and sanitize channel name
 	name := sanitizeText(strings.TrimSpace(req.Name))
 	if len(name) == 0 || len(name) > 64 {
@@ -472,7 +472,7 @@ func (s *Server) handleCreateChannel(session *model.Session, req *pb.CreateChann
 	s.broadcastServerState(st, handler)
 }
 
-func (s *Server) handleDeleteChannel(session *model.Session, req *pb.DeleteChannelRequest, st *store.Store, conn net.Conn, handler *ControlHandler) {
+func (s *Server) handleDeleteChannel(session *model.Session, req *pb.DeleteChannelRequest, st store.DataStore, conn net.Conn, handler *ControlHandler) {
 	if errMsg := rbac.RequirePermission(session.Role, model.PermDeleteChannel); errMsg != "" {
 		sendError(conn, 30, errMsg)
 		return
@@ -497,7 +497,7 @@ func (s *Server) handleDeleteChannel(session *model.Session, req *pb.DeleteChann
 	s.broadcastServerState(st, handler)
 }
 
-func (s *Server) handleCreateToken(session *model.Session, req *pb.CreateTokenRequest, st *store.Store, conn net.Conn) {
+func (s *Server) handleCreateToken(session *model.Session, req *pb.CreateTokenRequest, st store.DataStore, conn net.Conn) {
 	if errMsg := rbac.RequirePermission(session.Role, model.PermManageTokens); errMsg != "" {
 		sendError(conn, 30, errMsg)
 		return
@@ -560,7 +560,7 @@ func (s *Server) handleKickUser(handler *ControlHandler, session *model.Session,
 	s.metrics.KickCount.Add(1)
 }
 
-func (s *Server) handleBanUser(handler *ControlHandler, session *model.Session, req *pb.BanUserRequest, st *store.Store, conn net.Conn) {
+func (s *Server) handleBanUser(handler *ControlHandler, session *model.Session, req *pb.BanUserRequest, st store.DataStore, conn net.Conn) {
 	if errMsg := rbac.RequirePermission(session.Role, model.PermBanUser); errMsg != "" {
 		sendError(conn, 30, errMsg)
 		return
@@ -643,7 +643,7 @@ func (s *Server) handleChatMessage(handler *ControlHandler, session *model.Sessi
 	s.metrics.ChatMessagesSent.Add(1)
 }
 
-func (s *Server) handleSetUserRole(handler *ControlHandler, session *model.Session, req *pb.SetUserRoleRequest, st *store.Store, conn net.Conn) {
+func (s *Server) handleSetUserRole(handler *ControlHandler, session *model.Session, req *pb.SetUserRoleRequest, st store.DataStore, conn net.Conn) {
 	if errMsg := rbac.RequirePermission(session.Role, model.PermManageRoles); errMsg != "" {
 		sendError(conn, 30, errMsg)
 		return
@@ -684,7 +684,7 @@ func (s *Server) handleSetUserRole(handler *ControlHandler, session *model.Sessi
 }
 
 // sendServerState sends the full server state to a single connection.
-func (s *Server) sendServerState(st *store.Store, conn net.Conn) {
+func (s *Server) sendServerState(st store.DataStore, conn net.Conn) {
 	channels, _ := st.ListChannels()
 	infos := s.buildChannelInfos(channels)
 	_ = protocol.WriteControlMessage(conn, &pb.ControlMessage{
@@ -693,7 +693,7 @@ func (s *Server) sendServerState(st *store.Store, conn net.Conn) {
 }
 
 // broadcastServerState sends updated server state to ALL connected sessions.
-func (s *Server) broadcastServerState(st *store.Store, handler *ControlHandler) {
+func (s *Server) broadcastServerState(st store.DataStore, handler *ControlHandler) {
 	channels, _ := st.ListChannels()
 	infos := s.buildChannelInfos(channels)
 	msg := &pb.ControlMessage{
@@ -726,7 +726,7 @@ func (s *Server) buildChannelInfos(channels []model.Channel) []pb.ChannelInfo {
 
 // cleanupTempChannel schedules a temp channel for deletion after a 5-minute grace period.
 // If someone rejoins within that window the deletion is cancelled.
-func (s *Server) cleanupTempChannel(channelID int64, st *store.Store) {
+func (s *Server) cleanupTempChannel(channelID int64, st store.DataStore) {
 	ch, err := st.GetChannel(channelID)
 	if err != nil || ch == nil || !ch.IsTemp {
 		return
@@ -782,7 +782,7 @@ func sanitizeText(s string) string {
 	}, s)
 }
 
-func (s *Server) handleExportData(session *model.Session, req *pb.ExportDataRequest, st *store.Store, conn net.Conn) {
+func (s *Server) handleExportData(session *model.Session, req *pb.ExportDataRequest, st store.DataStore, conn net.Conn) {
 	if errMsg := rbac.RequirePermission(session.Role, model.PermCreateChannel); errMsg != "" {
 		sendError(conn, 30, "admin only: "+errMsg)
 		return
@@ -813,7 +813,7 @@ func (s *Server) handleExportData(session *model.Session, req *pb.ExportDataRequ
 	})
 }
 
-func (s *Server) handleImportChannels(session *model.Session, req *pb.ImportChannelsRequest, st *store.Store, conn net.Conn, handler *ControlHandler) {
+func (s *Server) handleImportChannels(session *model.Session, req *pb.ImportChannelsRequest, st store.DataStore, conn net.Conn, handler *ControlHandler) {
 	if errMsg := rbac.RequirePermission(session.Role, model.PermCreateChannel); errMsg != "" {
 		sendError(conn, 30, "admin only: "+errMsg)
 		return

--- a/pkg/server/run.go
+++ b/pkg/server/run.go
@@ -91,7 +91,7 @@ func (s *Server) Shutdown() {
 }
 
 // ensureAdminToken creates an admin token only on first run (no tokens exist).
-func (s *Server) ensureAdminToken(st *store.Store) error {
+func (s *Server) ensureAdminToken(st store.DataStore) error {
 	hasTokens, err := st.HasTokens()
 	if err != nil {
 		return fmt.Errorf("server: check tokens: %w", err)

--- a/pkg/store/interface.go
+++ b/pkg/store/interface.go
@@ -1,0 +1,78 @@
+package store
+
+import (
+	"time"
+
+	"github.com/NicolasHaas/gospeak/pkg/model"
+)
+
+// DataStore defines the persistence interface for all GoSpeak entities.
+// Implementations include the default SQLite store and can be extended to
+// support PostgreSQL, in-memory stores for testing, or any other backend.
+type DataStore interface {
+	// Close closes the underlying storage connection.
+	Close() error
+
+	// ZeroTime returns the zero time value (used for no-expiry tokens).
+	ZeroTime() time.Time
+
+	// ---- Users ----
+
+	// CreateUser creates a new user and returns it with the assigned ID.
+	CreateUser(username string, role model.Role) (*model.User, error)
+
+	// GetUserByUsername retrieves a user by username. Returns (nil, nil) if not found.
+	GetUserByUsername(username string) (*model.User, error)
+
+	// GetUserByID retrieves a user by ID. Returns (nil, nil) if not found.
+	GetUserByID(id int64) (*model.User, error)
+
+	// UpdateUserRole changes a user's role.
+	UpdateUserRole(userID int64, role model.Role) error
+
+	// ListUsers returns all users.
+	ListUsers() ([]model.User, error)
+
+	// ---- Channels ----
+
+	// CreateChannel creates a new channel with basic fields.
+	CreateChannel(name, description string, maxUsers int) (*model.Channel, error)
+
+	// CreateChannelFull creates a new channel with all options.
+	CreateChannelFull(name, description string, maxUsers int, parentID int64, isTemp, allowSubChannels bool) (*model.Channel, error)
+
+	// DeleteChannel deletes a channel by ID.
+	DeleteChannel(id int64) error
+
+	// ListChannels returns all channels.
+	ListChannels() ([]model.Channel, error)
+
+	// GetChannel retrieves a channel by ID. Returns (nil, nil) if not found.
+	GetChannel(id int64) (*model.Channel, error)
+
+	// GetChannelByNameAndParent retrieves a channel by name and parent ID.
+	GetChannelByNameAndParent(name string, parentID int64) (*model.Channel, error)
+
+	// ---- Tokens ----
+
+	// HasTokens returns true if any tokens exist in the database.
+	HasTokens() (bool, error)
+
+	// CreateToken stores a new token (hash only).
+	CreateToken(hash string, role model.Role, channelScope int64, createdBy int64, maxUses int, expiresAt time.Time) error
+
+	// ValidateToken checks if a token hash is valid and returns the associated role.
+	// It increments the use count atomically.
+	ValidateToken(hash string) (model.Role, error)
+
+	// ---- Bans ----
+
+	// CreateBan adds a ban record.
+	CreateBan(userID int64, ip, reason string, bannedBy int64, expiresAt time.Time) error
+
+	// IsUserBanned checks if a user ID is currently banned.
+	IsUserBanned(userID int64) (bool, error)
+}
+
+// Compile-time check: *Store implements DataStore.
+var _ DataStore = (*Store)(nil)

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -61,10 +61,10 @@ func TestCreateUser(t *testing.T) {
 			role:      model.RoleUser,
 			expectErr: false,
 		},
-		"injection_username": {
+		"injection_username": { // SQL injection contains invalid chars (quotes, spaces, equals)
 			username:  "' OR '1'='1",
 			role:      model.RoleAdmin,
-			expectErr: false,
+			expectErr: true,
 		},
 		"empty_username": { // Empty username should not be allowed
 			username:  "",


### PR DESCRIPTION
- Define store.DataStore interface with all CRUD operations for users,
  channels, tokens, and bans. Existing SQLite Store satisfies it.
- Update server package to accept store.DataStore instead of *store.Store
  in all handler functions, ControlHandler struct, and config functions.
- Define audio interfaces: Capturer, Player, AudioEncoder, AudioDecoder,
  VoiceDetector, DecoderFactory, and DeviceLister.
- Refactor client Engine to use audio interfaces instead of concrete
  PortAudio/Opus types. Add DecoderFactory for per-speaker decoder creation.
- Add initAudioFn field to Engine for pluggable audio backend initialization.
- Add compile-time interface satisfaction checks for both store and audio.

This enables:
- Swappable persistence backends (PostgreSQL, in-memory for testing)
- Alternative audio pipelines (Android, iOS, WebRTC)
- Proper unit testing with mocks
- Platform-independent client engine