### PR TITLE
test: finishes test coverage for data store

### DIFF
--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NicolasHaas/gospeak/pkg/crypto"
 	"github.com/NicolasHaas/gospeak/pkg/model"
 	"github.com/NicolasHaas/gospeak/pkg/store"
 
@@ -93,12 +94,12 @@ func TestCreateUser(t *testing.T) {
 			got, err := store.CreateUser(tc.username, tc.role)
 			if tc.expectErr {
 				if err == nil {
-					t.Fatalf("expected error, got nil")
+					t.Fatalf("CreateUser: expected error, got nil")
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+				t.Fatalf("CreateUser: unexpected error: %v", err)
 			}
 
 			want := &model.User{
@@ -155,21 +156,20 @@ func TestGetUserByUsername(t *testing.T) {
 			if tc.seedUser {
 				u, err := store.CreateUser(tc.username, tc.role)
 				if err != nil {
-					t.Fatalf("failed to seed user: %v", err)
+					t.Fatalf("CreateUser: failed to seed user: %v", err)
 				}
 				seeded = u
 			}
 
 			got, err := store.GetUserByUsername(tc.username)
-
 			if !tc.expectUser {
 				if got != nil {
-					t.Fatalf("expected nil, got user")
+					t.Fatalf("GetUserByUsername: expected nil, got user")
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+				t.Fatalf("GetUserByUsername: unexpected error: %v", err)
 			}
 
 			want := &model.User{
@@ -200,12 +200,12 @@ func TestGetUserByID(t *testing.T) {
 
 	_, err = store.CreateUser("johndoe", model.RoleUser)
 	if err != nil {
-		t.Fatalf("failed to seed user: %v", err)
+		t.Fatalf("CreateUser: failed to seed user: %v", err)
 	}
 
 	res, err := store.GetUserByID(want)
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("GetUserByID: unexpected error: %v", err)
 	}
 
 	got := res.ID
@@ -241,11 +241,11 @@ func TestUpdateUserRole(t *testing.T) {
 
 			u, err := store.CreateUser(tc.username, tc.role)
 			if err != nil {
-				t.Fatalf("failed to seed user: %v", err)
+				t.Fatalf("CreateUser: failed to seed user: %v", err)
 			}
 
 			if err := store.UpdateUserRole(u.ID, model.RoleAdmin); err != nil {
-				t.Fatalf("unexpected error: %v", err)
+				t.Fatalf("UpdateUserRole: unexpected error: %v", err)
 			}
 
 			want := &model.User{
@@ -255,7 +255,7 @@ func TestUpdateUserRole(t *testing.T) {
 
 			got, err := store.GetUserByID(u.ID)
 			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+				t.Fatalf("GetUserByID: unexpected error: %v", err)
 			}
 
 			if diff := cmp.Diff(want.Role, got.Role); diff != "" {
@@ -303,17 +303,736 @@ func TestListUsers(t *testing.T) {
 			for _, user := range tc.users {
 				_, err := store.CreateUser(user.Username, user.Role)
 				if err != nil {
-					t.Fatalf("failed to seed user: %v", err)
+					t.Fatalf("CreateUser: failed to seed user: %v", err)
 				}
 			}
 
 			users, err := store.ListUsers()
 			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+				t.Fatalf("ListUsers: unexpected error: %v", err)
 			}
 
 			if diff := cmp.Diff(tc.users, users, cmpopts.IgnoreFields(model.User{}, "ID", "CreatedAt")); diff != "" {
 				t.Fatalf("ListUsers mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCreateChannel(t *testing.T) {
+	t.Parallel()
+
+	type tcase struct {
+		name             string
+		description      string
+		maxUsers         int
+		expectedResponse *model.Channel
+		expecErr         bool
+	}
+
+	channelName, channelDescription := "New Channel", "A brand new channel"
+	channelMaxUsers := 10
+
+	tests := map[string]tcase{
+		"minimum_required_fields": {
+			name:        channelName,
+			description: channelDescription,
+			maxUsers:    channelMaxUsers,
+			expectedResponse: &model.Channel{
+				Name:             channelName,
+				Description:      channelDescription,
+				MaxUsers:         channelMaxUsers,
+				ParentID:         0,
+				IsTemp:           false,
+				AllowSubChannels: false,
+			},
+			expecErr: false,
+		},
+		"invalid_name": {
+			name:        "",
+			description: "Desc",
+			maxUsers:    1,
+			expecErr:    true,
+		},
+		"invalid_desc": {
+			name:        "Name",
+			description: "",
+			maxUsers:    1,
+			expecErr:    true,
+		},
+		"invalid_max_users": {
+			name:        "Name",
+			description: "Desc",
+			maxUsers:    0,
+			expecErr:    true,
+		},
+		"excessive_paramater_values": {
+			name:        "24433252080542468109190329288548376491503980265648043643151614656",
+			description: "24433252080542468109190329288548376491503980265648043643151614656",
+			maxUsers:    257,
+			expecErr:    true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := NewTestSqlConn(t)
+			if err != nil {
+				t.Fatalf("failed to open test connection: %v", err)
+			}
+
+			channel, err := store.CreateChannel(tc.name, tc.description, tc.maxUsers)
+			if tc.expecErr {
+				if err == nil {
+					t.Fatalf("CreateChannel: expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CreateChannel: unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.expectedResponse, channel, cmpopts.IgnoreFields(model.Channel{}, "ID", "CreatedAt")); diff != "" {
+				t.Fatalf("CreateChannel mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCreateChannelFull(t *testing.T) {
+	t.Parallel()
+
+	type tcase struct {
+		name             string
+		description      string
+		maxUsers         int
+		parentID         int64
+		isTempChannel    bool
+		allowSubChannels bool
+		expectedResponse *model.Channel
+		expecErr         bool
+	}
+
+	channelName, channelDescription := "New Channel", "A brand new channel"
+	channelMaxUsers := 10
+	channelParentID := int64(10)
+	channelIsTemp, channelAllowsSubs := true, true
+
+	tests := map[string]tcase{
+		"minimum_required_fields": {
+			name:             channelName,
+			description:      channelDescription,
+			maxUsers:         channelMaxUsers,
+			parentID:         10,
+			isTempChannel:    channelIsTemp,
+			allowSubChannels: channelAllowsSubs,
+			expectedResponse: &model.Channel{
+				Name:             channelName,
+				Description:      channelDescription,
+				MaxUsers:         channelMaxUsers,
+				ParentID:         channelParentID,
+				IsTemp:           channelIsTemp,
+				AllowSubChannels: channelAllowsSubs,
+			},
+			expecErr: false,
+		},
+		"invalid_name": {
+			name:        "",
+			description: "Desc",
+			maxUsers:    1,
+			expecErr:    true,
+		},
+		"invalid_desc": {
+			name:        "Name",
+			description: "",
+			maxUsers:    1,
+			expecErr:    true,
+		},
+		"invalid_max_users": {
+			name:        "Name",
+			description: "Desc",
+			maxUsers:    0,
+			expecErr:    true,
+		},
+		"excessive_paramater_values": {
+			name:        "24433252080542468109190329288548376491503980265648043643151614656",
+			description: "24433252080542468109190329288548376491503980265648043643151614656",
+			maxUsers:    257,
+			expecErr:    true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := NewTestSqlConn(t)
+			if err != nil {
+				t.Fatalf("failed to open test connection: %v", err)
+			}
+
+			channel, err := store.CreateChannelFull(tc.name, tc.description, tc.maxUsers, tc.parentID, tc.isTempChannel, tc.allowSubChannels)
+			if tc.expecErr {
+				if err == nil {
+					t.Fatalf("CreateChannelFull: expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CreateChannelFull: unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.expectedResponse, channel, cmpopts.IgnoreFields(model.Channel{}, "ID", "CreatedAt")); diff != "" {
+				t.Fatalf("CreateChannelFull mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDeleteChannel(t *testing.T) {
+	t.Parallel()
+
+	type tcase struct {
+		name        string
+		description string
+		maxUsers    int
+	}
+
+	channelName, channelDescription := "New Channel", "A brand new channel"
+	channelMaxUsers := 10
+
+	tests := map[string]tcase{
+		"minimum_required_fields": {
+			name:        channelName,
+			description: channelDescription,
+			maxUsers:    channelMaxUsers,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := NewTestSqlConn(t)
+			if err != nil {
+				t.Fatalf("failed to open test connection: %v", err)
+			}
+
+			channel, err := store.CreateChannel(tc.name, tc.description, tc.maxUsers)
+			if err != nil {
+				t.Fatalf("CreateChannel: unexpected error: %v", err)
+			}
+
+			if err := store.DeleteChannel(channel.ID); err != nil {
+				t.Fatalf("DeleteChannel: unexpected error: %v", err)
+			}
+
+			deletedChannel, err := store.GetChannel(channel.ID)
+			if err != nil {
+				t.Fatalf("GetChannel: unexpected error: %v", err)
+			}
+			if deletedChannel != nil {
+				t.Fatalf("expected channel to be nil got: %+v", deletedChannel)
+			}
+		})
+	}
+}
+
+func TestListChannels(t *testing.T) {
+	t.Parallel()
+
+	type tcase struct {
+		name        string
+		description string
+		iter        int
+	}
+
+	channelName, channelDescription := "Channel", "Description"
+
+	tests := map[string]tcase{
+		"minimum_required_fields": {
+			name:        channelName,
+			description: channelDescription,
+			iter:        10,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := NewTestSqlConn(t)
+			if err != nil {
+				t.Fatalf("failed to open test connection: %v", err)
+			}
+
+			var expectedChannels = make(map[string]*model.Channel)
+			for i := range tc.iter {
+				channelName := fmt.Sprintf("%s_%d", tc.name, i)
+				channelDesc := fmt.Sprintf("%s_%d", tc.description, i)
+
+				channel, err := store.CreateChannel(channelName, channelDesc, i+1)
+				if err != nil {
+					t.Fatalf("CreateChannel: unexpected error: %v", err)
+				}
+
+				expectedChannels[channelName] = channel
+			}
+
+			channelList, err := store.ListChannels()
+			if err != nil {
+				t.Fatalf("ListChannels: unexpected error: %v", err)
+			}
+
+			if len(channelList) != tc.iter {
+				t.Fatalf("ListChannels: length mistmatch got=%d want=%d", len(channelList), tc.iter)
+			}
+
+			for _, got := range channelList {
+				want, ok := expectedChannels[got.Name]
+				if !ok {
+					t.Fatalf("ListChannels: unexpected channel returned: %+v", got)
+				}
+
+				if got.Description != want.Description {
+					t.Errorf("ListChannels: channel description mismatch: got=%s want=%s", got.Description, want.Description)
+				}
+			}
+
+		})
+	}
+}
+
+func TestGetChannel(t *testing.T) {
+	t.Parallel()
+
+	type tcase struct {
+		name        string
+		description string
+		maxUsers    int
+	}
+
+	channelName, channelDescription := "New Channel", "A brand new channel"
+	channelMaxUsers := 10
+
+	tests := map[string]tcase{
+		"minimum_required_fields": {
+			name:        channelName,
+			description: channelDescription,
+			maxUsers:    channelMaxUsers,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := NewTestSqlConn(t)
+			if err != nil {
+				t.Fatalf("failed to open test connection: %v", err)
+			}
+
+			want, err := store.CreateChannel(tc.name, tc.description, tc.maxUsers)
+			if err != nil {
+				t.Fatalf("CreateChannel: unexpected error: %v", err)
+			}
+
+			got, err := store.GetChannel(want.ID)
+			if err != nil {
+				t.Fatalf("GetChannel: unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(model.Channel{}, "ID", "CreatedAt")); diff != "" {
+				t.Fatalf("GetChannel mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetChannelByNameAndParent(t *testing.T) {
+	t.Parallel()
+
+	type tcase struct {
+		parentChannel *model.Channel
+		childChannel  *model.Channel
+	}
+
+	tests := map[string]tcase{
+		"minimum_required_fields": {
+			parentChannel: &model.Channel{
+				Name:        "Parent",
+				Description: "Parent Channel",
+			},
+			childChannel: &model.Channel{
+				Name:        "Child",
+				Description: "Child Channel",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := NewTestSqlConn(t)
+			if err != nil {
+				t.Fatalf("failed to open test connection: %v", err)
+			}
+
+			parent, err := store.CreateChannelFull(tc.parentChannel.Name, tc.parentChannel.Description, 10, 0, false, false)
+			if err != nil {
+				t.Fatalf("CreateChannel: unexpected error creating parent: %v", err)
+			}
+
+			tc.childChannel.ParentID = parent.ID
+
+			want, err := store.CreateChannelFull(tc.childChannel.Name, tc.childChannel.Description, 10, parent.ID, false, false)
+			if err != nil {
+				t.Fatalf("CreateChannel: unexpected error creating child: %v", err)
+			}
+
+			got, err := store.GetChannelByNameAndParent(want.Name, want.ParentID)
+			if err != nil {
+				t.Fatalf("GetChannel: unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(model.Channel{}, "ID", "CreatedAt")); diff != "" {
+				t.Fatalf("GetChannel mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestHasTokens(t *testing.T) {
+	t.Parallel()
+
+	type tcase struct {
+		expectTokens bool
+	}
+
+	tests := map[string]tcase{
+		"expects_tokens": {
+			expectTokens: true,
+		},
+		"expects_no_tokens": {
+			expectTokens: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := NewTestSqlConn(t)
+			if err != nil {
+				t.Fatalf("failed to open test connection: %v", err)
+			}
+
+			if tc.expectTokens {
+				rawToken, err := crypto.GenerateToken()
+				if err != nil {
+					t.Fatalf("GenerateToken: failed to generate token: %v", err)
+				}
+
+				hash := crypto.HashToken(rawToken)
+
+				if err := store.CreateToken(hash, model.RoleUser, 1, 1, 1, time.Now().Add(time.Hour)); err != nil {
+					t.Fatalf("CreateToken: failed to create token: %v", err)
+				}
+			}
+
+			hasTokens, err := store.HasTokens()
+			if err != nil {
+				t.Fatalf("HasTokens: unexpected error: %v", err)
+			}
+
+			if hasTokens && !tc.expectTokens {
+				t.Fatalf("HasTokens mismatch want=%t got=%t", tc.expectTokens, hasTokens)
+			}
+		})
+	}
+}
+
+func TestCreateToken(t *testing.T) {
+	t.Parallel()
+
+	type tcase struct {
+		hash         string
+		role         model.Role
+		channelScope int64
+		createdBy    int64
+		maxUses      int
+		expiresAt    time.Time
+	}
+
+	tests := map[string]tcase{
+		"minimum_required_fields": {
+			hash:         crypto.HashToken("68FFA106C3C303C9BAB815240986C321"),
+			role:         model.RoleUser,
+			channelScope: 1,
+			createdBy:    1,
+			maxUses:      1,
+			expiresAt:    time.Now().Add(time.Hour),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := NewTestSqlConn(t)
+			if err != nil {
+				t.Fatalf("failed to open test connection: %v", err)
+			}
+
+			if err := store.CreateToken(tc.hash, tc.role, tc.channelScope, tc.createdBy, tc.maxUses, tc.expiresAt); err != nil {
+				t.Fatalf("CreateToken: failed to create token: %v", err)
+			}
+
+			hasTokens, err := store.HasTokens()
+			if err != nil {
+				t.Fatalf("HasTokens: unexpected error: %v", err)
+			}
+			if !hasTokens {
+				t.Fatalf("HasTokens: expected tokens, but empty")
+			}
+		})
+	}
+}
+
+func TestValidateToken(t *testing.T) {
+	t.Parallel()
+
+	type tcase struct {
+		token *struct {
+			hash         string
+			role         model.Role
+			channelScope int64
+			createdBy    int64
+			maxUses      int
+			expiresAt    time.Time
+		}
+		expectValidation bool
+	}
+
+	tests := map[string]tcase{
+		"valid_token": {
+			token: &struct {
+				hash         string
+				role         model.Role
+				channelScope int64
+				createdBy    int64
+				maxUses      int
+				expiresAt    time.Time
+			}{
+				hash:         crypto.HashToken("68FFA106C3C303C9BAB815240986C321"),
+				role:         model.RoleUser,
+				channelScope: 1,
+				createdBy:    1,
+				maxUses:      10,
+				expiresAt:    time.Now().Add(time.Hour),
+			},
+			expectValidation: true,
+		},
+		"invalid_token_expired": {
+			token: &struct {
+				hash         string
+				role         model.Role
+				channelScope int64
+				createdBy    int64
+				maxUses      int
+				expiresAt    time.Time
+			}{
+				hash:         crypto.HashToken("68FFA106C3C303C9BAB815240986C321"),
+				role:         model.RoleUser,
+				channelScope: 1,
+				createdBy:    1,
+				maxUses:      10,
+				expiresAt:    time.Now().Add(-time.Hour),
+			},
+			expectValidation: false,
+		},
+		"invalid_token_uses": {
+			token: &struct {
+				hash         string
+				role         model.Role
+				channelScope int64
+				createdBy    int64
+				maxUses      int
+				expiresAt    time.Time
+			}{
+				hash:         crypto.HashToken("68FFA106C3C303C9BAB815240986C321"),
+				role:         model.RoleUser,
+				channelScope: 1,
+				createdBy:    1,
+				maxUses:      1,
+				expiresAt:    time.Now().Add(time.Hour),
+			},
+			expectValidation: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := NewTestSqlConn(t)
+			if err != nil {
+				t.Fatalf("failed to open test connection: %v", err)
+			}
+
+			if err := store.CreateToken(tc.token.hash, tc.token.role, tc.token.channelScope, tc.token.createdBy, tc.token.maxUses, tc.token.expiresAt); err != nil {
+				t.Fatalf("CreateToken: failed to create token: %v", err)
+			}
+
+			// Simulate multiple token usages
+			_, err = store.ValidateToken(tc.token.hash)
+			if err != nil && tc.expectValidation {
+				t.Fatalf("ValidateToken_1: unexpected error: %v", err)
+			}
+			role, err := store.ValidateToken(tc.token.hash)
+			if !tc.expectValidation {
+				if err == nil {
+					t.Fatalf("ValidateToken_2: expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateToken: unexpected error: %v", err)
+			}
+
+			if tc.token.role != role {
+				t.Fatalf("ValidateToken: role mismatch want=%d got=%d", int(tc.token.role), int(role))
+			}
+		})
+	}
+}
+
+func TestCreateBan(t *testing.T) {
+	t.Parallel()
+
+	type tcase struct {
+		userID    int64
+		ip        string
+		reason    string
+		bannedBy  int64
+		expiredAt time.Time
+	}
+
+	tests := map[string]tcase{
+		"minimum_required_fields": {
+			userID:    1,
+			ip:        "192.0.0.1",
+			reason:    "Bad behavior",
+			bannedBy:  2,
+			expiredAt: time.Now().Add(time.Hour),
+		},
+		"expired_ban": {
+			userID:    1,
+			ip:        "192.0.0.1",
+			reason:    "Bad behavior",
+			bannedBy:  2,
+			expiredAt: time.Now().Add(-time.Hour),
+		},
+		"ban_self": {
+			userID:    1,
+			ip:        "192.0.0.1",
+			reason:    "Bad behavior",
+			bannedBy:  1,
+			expiredAt: time.Now().Add(time.Hour),
+		},
+		"reason_empty": {
+			userID:    1,
+			ip:        "192.0.0.1",
+			reason:    "",
+			bannedBy:  2,
+			expiredAt: time.Now().Add(time.Hour),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			store, err := NewTestSqlConn(t)
+			if err != nil {
+				t.Fatalf("failed to open test connection: %v", err)
+			}
+
+			if err := store.CreateBan(tc.userID, tc.ip, tc.reason, tc.bannedBy, tc.expiredAt); err != nil {
+				t.Fatalf("CreateBan: unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestIsUserBanned(t *testing.T) {
+	t.Parallel()
+
+	type tcase struct {
+		userID    int64
+		ip        string
+		reason    string
+		bannedBy  int64
+		expiredAt time.Time
+		expectBan bool
+		multiBan  bool
+	}
+
+	tests := map[string]tcase{
+		"user_has_valid_ban": {
+			userID:    1,
+			ip:        "192.0.0.1",
+			reason:    "Bad behavior",
+			bannedBy:  2,
+			expiredAt: time.Now().Add(time.Hour),
+			expectBan: true,
+			multiBan:  false,
+		},
+		"user_ban_expired": {
+			userID:    1,
+			ip:        "192.0.0.1",
+			reason:    "Bad behavior",
+			bannedBy:  2,
+			expiredAt: time.Now().Add(-time.Hour),
+			expectBan: false,
+			multiBan:  false,
+		},
+		"user_multi_ban": {
+			userID:    1,
+			ip:        "192.0.0.1",
+			reason:    "Bad behavior",
+			bannedBy:  2,
+			expiredAt: time.Now().Add(-time.Hour),
+			expectBan: true,
+			multiBan:  true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			store, err := NewTestSqlConn(t)
+			if err != nil {
+				t.Fatalf("failed to open test connection: %v", err)
+			}
+
+			if err := store.CreateBan(tc.userID, tc.ip, tc.reason, tc.bannedBy, tc.expiredAt); err != nil {
+				t.Fatalf("CreateBan: unexpected error: %v", err)
+			}
+			// For the multi ban express the user has one valid and one invalid ban
+			// asserting that the newer valid ban will still cause a positive ban
+			if tc.multiBan {
+				if err := store.CreateBan(tc.userID, tc.ip, tc.reason, tc.bannedBy, time.Now().Add(time.Hour)); err != nil {
+					t.Fatalf("CreateBan_Multi: unexpected error: %v", err)
+				}
+			}
+
+			isBanned, err := store.IsUserBanned(tc.userID)
+			if err != nil {
+				t.Fatalf("IsUserBanned: unexpected error: %v", err)
+			}
+			if tc.expectBan != isBanned {
+				t.Fatalf("IsUserBanned: ban mismatch want=%t got=%t", tc.expectBan, isBanned)
 			}
 		})
 	}


### PR DESCRIPTION
### This PR

Cleans up and completes base test coverage for the data store.

### Note

Uncovered possible validation exception for creating channels with blank names, descriptions, and 0 users. If these cases are intended let me know and I can invert the test case expectation.