### PR TITLE
refactor: channel factory and validation

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // Role represents a user's permission level.
@@ -100,6 +102,25 @@ type User struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+const (
+	ChannelDefaultName               = "Lobby"
+	ChannelDefaultDescription        = "Default voice channel"
+	ChannelDefaultMaxUsers           = 0
+	ChannelDefaultParentID           = 0
+	ChannelDefaultIsTemp             = false
+	ChannelDefaultAllowedSubChannels = false
+
+	MaxChannelNameLength = 64
+	MaxChannelDescLength = 256
+	MaxChannelUsers      = 256
+)
+
+var ErrChannelNameEmpty = errors.New("channel name must not be empty")
+var ErrChannelNameTooLong = errors.New("channel name too long")
+var ErrChannelDescTooLong = errors.New("channel description too long")
+var ErrChannelMaxUsers = errors.New("channel max users out of range")
+var ErrChannelParentID = errors.New("channel parent id out of range")
+
 // Channel represents a voice channel on the server.
 type Channel struct {
 	ID               int64     `json:"id"`
@@ -110,6 +131,47 @@ type Channel struct {
 	IsTemp           bool      `json:"is_temp"`            // temp channels auto-delete when empty
 	AllowSubChannels bool      `json:"allow_sub_channels"` // users can create temp sub-channels here
 	CreatedAt        time.Time `json:"created_at"`
+}
+
+// Creates and returns a new channel using default values
+//
+// Can be expanded in the future to accept opts ...ChannelOptions
+func NewChannel() *Channel {
+	return &Channel{
+		Name:             ChannelDefaultName,
+		Description:      ChannelDefaultDescription,
+		MaxUsers:         ChannelDefaultMaxUsers,
+		ParentID:         ChannelDefaultParentID,
+		IsTemp:           ChannelDefaultIsTemp,
+		AllowSubChannels: ChannelDefaultAllowedSubChannels,
+	}
+}
+
+// Validates a channel returning a list of errors
+func (ch *Channel) Validate() error {
+	// Name
+	if strings.TrimSpace(ch.Name) == "" {
+		return ErrChannelNameEmpty
+	} else if utf8.RuneCountInString(ch.Name) > MaxChannelNameLength {
+		return ErrChannelNameTooLong
+	}
+
+	// Description
+	if utf8.RuneCountInString(ch.Description) > MaxChannelDescLength {
+		return ErrChannelDescTooLong
+	}
+
+	// MaxUsers
+	if ch.MaxUsers < 0 || ch.MaxUsers > MaxChannelUsers {
+		return ErrChannelMaxUsers
+	}
+
+	// ParentID rule example (optional)
+	if ch.ParentID < 0 {
+		return ErrChannelParentID
+	}
+
+	return nil
 }
 
 // Token represents an invite/auth token.

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -74,11 +74,18 @@ func ensureChannel(st store.DataStore, ch ChannelYAML, parentID int64) error {
 	if existing != nil {
 		channelID = existing.ID
 	} else {
-		created, err := st.CreateChannelFull(ch.Name, ch.Description, ch.MaxUsers, parentID, false, ch.AllowSubChannels)
-		if err != nil {
+		channel := &model.Channel{
+			Name:             ch.Name,
+			Description:      ch.Description,
+			MaxUsers:         ch.MaxUsers,
+			ParentID:         parentID,
+			IsTemp:           false,
+			AllowSubChannels: ch.AllowSubChannels,
+		}
+		if err := st.CreateChannel(channel); err != nil {
 			return err
 		}
-		channelID = created.ID
+		channelID = channel.ID
 		slog.Debug("created channel from config", "name", ch.Name, "parent", parentID)
 	}
 

--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -459,8 +459,15 @@ func (s *Server) handleCreateChannel(session *model.Session, req *pb.CreateChann
 		desc = desc[:256]
 	}
 
-	ch, err := st.CreateChannelFull(name, desc, int(req.MaxUsers), req.ParentID, req.IsTemp, req.AllowSubChannels)
-	if err != nil {
+	ch := &model.Channel{
+		Name:             name,
+		Description:      desc,
+		MaxUsers:         int(req.MaxUsers),
+		ParentID:         req.ParentID,
+		IsTemp:           req.IsTemp,
+		AllowSubChannels: req.AllowSubChannels,
+	}
+	if err := st.CreateChannel(ch); err != nil {
 		sendError(conn, 31, "failed to create channel: "+err.Error())
 		return
 	}

--- a/pkg/server/run.go
+++ b/pkg/server/run.go
@@ -32,7 +32,7 @@ func (s *Server) Run() error {
 	// Ensure default "Lobby" channel exists
 	channels, _ := st.ListChannels()
 	if len(channels) == 0 {
-		if _, err := st.CreateChannel("Lobby", "Default voice channel", 0); err != nil {
+		if err := st.CreateChannel(model.NewChannel()); err != nil {
 			return fmt.Errorf("server: create lobby: %w", err)
 		}
 		slog.Info("created default Lobby channel")

--- a/pkg/store/interface.go
+++ b/pkg/store/interface.go
@@ -36,10 +36,7 @@ type DataStore interface {
 	// ---- Channels ----
 
 	// CreateChannel creates a new channel with basic fields.
-	CreateChannel(name, description string, maxUsers int) (*model.Channel, error)
-
-	// CreateChannelFull creates a new channel with all options.
-	CreateChannelFull(name, description string, maxUsers int, parentID int64, isTemp, allowSubChannels bool) (*model.Channel, error)
+	CreateChannel(channel *model.Channel) error
 
 	// DeleteChannel deletes a channel by ID.
 	DeleteChannel(id int64) error


### PR DESCRIPTION
### This PR

- Adds channel Default constants.
- Adds channel Validation constants.
- Adds channel Validation errors.
- Adds channel factory constructor with default values.
* * This is extremely helpful in the future when/if `Channel` expands the function can then take `(opts ...ChannelOptions)` for constructing more precise and verbose models.
- Adds channel Validation method to return errors based on validation ruleset
- Consolidates `CreateChannelX` store functions into a singular `CreateChannel` function that accepts a `Channel` to create and mutates the original channel via pointer.
- Refactors existing code that referenced `CreateChannel` to use new pattern.

### TODO

- [ ] After this PR is completed #5 will need a light refactor to remove redundant test, and to resolve new rule-based cases