### PR TITLE
Server foundations: dependency injection, session snapshots, memory store

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ pkg/
   protocol/pb/     Message type definitions
   rbac/            Role-based access control
   server/          Server core (control, voice, config)
-  store/           DataStore interface + SQLite implementation
+  store/           DataStore interface + SQLite and in-memory implementations
 ui/                Fyne desktop GUI
 docs/              Documentation with Mermaid diagrams
 ```
@@ -95,6 +95,12 @@ GoSpeak follows an **onion architecture**, the server and client depend on inter
 e.g. **`store.DataStore`**, the server uses this interface for all persistence. The default implementation is SQLite, but alternative backends (PostgreSQL, in-memory for tests) can be added by implementing the interface. See [`pkg/store/interface.go`](pkg/store/interface.go).
 
 When contributing new features, prefer depending on interfaces rather than concrete types.
+
+## Testing Architecture
+
+- Use `store.NewMemory()` for fast, deterministic tests that require persistence.
+- Keep tests backend-agnostic when possible by coding against `store.DataStore`.
+- Server tests can construct `server.Dependencies{Store: store.NewMemory()}` to avoid external DB setup.
 
 ## Areas for Contribution
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -68,7 +68,13 @@ func main() {
 		return
 	}
 
-	srv := server.New(cfg)
+	st, err := store.New(cfg.DBPath)
+	if err != nil {
+		slog.Error("open database", "err", err)
+		os.Exit(1)
+	}
+
+	srv := server.New(cfg, server.Dependencies{Store: st})
 	if err := srv.Run(); err != nil {
 		slog.Error("server error", "err", err)
 		os.Exit(1)

--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -211,24 +211,28 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st st
 
 	// Create session (voice key is shared server-wide for SFU model)
 	session := s.sessions.Create(user.ID, user.Username, sessionRole)
-	handler.setConn(session.ID, conn)
+	sessionID := session.ID
+	userID := session.UserID
+	username := session.Username
+
+	handler.setConn(sessionID, conn)
 	defer func() {
 		// Cleanup on disconnect
-		chID := s.channels.Leave(session.ID)
-		handler.removeConn(session.ID)
-		s.sessions.Remove(session.ID)
+		chID := s.channels.Leave(sessionID)
+		handler.removeConn(sessionID)
+		s.sessions.Remove(sessionID)
 		s.metrics.ActiveConnections.Add(-1)
 		s.metrics.TotalDisconnects.Add(1)
-		slog.Info("client disconnected", "user", user.Username, "session", session.ID)
+		slog.Info("client disconnected", "user", username, "session", sessionID)
 
 		if chID > 0 {
 			handler.broadcastToChannel(chID, &pb.ControlMessage{
 				ChannelLeftEvent: &pb.ChannelLeftEvent{
 					ChannelID: chID,
-					UserID:    user.ID,
-					Username:  user.Username,
+					UserID:    userID,
+					Username:  username,
 				},
-			}, session.ID)
+			}, sessionID)
 
 			// Auto-delete temp channels when empty
 			s.cleanupTempChannel(chID, st)
@@ -245,7 +249,7 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st st
 	// Send auth response
 	authResp := &pb.ControlMessage{
 		AuthResponse: &pb.AuthResponse{
-			SessionID:     session.ID,
+			SessionID:     sessionID,
 			Username:      user.Username,
 			Role:          sessionRole.String(),
 			EncryptionKey: s.voiceKey,
@@ -258,7 +262,7 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st st
 		return
 	}
 
-	slog.Info("client authenticated", "user", user.Username, "role", sessionRole, "session", session.ID)
+	slog.Info("client authenticated", "user", user.Username, "role", sessionRole, "session", sessionID)
 	s.metrics.SuccessfulAuths.Add(1)
 
 	// Message loop
@@ -278,51 +282,51 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st st
 			return
 		}
 
-		s.handleMessage(handler, session, msg, st, conn)
+		s.handleMessage(handler, sessionID, msg, st, conn)
 	}
 }
 
 // handleMessage dispatches a control message to the appropriate handler.
-func (s *Server) handleMessage(handler *ControlHandler, session *model.Session, msg *pb.ControlMessage, st store.DataStore, conn net.Conn) {
+func (s *Server) handleMessage(handler *ControlHandler, sessionID uint32, msg *pb.ControlMessage, st store.DataStore, conn net.Conn) {
 	switch {
 	case msg.JoinChannelRequest != nil:
-		s.handleJoinChannel(handler, session, msg.JoinChannelRequest, st, conn)
+		s.handleJoinChannel(handler, sessionID, msg.JoinChannelRequest, st, conn)
 
 	case msg.LeaveChannelRequest != nil:
-		s.handleLeaveChannel(handler, session, st, conn)
+		s.handleLeaveChannel(handler, sessionID, st, conn)
 
 	case msg.ChannelListRequest != nil:
 		s.handleChannelList(st, conn)
 
 	case msg.UserStateUpdate != nil:
-		s.handleUserState(handler, session, msg.UserStateUpdate, st)
+		s.handleUserState(handler, sessionID, msg.UserStateUpdate, st)
 
 	case msg.CreateChannelReq != nil:
-		s.handleCreateChannel(session, msg.CreateChannelReq, st, conn, handler)
+		s.handleCreateChannel(sessionID, msg.CreateChannelReq, st, conn, handler)
 
 	case msg.DeleteChannelReq != nil:
-		s.handleDeleteChannel(session, msg.DeleteChannelReq, st, conn, handler)
+		s.handleDeleteChannel(sessionID, msg.DeleteChannelReq, st, conn, handler)
 
 	case msg.CreateTokenReq != nil:
-		s.handleCreateToken(session, msg.CreateTokenReq, st, conn)
+		s.handleCreateToken(sessionID, msg.CreateTokenReq, st, conn)
 
 	case msg.KickUserReq != nil:
-		s.handleKickUser(handler, session, msg.KickUserReq, conn)
+		s.handleKickUser(handler, sessionID, msg.KickUserReq, conn)
 
 	case msg.BanUserReq != nil:
-		s.handleBanUser(handler, session, msg.BanUserReq, st, conn)
+		s.handleBanUser(handler, sessionID, msg.BanUserReq, st, conn)
 
 	case msg.ChatMsg != nil:
-		s.handleChatMessage(handler, session, msg.ChatMsg)
+		s.handleChatMessage(handler, sessionID, msg.ChatMsg)
 
 	case msg.SetUserRoleReq != nil:
-		s.handleSetUserRole(handler, session, msg.SetUserRoleReq, st, conn)
+		s.handleSetUserRole(handler, sessionID, msg.SetUserRoleReq, st, conn)
 
 	case msg.ExportDataReq != nil:
-		s.handleExportData(session, msg.ExportDataReq, st, conn)
+		s.handleExportData(sessionID, msg.ExportDataReq, st, conn)
 
 	case msg.ImportChannelsReq != nil:
-		s.handleImportChannels(session, msg.ImportChannelsReq, st, conn, handler)
+		s.handleImportChannels(sessionID, msg.ImportChannelsReq, st, conn, handler)
 
 	case msg.Ping != nil:
 		_ = protocol.WriteControlMessage(conn, &pb.ControlMessage{
@@ -331,7 +335,12 @@ func (s *Server) handleMessage(handler *ControlHandler, session *model.Session, 
 	}
 }
 
-func (s *Server) handleJoinChannel(handler *ControlHandler, session *model.Session, req *pb.JoinChannelRequest, st store.DataStore, conn net.Conn) {
+func (s *Server) handleJoinChannel(handler *ControlHandler, sessionID uint32, req *pb.JoinChannelRequest, st store.DataStore, conn net.Conn) {
+	session, ok := s.sessions.GetSnapshot(sessionID)
+	if !ok {
+		sendError(conn, 3, "session not found")
+		return
+	}
 	// Verify channel exists
 	ch, err := st.GetChannel(req.ChannelID)
 	if err != nil || ch == nil {
@@ -346,7 +355,7 @@ func (s *Server) handleJoinChannel(handler *ControlHandler, session *model.Sessi
 	}
 
 	prevCh := s.channels.Join(session.ID, ch.ID)
-	session.ChannelID = ch.ID
+	s.sessions.SetChannel(session.ID, ch.ID)
 
 	// Notify old channel
 	if prevCh > 0 {
@@ -380,9 +389,14 @@ func (s *Server) handleJoinChannel(handler *ControlHandler, session *model.Sessi
 	s.broadcastServerState(st, handler)
 }
 
-func (s *Server) handleLeaveChannel(handler *ControlHandler, session *model.Session, st store.DataStore, conn net.Conn) {
+func (s *Server) handleLeaveChannel(handler *ControlHandler, sessionID uint32, st store.DataStore, conn net.Conn) {
+	session, ok := s.sessions.GetSnapshot(sessionID)
+	if !ok {
+		sendError(conn, 3, "session not found")
+		return
+	}
 	chID := s.channels.Leave(session.ID)
-	session.ChannelID = 0
+	s.sessions.SetChannel(session.ID, 0)
 
 	if chID > 0 {
 		handler.broadcastToChannel(chID, &pb.ControlMessage{
@@ -409,15 +423,19 @@ func (s *Server) handleChannelList(st store.DataStore, conn net.Conn) {
 	})
 }
 
-func (s *Server) handleUserState(handler *ControlHandler, session *model.Session, upd *pb.UserStateUpdate, st store.DataStore) {
-	session.Muted = upd.Muted
-	session.Deafened = upd.Deafened
+func (s *Server) handleUserState(handler *ControlHandler, sessionID uint32, upd *pb.UserStateUpdate, st store.DataStore) {
+	s.sessions.UpdateUserState(sessionID, upd.Muted, upd.Deafened)
 
 	// Broadcast updated server state to all clients
 	s.broadcastServerState(st, handler)
 }
 
-func (s *Server) handleCreateChannel(session *model.Session, req *pb.CreateChannelRequest, st store.DataStore, conn net.Conn, handler *ControlHandler) {
+func (s *Server) handleCreateChannel(sessionID uint32, req *pb.CreateChannelRequest, st store.DataStore, conn net.Conn, handler *ControlHandler) {
+	session, ok := s.sessions.GetSnapshot(sessionID)
+	if !ok {
+		sendError(conn, 3, "session not found")
+		return
+	}
 	// Validate and sanitize channel name
 	name := sanitizeText(strings.TrimSpace(req.Name))
 	if len(name) == 0 || len(name) > 64 {
@@ -479,7 +497,12 @@ func (s *Server) handleCreateChannel(session *model.Session, req *pb.CreateChann
 	s.broadcastServerState(st, handler)
 }
 
-func (s *Server) handleDeleteChannel(session *model.Session, req *pb.DeleteChannelRequest, st store.DataStore, conn net.Conn, handler *ControlHandler) {
+func (s *Server) handleDeleteChannel(sessionID uint32, req *pb.DeleteChannelRequest, st store.DataStore, conn net.Conn, handler *ControlHandler) {
+	session, ok := s.sessions.GetSnapshot(sessionID)
+	if !ok {
+		sendError(conn, 3, "session not found")
+		return
+	}
 	if errMsg := rbac.RequirePermission(session.Role, model.PermDeleteChannel); errMsg != "" {
 		sendError(conn, 30, errMsg)
 		return
@@ -494,9 +517,7 @@ func (s *Server) handleDeleteChannel(session *model.Session, req *pb.DeleteChann
 	members := s.channels.Members(req.ChannelID)
 	for _, sid := range members {
 		s.channels.Leave(sid)
-		if sess := s.sessions.Get(sid); sess != nil {
-			sess.ChannelID = 0
-		}
+		s.sessions.SetChannel(sid, 0)
 	}
 
 	slog.Info("channel deleted", "id", req.ChannelID, "by", session.Username)
@@ -504,7 +525,12 @@ func (s *Server) handleDeleteChannel(session *model.Session, req *pb.DeleteChann
 	s.broadcastServerState(st, handler)
 }
 
-func (s *Server) handleCreateToken(session *model.Session, req *pb.CreateTokenRequest, st store.DataStore, conn net.Conn) {
+func (s *Server) handleCreateToken(sessionID uint32, req *pb.CreateTokenRequest, st store.DataStore, conn net.Conn) {
+	session, ok := s.sessions.GetSnapshot(sessionID)
+	if !ok {
+		sendError(conn, 3, "session not found")
+		return
+	}
 	if errMsg := rbac.RequirePermission(session.Role, model.PermManageTokens); errMsg != "" {
 		sendError(conn, 30, errMsg)
 		return
@@ -537,7 +563,12 @@ func (s *Server) handleCreateToken(session *model.Session, req *pb.CreateTokenRe
 	})
 }
 
-func (s *Server) handleKickUser(handler *ControlHandler, session *model.Session, req *pb.KickUserRequest, conn net.Conn) {
+func (s *Server) handleKickUser(handler *ControlHandler, sessionID uint32, req *pb.KickUserRequest, conn net.Conn) {
+	session, ok := s.sessions.GetSnapshot(sessionID)
+	if !ok {
+		sendError(conn, 3, "session not found")
+		return
+	}
 	if errMsg := rbac.RequirePermission(session.Role, model.PermKickUser); errMsg != "" {
 		sendError(conn, 30, errMsg)
 		return
@@ -548,8 +579,8 @@ func (s *Server) handleKickUser(handler *ControlHandler, session *model.Session,
 		reason = reason[:256]
 	}
 
-	target := s.sessions.GetByUserID(req.UserID)
-	if target == nil {
+	target, ok := s.sessions.GetByUserIDSnapshot(req.UserID)
+	if !ok {
 		sendError(conn, 32, "user not online")
 		return
 	}
@@ -567,7 +598,12 @@ func (s *Server) handleKickUser(handler *ControlHandler, session *model.Session,
 	s.metrics.KickCount.Add(1)
 }
 
-func (s *Server) handleBanUser(handler *ControlHandler, session *model.Session, req *pb.BanUserRequest, st store.DataStore, conn net.Conn) {
+func (s *Server) handleBanUser(handler *ControlHandler, sessionID uint32, req *pb.BanUserRequest, st store.DataStore, conn net.Conn) {
+	session, ok := s.sessions.GetSnapshot(sessionID)
+	if !ok {
+		sendError(conn, 3, "session not found")
+		return
+	}
 	if errMsg := rbac.RequirePermission(session.Role, model.PermBanUser); errMsg != "" {
 		sendError(conn, 30, errMsg)
 		return
@@ -589,8 +625,7 @@ func (s *Server) handleBanUser(handler *ControlHandler, session *model.Session, 
 	}
 
 	// Also kick them if online
-	target := s.sessions.GetByUserID(req.UserID)
-	if target != nil {
+	if target, ok := s.sessions.GetByUserIDSnapshot(req.UserID); ok {
 		handler.mu.RLock()
 		targetConn, ok := handler.connMap[target.ID]
 		handler.mu.RUnlock()
@@ -609,8 +644,8 @@ func (s *Server) channelUsers(channelID int64) []pb.UserInfo {
 	members := s.channels.Members(channelID)
 	users := make([]pb.UserInfo, 0, len(members))
 	for _, sid := range members {
-		sess := s.sessions.Get(sid)
-		if sess != nil {
+		sess, ok := s.sessions.GetSnapshot(sid)
+		if ok {
 			users = append(users, pb.UserInfo{
 				ID:       sess.UserID,
 				Username: sess.Username,
@@ -623,7 +658,11 @@ func (s *Server) channelUsers(channelID int64) []pb.UserInfo {
 	return users
 }
 
-func (s *Server) handleChatMessage(handler *ControlHandler, session *model.Session, chat *pb.ChatMessage) {
+func (s *Server) handleChatMessage(handler *ControlHandler, sessionID uint32, chat *pb.ChatMessage) {
+	session, ok := s.sessions.GetSnapshot(sessionID)
+	if !ok {
+		return
+	}
 	chID := s.channels.ChannelOf(session.ID)
 	if chID == 0 {
 		return // not in a channel
@@ -650,7 +689,12 @@ func (s *Server) handleChatMessage(handler *ControlHandler, session *model.Sessi
 	s.metrics.ChatMessagesSent.Add(1)
 }
 
-func (s *Server) handleSetUserRole(handler *ControlHandler, session *model.Session, req *pb.SetUserRoleRequest, st store.DataStore, conn net.Conn) {
+func (s *Server) handleSetUserRole(handler *ControlHandler, sessionID uint32, req *pb.SetUserRoleRequest, st store.DataStore, conn net.Conn) {
+	session, ok := s.sessions.GetSnapshot(sessionID)
+	if !ok {
+		sendError(conn, 3, "session not found")
+		return
+	}
 	if errMsg := rbac.RequirePermission(session.Role, model.PermManageRoles); errMsg != "" {
 		sendError(conn, 30, errMsg)
 		return
@@ -675,9 +719,8 @@ func (s *Server) handleSetUserRole(handler *ControlHandler, session *model.Sessi
 	}
 
 	// Update the session if the target user is online
-	target := s.sessions.GetByUserID(req.TargetUserID)
-	if target != nil {
-		target.Role = newRole
+	if target, ok := s.sessions.GetByUserIDSnapshot(req.TargetUserID); ok {
+		s.sessions.UpdateRole(target.ID, newRole)
 	}
 
 	slog.Info("user role changed", "target_user", req.TargetUserID, "new_role", newRole, "by", session.Username)
@@ -789,7 +832,12 @@ func sanitizeText(s string) string {
 	}, s)
 }
 
-func (s *Server) handleExportData(session *model.Session, req *pb.ExportDataRequest, st store.DataStore, conn net.Conn) {
+func (s *Server) handleExportData(sessionID uint32, req *pb.ExportDataRequest, st store.DataStore, conn net.Conn) {
+	session, ok := s.sessions.GetSnapshot(sessionID)
+	if !ok {
+		sendError(conn, 3, "session not found")
+		return
+	}
 	if errMsg := rbac.RequirePermission(session.Role, model.PermCreateChannel); errMsg != "" {
 		sendError(conn, 30, "admin only: "+errMsg)
 		return
@@ -820,7 +868,12 @@ func (s *Server) handleExportData(session *model.Session, req *pb.ExportDataRequ
 	})
 }
 
-func (s *Server) handleImportChannels(session *model.Session, req *pb.ImportChannelsRequest, st store.DataStore, conn net.Conn, handler *ControlHandler) {
+func (s *Server) handleImportChannels(sessionID uint32, req *pb.ImportChannelsRequest, st store.DataStore, conn net.Conn, handler *ControlHandler) {
+	session, ok := s.sessions.GetSnapshot(sessionID)
+	if !ok {
+		sendError(conn, 3, "session not found")
+		return
+	}
 	if errMsg := rbac.RequirePermission(session.Role, model.PermCreateChannel); errMsg != "" {
 		sendError(conn, 30, "admin only: "+errMsg)
 		return

--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -212,8 +212,6 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st st
 	// Create session (voice key is shared server-wide for SFU model)
 	session := s.sessions.Create(user.ID, user.Username, sessionRole)
 	sessionID := session.ID
-	userID := session.UserID
-	username := session.Username
 
 	handler.setConn(sessionID, conn)
 	defer func() {
@@ -223,14 +221,14 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st st
 		s.sessions.Remove(sessionID)
 		s.metrics.ActiveConnections.Add(-1)
 		s.metrics.TotalDisconnects.Add(1)
-		slog.Info("client disconnected", "user", username, "session", sessionID)
+		slog.Info("client disconnected", "user", user.Username, "session", sessionID)
 
 		if chID > 0 {
 			handler.broadcastToChannel(chID, &pb.ControlMessage{
 				ChannelLeftEvent: &pb.ChannelLeftEvent{
 					ChannelID: chID,
-					UserID:    userID,
-					Username:  username,
+					UserID:    user.ID,
+					Username:  user.Username,
 				},
 			}, sessionID)
 

--- a/pkg/server/run.go
+++ b/pkg/server/run.go
@@ -15,11 +15,10 @@ import (
 
 // Run starts the server and blocks until shutdown signal.
 func (s *Server) Run() error {
-	// Open database
-	st, err := store.New(s.cfg.DBPath)
-	if err != nil {
-		return fmt.Errorf("server: open store: %w", err)
+	if s.store == nil {
+		return fmt.Errorf("server: missing store dependency")
 	}
+	st := s.store
 	defer func() { _ = st.Close() }()
 
 	// Generate shared voice encryption key

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/NicolasHaas/gospeak/pkg/model"
+	pb "github.com/NicolasHaas/gospeak/pkg/protocol/pb"
+	"github.com/NicolasHaas/gospeak/pkg/store"
+)
+
+type nopConn struct{}
+
+func (c *nopConn) Read(_ []byte) (int, error)         { return 0, io.EOF }
+func (c *nopConn) Write(p []byte) (int, error)        { return len(p), nil }
+func (c *nopConn) Close() error                       { return nil }
+func (c *nopConn) LocalAddr() net.Addr                { return &net.IPAddr{} }
+func (c *nopConn) RemoteAddr() net.Addr               { return &net.IPAddr{} }
+func (c *nopConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *nopConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *nopConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+func newTestServer(t *testing.T) (*Server, store.DataStore, *ControlHandler) {
+	t.Helper()
+	st := store.NewMemory()
+	cfg := DefaultConfig()
+	srv := New(cfg, Dependencies{Store: st})
+	handler := newControlHandler(srv, st)
+	return srv, st, handler
+}
+
+func TestHandleJoinLeaveChannel(t *testing.T) {
+	srv, st, handler := newTestServer(t)
+	conn := &nopConn{}
+
+	ch := model.NewChannel()
+	if err := st.CreateChannel(ch); err != nil {
+		t.Fatalf("CreateChannel: %v", err)
+	}
+
+	session := srv.sessions.Create(1, "johndoe", model.RoleUser)
+
+	srv.handleJoinChannel(handler, session.ID, &pb.JoinChannelRequest{ChannelID: ch.ID}, st, conn)
+	joinedChannel := srv.channels.ChannelOf(session.ID)
+	if joinedChannel != ch.ID {
+		t.Fatalf("JoinChannel: expected channel %d got %d", ch.ID, joinedChannel)
+	}
+
+	snap, ok := srv.sessions.GetSnapshot(session.ID)
+	if !ok {
+		t.Fatalf("GetSnapshot: missing session")
+	}
+	if snap.ChannelID != ch.ID {
+		t.Fatalf("JoinChannel: session channel mismatch want=%d got=%d", ch.ID, snap.ChannelID)
+	}
+
+	srv.handleLeaveChannel(handler, session.ID, st, conn)
+	leftChannel := srv.channels.ChannelOf(session.ID)
+	if leftChannel != 0 {
+		t.Fatalf("LeaveChannel: expected channel 0 got %d", leftChannel)
+	}
+
+	snap, ok = srv.sessions.GetSnapshot(session.ID)
+	if !ok {
+		t.Fatalf("GetSnapshot: missing session")
+	}
+	if snap.ChannelID != 0 {
+		t.Fatalf("LeaveChannel: session channel mismatch want=0 got=%d", snap.ChannelID)
+	}
+}
+
+func TestHandleUserState(t *testing.T) {
+	srv, st, handler := newTestServer(t)
+
+	session := srv.sessions.Create(1, "johndoe", model.RoleUser)
+
+	srv.handleUserState(handler, session.ID, &pb.UserStateUpdate{Muted: true, Deafened: true}, st)
+
+	snap, ok := srv.sessions.GetSnapshot(session.ID)
+	if !ok {
+		t.Fatalf("GetSnapshot: missing session")
+	}
+	if !snap.Muted || !snap.Deafened {
+		t.Fatalf("HandleUserState: expected muted/deafened true, got muted=%t deafened=%t", snap.Muted, snap.Deafened)
+	}
+}

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -64,11 +64,11 @@ func (sm *SessionManager) Create(userID int64, username string, role model.Role)
 	return sess
 }
 
-// GetSnapshot returns an immutable snapshot of the session.
-func (sm *SessionManager) GetSnapshot(id uint32) (SessionSnapshot, bool) {
+// GetSnapshot returns an immutable snapshot of the session by session ID.
+func (sm *SessionManager) GetSnapshot(sessionID uint32) (SessionSnapshot, bool) {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
-	s, ok := sm.sessions[id]
+	s, ok := sm.sessions[sessionID]
 	if !ok {
 		return SessionSnapshot{}, false
 	}

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -15,6 +15,18 @@ type SessionManager struct {
 	sessions map[uint32]*model.Session // sessionID -> session
 }
 
+// SessionSnapshot is an immutable view of a session.
+type SessionSnapshot struct {
+	ID        uint32
+	UserID    int64
+	Username  string
+	Role      model.Role
+	ChannelID int64
+	UDPAddr   *net.UDPAddr
+	Muted     bool
+	Deafened  bool
+}
+
 // NewSessionManager creates a new session manager.
 func NewSessionManager() *SessionManager {
 	return &SessionManager{
@@ -52,23 +64,45 @@ func (sm *SessionManager) Create(userID int64, username string, role model.Role)
 	return sess
 }
 
-// Get retrieves a session by ID.
-func (sm *SessionManager) Get(id uint32) *model.Session {
+// GetSnapshot returns an immutable snapshot of the session.
+func (sm *SessionManager) GetSnapshot(id uint32) (SessionSnapshot, bool) {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
-	return sm.sessions[id]
+	s, ok := sm.sessions[id]
+	if !ok {
+		return SessionSnapshot{}, false
+	}
+	return SessionSnapshot{
+		ID:        s.ID,
+		UserID:    s.UserID,
+		Username:  s.Username,
+		Role:      s.Role,
+		ChannelID: s.ChannelID,
+		UDPAddr:   cloneUDPAddr(s.UDPAddr),
+		Muted:     s.Muted,
+		Deafened:  s.Deafened,
+	}, true
 }
 
-// GetByUserID retrieves a session by user ID.
-func (sm *SessionManager) GetByUserID(userID int64) *model.Session {
+// GetByUserIDSnapshot retrieves a session snapshot by user ID.
+func (sm *SessionManager) GetByUserIDSnapshot(userID int64) (SessionSnapshot, bool) {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
 	for _, s := range sm.sessions {
 		if s.UserID == userID {
-			return s
+			return SessionSnapshot{
+				ID:        s.ID,
+				UserID:    s.UserID,
+				Username:  s.Username,
+				Role:      s.Role,
+				ChannelID: s.ChannelID,
+				UDPAddr:   cloneUDPAddr(s.UDPAddr),
+				Muted:     s.Muted,
+				Deafened:  s.Deafened,
+			}, true
 		}
 	}
-	return nil
+	return SessionSnapshot{}, false
 }
 
 // Remove removes a session.
@@ -83,7 +117,35 @@ func (sm *SessionManager) SetUDPAddr(id uint32, addr *net.UDPAddr) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	if s, ok := sm.sessions[id]; ok {
-		s.UDPAddr = addr
+		s.UDPAddr = cloneUDPAddr(addr)
+	}
+}
+
+// UpdateUserState updates muted/deafened for a session.
+func (sm *SessionManager) UpdateUserState(id uint32, muted, deafened bool) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if s, ok := sm.sessions[id]; ok {
+		s.Muted = muted
+		s.Deafened = deafened
+	}
+}
+
+// SetChannel sets the channel ID for a session.
+func (sm *SessionManager) SetChannel(id uint32, channelID int64) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if s, ok := sm.sessions[id]; ok {
+		s.ChannelID = channelID
+	}
+}
+
+// UpdateRole updates the role for a session.
+func (sm *SessionManager) UpdateRole(id uint32, role model.Role) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if s, ok := sm.sessions[id]; ok {
+		s.Role = role
 	}
 }
 
@@ -94,13 +156,13 @@ func (sm *SessionManager) Count() int {
 	return len(sm.sessions)
 }
 
-// All returns all active sessions (snapshot).
-func (sm *SessionManager) All() []*model.Session {
-	sm.mu.RLock()
-	defer sm.mu.RUnlock()
-	result := make([]*model.Session, 0, len(sm.sessions))
-	for _, s := range sm.sessions {
-		result = append(result, s)
+func cloneUDPAddr(addr *net.UDPAddr) *net.UDPAddr {
+	if addr == nil {
+		return nil
 	}
-	return result
+	clone := *addr
+	if addr.IP != nil {
+		clone.IP = append([]byte(nil), addr.IP...)
+	}
+	return &clone
 }

--- a/pkg/server/voice.go
+++ b/pkg/server/voice.go
@@ -73,8 +73,8 @@ func (s *Server) voiceLoop() {
 		}
 
 		// Look up sender session
-		session := s.sessions.Get(pkt.SessionID)
-		if session == nil {
+		session, ok := s.sessions.GetSnapshot(pkt.SessionID)
+		if !ok {
 			s.metrics.VoicePacketsDropped.Add(1)
 			continue // unknown session, discard
 		}
@@ -111,8 +111,8 @@ func (s *Server) voiceLoop() {
 				continue // don't echo back to sender
 			}
 
-			memberSession := s.sessions.Get(memberSID)
-			if memberSession == nil || memberSession.UDPAddr == nil {
+			memberSession, ok := s.sessions.GetSnapshot(memberSID)
+			if !ok || memberSession.UDPAddr == nil {
 				continue
 			}
 			if memberSession.Deafened {

--- a/pkg/store/memory.go
+++ b/pkg/store/memory.go
@@ -1,0 +1,315 @@
+package store
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/NicolasHaas/gospeak/pkg/model"
+)
+
+// MemoryStore provides an in-memory DataStore implementation for tests.
+// It mirrors SQLite behavior for validation and error handling.
+type MemoryStore struct {
+	mu sync.RWMutex
+
+	now func() time.Time
+
+	nextUserID    int64
+	nextChannelID int64
+	nextTokenID   int64
+	nextBanID     int64
+
+	usersByID       map[int64]*model.User
+	usersByUsername map[string]*model.User
+	channelsByID    map[int64]*model.Channel
+	tokensByHash    map[string]*memoryToken
+	bansByID        map[int64]*model.Ban
+}
+
+type memoryToken struct {
+	id           int64
+	hash         string
+	role         model.Role
+	channelScope int64
+	createdBy    int64
+	maxUses      int
+	useCount     int
+	expiresAt    time.Time
+	createdAt    time.Time
+}
+
+// NewMemory creates a MemoryStore using time.Now().UTC().
+func NewMemory() *MemoryStore {
+	return NewMemoryWithClock(func() time.Time { return time.Now().UTC() })
+}
+
+// NewMemoryWithClock creates a MemoryStore with a custom clock.
+func NewMemoryWithClock(now func() time.Time) *MemoryStore {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &MemoryStore{
+		now:             now,
+		nextUserID:      1,
+		nextChannelID:   1,
+		nextTokenID:     1,
+		nextBanID:       1,
+		usersByID:       make(map[int64]*model.User),
+		usersByUsername: make(map[string]*model.User),
+		channelsByID:    make(map[int64]*model.Channel),
+		tokensByHash:    make(map[string]*memoryToken),
+		bansByID:        make(map[int64]*model.Ban),
+	}
+}
+
+// Close is a no-op for MemoryStore.
+func (s *MemoryStore) Close() error {
+	return nil
+}
+
+// ZeroTime returns the zero time value (used for no-expiry tokens).
+func (s *MemoryStore) ZeroTime() time.Time {
+	return time.Time{}
+}
+
+// CreateUser creates a new user and returns it with the assigned ID.
+func (s *MemoryStore) CreateUser(username string, role model.Role) (*model.User, error) {
+	if err := model.ValidateUsername(username); err != nil {
+		return nil, fmt.Errorf("store: create user: %w", err)
+	}
+	if !role.Valid() {
+		return nil, fmt.Errorf("store: create user: %w", model.ErrInvalidRole)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.usersByUsername[username]; exists {
+		return nil, fmt.Errorf("store: create user: constraint failed: UNIQUE constraint failed: users.username")
+	}
+	createdAt := s.now().UTC()
+	user := &model.User{
+		ID:        s.nextUserID,
+		Username:  username,
+		Role:      role,
+		CreatedAt: createdAt,
+	}
+	s.nextUserID++
+	copyUser := *user
+	s.usersByID[user.ID] = user
+	s.usersByUsername[username] = user
+	return &copyUser, nil
+}
+
+// GetUserByUsername retrieves a user by username.
+func (s *MemoryStore) GetUserByUsername(username string) (*model.User, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	user, ok := s.usersByUsername[username]
+	if !ok {
+		return nil, nil
+	}
+	copyUser := *user
+	return &copyUser, nil
+}
+
+// GetUserByID retrieves a user by ID.
+func (s *MemoryStore) GetUserByID(id int64) (*model.User, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	user, ok := s.usersByID[id]
+	if !ok {
+		return nil, nil
+	}
+	copyUser := *user
+	return &copyUser, nil
+}
+
+// UpdateUserRole changes a user's role.
+func (s *MemoryStore) UpdateUserRole(userID int64, role model.Role) error {
+	if !role.Valid() {
+		return fmt.Errorf("store: update user role: %w", model.ErrInvalidRole)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	user, ok := s.usersByID[userID]
+	if !ok {
+		return nil
+	}
+	user.Role = role
+	return nil
+}
+
+// ListUsers returns all users.
+func (s *MemoryStore) ListUsers() ([]model.User, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	users := make([]model.User, 0, len(s.usersByID))
+	for _, user := range s.usersByID {
+		users = append(users, *user)
+	}
+	sort.Slice(users, func(i, j int) bool {
+		return users[i].ID < users[j].ID
+	})
+	return users, nil
+}
+
+// CreateChannel creates a new channel with basic fields.
+func (s *MemoryStore) CreateChannel(channel *model.Channel) error {
+	if err := channel.Validate(); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	channel.ID = s.nextChannelID
+	channel.CreatedAt = s.now().UTC()
+	s.nextChannelID++
+	copyChannel := *channel
+	s.channelsByID[channel.ID] = &copyChannel
+	return nil
+}
+
+// DeleteChannel deletes a channel by ID.
+func (s *MemoryStore) DeleteChannel(id int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.channelsByID, id)
+	return nil
+}
+
+// ListChannels returns all channels.
+func (s *MemoryStore) ListChannels() ([]model.Channel, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	channels := make([]model.Channel, 0, len(s.channelsByID))
+	for _, ch := range s.channelsByID {
+		channels = append(channels, *ch)
+	}
+	sort.Slice(channels, func(i, j int) bool {
+		if channels[i].ParentID == channels[j].ParentID {
+			return channels[i].ID < channels[j].ID
+		}
+		return channels[i].ParentID < channels[j].ParentID
+	})
+	return channels, nil
+}
+
+// GetChannel retrieves a channel by ID.
+func (s *MemoryStore) GetChannel(id int64) (*model.Channel, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ch, ok := s.channelsByID[id]
+	if !ok {
+		return nil, nil
+	}
+	copyChannel := *ch
+	return &copyChannel, nil
+}
+
+// GetChannelByNameAndParent retrieves a channel by name and parent ID.
+func (s *MemoryStore) GetChannelByNameAndParent(name string, parentID int64) (*model.Channel, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, ch := range s.channelsByID {
+		if ch.Name == name && ch.ParentID == parentID {
+			copyChannel := *ch
+			return &copyChannel, nil
+		}
+	}
+	return nil, nil
+}
+
+// HasTokens returns true if any tokens exist in the database.
+func (s *MemoryStore) HasTokens() (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.tokensByHash) > 0, nil
+}
+
+// CreateToken stores a new token (hash only).
+func (s *MemoryStore) CreateToken(hash string, role model.Role, channelScope int64, createdBy int64, maxUses int, expiresAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.tokensByHash[hash]; exists {
+		return fmt.Errorf("store: create token: constraint failed: UNIQUE constraint failed: tokens.hash")
+	}
+	createdAt := s.now().UTC()
+	if expiresAt.IsZero() {
+		expiresAt = time.Time{}
+	} else {
+		expiresAt = expiresAt.UTC()
+	}
+	s.tokensByHash[hash] = &memoryToken{
+		id:           s.nextTokenID,
+		hash:         hash,
+		role:         role,
+		channelScope: channelScope,
+		createdBy:    createdBy,
+		maxUses:      maxUses,
+		useCount:     0,
+		expiresAt:    expiresAt,
+		createdAt:    createdAt,
+	}
+	s.nextTokenID++
+	return nil
+}
+
+// ValidateToken checks if a token hash is valid and returns the associated role.
+// It increments the use count atomically.
+func (s *MemoryStore) ValidateToken(hash string) (model.Role, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	token, ok := s.tokensByHash[hash]
+	if !ok {
+		return 0, fmt.Errorf("store: invalid token")
+	}
+
+	if !token.expiresAt.IsZero() && s.now().UTC().After(token.expiresAt) {
+		return 0, fmt.Errorf("store: token expired")
+	}
+	if token.maxUses > 0 && token.useCount >= token.maxUses {
+		return 0, fmt.Errorf("store: token exhausted")
+	}
+
+	token.useCount++
+	return token.role, nil
+}
+
+// CreateBan adds a ban record.
+func (s *MemoryStore) CreateBan(userID int64, ip, reason string, bannedBy int64, expiresAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ban := &model.Ban{
+		ID:        s.nextBanID,
+		UserID:    userID,
+		IP:        ip,
+		Reason:    reason,
+		BannedBy:  bannedBy,
+		ExpiresAt: expiresAt,
+		CreatedAt: s.now().UTC(),
+	}
+	s.nextBanID++
+	s.bansByID[ban.ID] = ban
+	return nil
+}
+
+// IsUserBanned checks if a user ID is currently banned.
+func (s *MemoryStore) IsUserBanned(userID int64) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	now := s.now().UTC()
+	for _, ban := range s.bansByID {
+		if ban.UserID != userID {
+			continue
+		}
+		if ban.ExpiresAt.IsZero() || ban.ExpiresAt.After(now) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Compile-time check: *MemoryStore implements DataStore.
+var _ DataStore = (*MemoryStore)(nil)

--- a/pkg/store/memory_store_test.go
+++ b/pkg/store/memory_store_test.go
@@ -1,0 +1,47 @@
+package store_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/NicolasHaas/gospeak/pkg/crypto"
+	"github.com/NicolasHaas/gospeak/pkg/model"
+	"github.com/NicolasHaas/gospeak/pkg/store"
+)
+
+func TestStoreBasicFlow(t *testing.T) {
+	withStores(t, func(t *testing.T, st store.DataStore) {
+		user, err := st.CreateUser("johndoe", model.RoleUser)
+		if err != nil {
+			t.Fatalf("CreateUser: unexpected error: %v", err)
+		}
+		if user.ID == 0 {
+			t.Fatalf("CreateUser: expected non-zero ID")
+		}
+
+		fetched, err := st.GetUserByUsername("johndoe")
+		if err != nil {
+			t.Fatalf("GetUserByUsername: unexpected error: %v", err)
+		}
+		if fetched == nil || fetched.ID != user.ID {
+			t.Fatalf("GetUserByUsername: expected user with ID %d", user.ID)
+		}
+
+		rawToken, err := crypto.GenerateToken()
+		if err != nil {
+			t.Fatalf("GenerateToken: unexpected error: %v", err)
+		}
+		hash := crypto.HashToken(rawToken)
+		if err := st.CreateToken(hash, model.RoleUser, 0, user.ID, 1, time.Now().Add(time.Hour)); err != nil {
+			t.Fatalf("CreateToken: unexpected error: %v", err)
+		}
+
+		role, err := st.ValidateToken(hash)
+		if err != nil {
+			t.Fatalf("ValidateToken: unexpected error: %v", err)
+		}
+		if role != model.RoleUser {
+			t.Fatalf("ValidateToken: role mismatch want=%d got=%d", model.RoleUser, role)
+		}
+	})
+}


### PR DESCRIPTION
- Inject the server’s persistence via `server.Dependencies` and wire it in `cmd/server` to keep core logic backend-agnostic.
- Make session state concurrency-safe with snapshot reads and centralized mutation, simplify channel membership tracking.
- Add versioned store migrations and strict UTC time parsing/formatting.
- Provide a parity in-memory store and backend-agnostic store tests; document testing approach.


Session snapshots avoid races between control-plane updates and voice forwarding.
 `pkg/store/memory.go` mirrors SQLite validation/error behavior for reliable tests.