### PR TITLE
Improve connect UX and enforce personal-token auth (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Download the appropriate binary for your platform from [Releases](https://github
 ./bin/gospeak-client-lin       # Linux
 ```
 
-Enter the server address, your username, and (optionally) a token to connect.
+Enter the server address, your username, and (optionally) an invite token to connect. On first login the server issues a personal token; keep it to reconnect with the same username.
 
 ## Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,11 +134,12 @@ sequenceDiagram
     participant UDP as UDP Voice
     participant Srv as Server
 
-    UI->>Eng: Connect(host, token, username)
+    UI->>Eng: Connect(host, token?, username)
     Eng->>TLS: Dial TCP/TLS (skip verify for self-signed)
     TLS->>Srv: TLS 1.3 Handshake
-    Eng->>Srv: AuthRequest{token, username}
-    Srv->>Eng: AuthResponse{sessionID, role, encryptionKey, channels}
+    Eng->>Srv: AuthRequest{token?, username}
+    Srv->>Eng: AuthResponse{sessionID, role, encryptionKey, channels, autoToken?}
+    Note over Eng: Store autoToken for future logins
     Eng->>Eng: Create VoiceCipher from encryptionKey
     Eng->>UDP: Dial UDP to server:9601
     Eng->>Eng: Start audio capture + playback

--- a/docs/building.md
+++ b/docs/building.md
@@ -111,7 +111,7 @@ docker run -p 9600:9600 -p 9601:9601/udp \
 | `-data` | `.` | Directory for auto-generated TLS certs |
 | `-cert` | *(auto)* | Custom TLS certificate path |
 | `-key` | *(auto)* | Custom TLS private key path |
-| `-open` | `false` | Allow connections without a token |
+| `-open` | `false` | Allow first-time connections without an invite token (personal token still required on reconnect) |
 | `-channels-file` | *(none)* | YAML file defining channels to create on startup |
 | `-metrics` | `:9602` | HTTP bind address for Prometheus /metrics (empty to disable) |
 | `-export-users` | `false` | Export all users as YAML and exit |

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -52,13 +52,19 @@ sequenceDiagram
     participant C as Client
     participant S as Server
 
-    C->>S: AuthRequest{token, username}
-    alt Token valid (or open server)
-        S->>S: Find/create user in SQLite
+    C->>S: AuthRequest{token?, username}
+    alt New user (invite or open server)
+        S->>S: Validate invite token or allow open join
+        S->>S: Create user + personal token
+        S->>S: Check bans
+        S->>S: Generate session
+        S->>C: AuthResponse{sessionID, role, encryptionKey, channels, autoToken}
+        Note over C: Store personal token for reconnect
+    else Existing user
+        S->>S: Require personal token
         S->>S: Check bans
         S->>S: Generate session
         S->>C: AuthResponse{sessionID, role, encryptionKey, channels}
-        Note over C: Client stores AES-128 key for voice encryption
     else Invalid token / banned
         S->>C: ErrorResponse{code, message}
         S->>S: Close connection

--- a/docs/security.md
+++ b/docs/security.md
@@ -124,13 +124,13 @@ graph TB
 ```
 
 - Tokens are 256-bit random values (64 hex characters)
-- Only the SHA-256 hash is stored in the database
+- Only the SHA-256 hash is stored in the database (invite + personal tokens). Personal tokens are stored on the user record and are shown only once.
 - Tokens can have: role assignment, channel scope, max uses, expiration
 - On first server run, an admin token is automatically generated and logged
 
 ### Open Server Mode
 
-When `AllowNoToken` is enabled, clients can connect without a token and receive the `user` role. The server auto-generates a token internally for tracking purposes.
+When `AllowNoToken` is enabled, clients can connect without an invite token and receive the `user` role. The server issues a **personal token** on first login; that personal token is required for future logins with the same username.
 
 ## Role-Based Access Control (RBAC)
 
@@ -162,7 +162,7 @@ graph TB
     MOD --> P3
 ```
 
-Every admin operation is checked server-side via `rbac.HasPermission()` before execution. The client's role is determined by the token used during authentication.
+Every admin operation is checked server-side via `rbac.HasPermission()` before execution. The client's role is determined by the stored user role, and logins require the user's personal token.
 
 ## Password Hashing
 

--- a/pkg/client/bookmarks.go
+++ b/pkg/client/bookmarks.go
@@ -14,6 +14,7 @@ type Bookmark struct {
 	VoiceAddr   string `yaml:"voice_addr"`
 	Username    string `yaml:"username"`
 	Token       string `yaml:"token"`
+	LastUsed    int64  `yaml:"last_used,omitempty"`
 }
 
 // BookmarkStore manages server bookmarks stored next to the binary.
@@ -66,6 +67,17 @@ func (bs *BookmarkStore) Add(b Bookmark) bool {
 	}
 	bs.Bookmarks = append(bs.Bookmarks, b)
 	return true
+}
+
+// Touch updates LastUsed for an existing bookmark.
+func (bs *BookmarkStore) Touch(controlAddr, username string, ts int64) bool {
+	for i := range bs.Bookmarks {
+		if bs.Bookmarks[i].ControlAddr == controlAddr && bs.Bookmarks[i].Username == username {
+			bs.Bookmarks[i].LastUsed = ts
+			return true
+		}
+	}
+	return false
 }
 
 // FindByAddr returns a bookmark matching the given control address, or nil.

--- a/pkg/client/engine.go
+++ b/pkg/client/engine.go
@@ -742,6 +742,13 @@ func (e *Engine) GetChannels() []pb.ChannelInfo {
 	return result
 }
 
+// GetChannelID returns the current channel ID (0 if none).
+func (e *Engine) GetChannelID() int64 {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.channelID
+}
+
 // IsMuted returns whether the client is muted.
 func (e *Engine) IsMuted() bool {
 	e.mu.RLock()
@@ -764,6 +771,8 @@ func (e *Engine) handleDisconnect(reason string) {
 	}
 	e.state = StateDisconnected
 	e.channelID = 0
+	e.muted = false
+	e.deafened = false
 
 	ctrl := e.control
 	voice := e.voice

--- a/pkg/datastore/interface.go
+++ b/pkg/datastore/interface.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/NicolasHaas/gospeak/pkg/model"
@@ -42,6 +43,10 @@ type DataStore interface {
 }
 
 // Compile-time check: *Store implements DataStore.
+// ErrUsernameTaken is returned when a CreateUser call fails due to a
+// duplicate username constraint.
+var ErrUsernameTaken = errors.New("datastore: username already taken")
+
 var _ DataProviderFactory = (*ProviderFactory)(nil)
 
 type ConfigReadProvider interface {

--- a/pkg/datastore/interface.go
+++ b/pkg/datastore/interface.go
@@ -51,12 +51,14 @@ type ConfigReadProvider interface {
 type UserReadProvider interface {
 	GetUserByUsername(username string) (*model.User, error)
 	GetUserByID(id int64) (*model.User, error)
+	GetUserByPersonalTokenHash(hash string) (*model.User, error)
 	ListUsers() ([]model.User, error)
 }
 
 type UserWriteProvider interface {
 	CreateUser(username string, role model.Role) (*model.User, error)
 	UpdateUserRole(userID int64, role model.Role) error
+	UpdateUserPersonalToken(userID int64, hash string, createdAt time.Time) error
 }
 
 type ChannelReadProvider interface {

--- a/pkg/datastore/sql.go
+++ b/pkg/datastore/sql.go
@@ -114,6 +114,8 @@ func (s *ProviderFactory) migrate() error {
 		id         INTEGER PRIMARY KEY AUTOINCREMENT,
 		username   TEXT    NOT NULL UNIQUE CHECK(length(username) > 0 AND length(username) <= 32),
 		role       INTEGER NOT NULL DEFAULT 0 CHECK(role >= 0 AND role <= 2),
+		personal_token_hash TEXT NOT NULL DEFAULT '',
+		personal_token_created_at TEXT NOT NULL DEFAULT (datetime('now')),
 		created_at TEXT    NOT NULL DEFAULT (datetime('now'))
 	);
 
@@ -182,6 +184,21 @@ func (s *ProviderFactory) migrate() error {
 				"ALTER TABLE channels ADD COLUMN parent_id INTEGER NOT NULL DEFAULT 0",
 				"ALTER TABLE channels ADD COLUMN is_temp INTEGER NOT NULL DEFAULT 0",
 				"ALTER TABLE channels ADD COLUMN allow_sub_channels INTEGER NOT NULL DEFAULT 0",
+			},
+			ignoreErrors: true,
+		},
+		{
+			version: 3,
+			statements: []string{
+				"ALTER TABLE users ADD COLUMN personal_token_hash TEXT NOT NULL DEFAULT ''",
+				"ALTER TABLE users ADD COLUMN personal_token_created_at TEXT NOT NULL DEFAULT (datetime('now'))",
+			},
+			ignoreErrors: true,
+		},
+		{
+			version: 4,
+			statements: []string{
+				"CREATE INDEX IF NOT EXISTS idx_users_personal_token_hash ON users(personal_token_hash)",
 			},
 			ignoreErrors: true,
 		},
@@ -263,7 +280,14 @@ func (s *baseProvider) CreateUser(username string, role model.Role) (*model.User
 	if !role.Valid() {
 		return nil, fmt.Errorf("datastore: create user: %w", model.ErrInvalidRole)
 	}
-	res, err := s.ExecContext(context.Background(), "INSERT INTO users (username, role) VALUES (?, ?)", username, int(role))
+	res, err := s.ExecContext(
+		context.Background(),
+		"INSERT INTO users (username, role, personal_token_hash, personal_token_created_at) VALUES (?, ?, ?, ?)",
+		username,
+		int(role),
+		"",
+		formatDBTime(time.Now().UTC()),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("datastore: create user: %w", err)
 	}
@@ -281,8 +305,12 @@ func (s *baseProvider) GetUserByUsername(username string) (*model.User, error) {
 	u := &model.User{}
 	var roleInt int
 	var createdAt string
-	err := s.QueryRowContext(context.Background(), "SELECT id, username, role, created_at FROM users WHERE username = ?", username).
-		Scan(&u.ID, &u.Username, &roleInt, &createdAt)
+	var personalTokenCreatedAt string
+	err := s.QueryRowContext(
+		context.Background(),
+		"SELECT id, username, role, personal_token_hash, personal_token_created_at, created_at FROM users WHERE username = ?",
+		username,
+	).Scan(&u.ID, &u.Username, &roleInt, &u.PersonalTokenHash, &personalTokenCreatedAt, &createdAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -295,6 +323,10 @@ func (s *baseProvider) GetUserByUsername(username string) (*model.User, error) {
 		return nil, fmt.Errorf("datastore: get user: %w", err)
 	}
 	u.CreatedAt = parsed
+	u.PersonalTokenCreatedAt, err = parseDBTime(personalTokenCreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("datastore: get user: %w", err)
+	}
 	return u, nil
 }
 
@@ -303,8 +335,12 @@ func (s *baseProvider) GetUserByID(id int64) (*model.User, error) {
 	u := &model.User{}
 	var roleInt int
 	var createdAt string
-	err := s.QueryRowContext(context.Background(), "SELECT id, username, role, created_at FROM users WHERE id = ?", id).
-		Scan(&u.ID, &u.Username, &roleInt, &createdAt)
+	var personalTokenCreatedAt string
+	err := s.QueryRowContext(
+		context.Background(),
+		"SELECT id, username, role, personal_token_hash, personal_token_created_at, created_at FROM users WHERE id = ?",
+		id,
+	).Scan(&u.ID, &u.Username, &roleInt, &u.PersonalTokenHash, &personalTokenCreatedAt, &createdAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -317,6 +353,38 @@ func (s *baseProvider) GetUserByID(id int64) (*model.User, error) {
 		return nil, fmt.Errorf("datastore: get user: %w", err)
 	}
 	u.CreatedAt = parsed
+	u.PersonalTokenCreatedAt, err = parseDBTime(personalTokenCreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("datastore: get user: %w", err)
+	}
+	return u, nil
+}
+
+func (s *baseProvider) GetUserByPersonalTokenHash(hash string) (*model.User, error) {
+	u := &model.User{}
+	var roleInt int
+	var createdAt string
+	var personalTokenCreatedAt string
+	err := s.QueryRowContext(
+		context.Background(),
+		"SELECT id, username, role, personal_token_hash, personal_token_created_at, created_at FROM users WHERE personal_token_hash = ?",
+		hash,
+	).Scan(&u.ID, &u.Username, &roleInt, &u.PersonalTokenHash, &personalTokenCreatedAt, &createdAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("datastore: get user by token: %w", err)
+	}
+	u.Role = model.Role(roleInt)
+	u.CreatedAt, err = parseDBTime(createdAt)
+	if err != nil {
+		return nil, fmt.Errorf("datastore: get user by token: %w", err)
+	}
+	u.PersonalTokenCreatedAt, err = parseDBTime(personalTokenCreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("datastore: get user by token: %w", err)
+	}
 	return u, nil
 }
 
@@ -332,9 +400,28 @@ func (s *baseProvider) UpdateUserRole(userID int64, role model.Role) error {
 	return nil
 }
 
+func (s *baseProvider) UpdateUserPersonalToken(userID int64, hash string, createdAt time.Time) error {
+	var createdAtValue *string
+	if !createdAt.IsZero() {
+		value := formatDBTime(createdAt)
+		createdAtValue = &value
+	}
+	_, err := s.ExecContext(
+		context.Background(),
+		"UPDATE users SET personal_token_hash = ?, personal_token_created_at = ? WHERE id = ?",
+		hash,
+		createdAtValue,
+		userID,
+	)
+	if err != nil {
+		return fmt.Errorf("datastore: update personal token: %w", err)
+	}
+	return nil
+}
+
 // ListUsers returns all users.
 func (s *baseProvider) ListUsers() ([]model.User, error) {
-	rows, err := s.QueryContext(context.Background(), "SELECT id, username, role, created_at FROM users ORDER BY id")
+	rows, err := s.QueryContext(context.Background(), "SELECT id, username, role, personal_token_hash, personal_token_created_at, created_at FROM users ORDER BY id")
 	if err != nil {
 		return nil, fmt.Errorf("datastore: list users: %w", err)
 	}
@@ -345,15 +432,19 @@ func (s *baseProvider) ListUsers() ([]model.User, error) {
 		var u model.User
 		var roleInt int
 		var createdAt string
-		if err := rows.Scan(&u.ID, &u.Username, &roleInt, &createdAt); err != nil {
+		var personalTokenCreatedAt string
+		if err := rows.Scan(&u.ID, &u.Username, &roleInt, &u.PersonalTokenHash, &personalTokenCreatedAt, &createdAt); err != nil {
 			return nil, fmt.Errorf("datastore: scan user: %w", err)
 		}
 		u.Role = model.Role(roleInt)
-		parsed, err := parseDBTime(createdAt)
+		u.CreatedAt, err = parseDBTime(createdAt)
 		if err != nil {
 			return nil, fmt.Errorf("datastore: scan user: %w", err)
 		}
-		u.CreatedAt = parsed
+		u.PersonalTokenCreatedAt, err = parseDBTime(personalTokenCreatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("datastore: scan user: %w", err)
+		}
 		users = append(users, u)
 	}
 	return users, rows.Err()

--- a/pkg/datastore/sql.go
+++ b/pkg/datastore/sql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -289,6 +290,9 @@ func (s *baseProvider) CreateUser(username string, role model.Role) (*model.User
 		formatDBTime(time.Now().UTC()),
 	)
 	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed: users.username") {
+			return nil, fmt.Errorf("datastore: create user: %w", ErrUsernameTaken)
+		}
 		return nil, fmt.Errorf("datastore: create user: %w", err)
 	}
 	id, _ := res.LastInsertId()
@@ -401,16 +405,15 @@ func (s *baseProvider) UpdateUserRole(userID int64, role model.Role) error {
 }
 
 func (s *baseProvider) UpdateUserPersonalToken(userID int64, hash string, createdAt time.Time) error {
-	var createdAtValue *string
-	if !createdAt.IsZero() {
-		value := formatDBTime(createdAt)
-		createdAtValue = &value
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
 	}
+	createdAtStr := formatDBTime(createdAt)
 	_, err := s.ExecContext(
 		context.Background(),
 		"UPDATE users SET personal_token_hash = ?, personal_token_created_at = ? WHERE id = ?",
 		hash,
-		createdAtValue,
+		createdAtStr,
 		userID,
 	)
 	if err != nil {

--- a/pkg/datastore/sql_test.go
+++ b/pkg/datastore/sql_test.go
@@ -284,61 +284,115 @@ func TestUpdateUserRole(t *testing.T) {
 func TestGetUserByPersonalTokenHash(t *testing.T) {
 	t.Parallel()
 
-	store, err := NewTestSqlConn(t)
-	if err != nil {
-		t.Fatalf("failed to open test connection: %v", err)
+	type tcase struct {
+		seedUsername string
+		lookupHash   string
+		expectUser   bool
 	}
 
-	u, err := store.NonTx().CreateUser("johndoe", model.RoleUser)
-	if err != nil {
-		t.Fatalf("CreateUser: failed to seed user: %v", err)
+	tests := map[string]tcase{
+		"hash_matches_user": {
+			seedUsername: "johndoe",
+			lookupHash:   crypto.HashToken("personal-token"),
+			expectUser:   true,
+		},
+		"hash_not_found": {
+			seedUsername: "janedoe",
+			lookupHash:   crypto.HashToken("missing-token"),
+			expectUser:   false,
+		},
 	}
 
-	hash := crypto.HashToken("personal-token")
-	if err := store.NonTx().UpdateUserPersonalToken(u.ID, hash, time.Now().UTC()); err != nil {
-		t.Fatalf("UpdateUserPersonalToken: unexpected error: %v", err)
-	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	got, err := store.NonTx().GetUserByPersonalTokenHash(hash)
-	if err != nil {
-		t.Fatalf("GetUserByPersonalTokenHash: unexpected error: %v", err)
-	}
-	if got == nil {
-		t.Fatalf("GetUserByPersonalTokenHash: expected user, got nil")
-	}
-	if got.ID != u.ID {
-		t.Fatalf("GetUserByPersonalTokenHash: id mismatch want=%d got=%d", u.ID, got.ID)
+			store, err := NewTestSqlConn(t)
+			if err != nil {
+				t.Fatalf("failed to open test connection: %v", err)
+			}
+
+			u, err := store.NonTx().CreateUser(tc.seedUsername, model.RoleUser)
+			if err != nil {
+				t.Fatalf("CreateUser: failed to seed user: %v", err)
+			}
+
+			if tc.expectUser {
+				if err := store.NonTx().UpdateUserPersonalToken(u.ID, tc.lookupHash, time.Now().UTC()); err != nil {
+					t.Fatalf("UpdateUserPersonalToken: unexpected error: %v", err)
+				}
+			}
+
+			got, err := store.NonTx().GetUserByPersonalTokenHash(tc.lookupHash)
+			if err != nil {
+				t.Fatalf("GetUserByPersonalTokenHash: unexpected error: %v", err)
+			}
+			if !tc.expectUser {
+				if got != nil {
+					t.Fatalf("GetUserByPersonalTokenHash: expected nil user")
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("GetUserByPersonalTokenHash: expected user, got nil")
+			}
+			if got.ID != u.ID {
+				t.Fatalf("GetUserByPersonalTokenHash: id mismatch want=%d got=%d", u.ID, got.ID)
+			}
+		})
 	}
 }
 
 func TestUpdateUserPersonalToken(t *testing.T) {
 	t.Parallel()
 
-	store, err := NewTestSqlConn(t)
-	if err != nil {
-		t.Fatalf("failed to open test connection: %v", err)
+	type tcase struct {
+		username  string
+		tokenText string
 	}
 
-	u, err := store.NonTx().CreateUser("janedoe", model.RoleUser)
-	if err != nil {
-		t.Fatalf("CreateUser: failed to seed user: %v", err)
+	tests := map[string]tcase{
+		"updates_to_first_token": {
+			username:  "janedoe",
+			tokenText: "new-personal-token",
+		},
+		"updates_to_replacement_token": {
+			username:  "johnsmith",
+			tokenText: "replacement-personal-token",
+		},
 	}
 
-	hash := crypto.HashToken("new-personal-token")
-	now := time.Now().UTC()
-	if err := store.NonTx().UpdateUserPersonalToken(u.ID, hash, now); err != nil {
-		t.Fatalf("UpdateUserPersonalToken: unexpected error: %v", err)
-	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	got, err := store.NonTx().GetUserByID(u.ID)
-	if err != nil {
-		t.Fatalf("GetUserByID: unexpected error: %v", err)
-	}
-	if got == nil {
-		t.Fatalf("GetUserByID: expected user, got nil")
-	}
-	if got.PersonalTokenHash != hash {
-		t.Fatalf("UpdateUserPersonalToken: hash mismatch")
+			store, err := NewTestSqlConn(t)
+			if err != nil {
+				t.Fatalf("failed to open test connection: %v", err)
+			}
+
+			u, err := store.NonTx().CreateUser(tc.username, model.RoleUser)
+			if err != nil {
+				t.Fatalf("CreateUser: failed to seed user: %v", err)
+			}
+
+			hash := crypto.HashToken(tc.tokenText)
+			now := time.Now().UTC()
+			if err := store.NonTx().UpdateUserPersonalToken(u.ID, hash, now); err != nil {
+				t.Fatalf("UpdateUserPersonalToken: unexpected error: %v", err)
+			}
+
+			got, err := store.NonTx().GetUserByID(u.ID)
+			if err != nil {
+				t.Fatalf("GetUserByID: unexpected error: %v", err)
+			}
+			if got == nil {
+				t.Fatalf("GetUserByID: expected user, got nil")
+			}
+			if got.PersonalTokenHash != hash {
+				t.Fatalf("UpdateUserPersonalToken: hash mismatch")
+			}
+		})
 	}
 }
 

--- a/pkg/datastore/sql_test.go
+++ b/pkg/datastore/sql_test.go
@@ -123,7 +123,7 @@ func TestCreateUser(t *testing.T) {
 				Role:     tc.role,
 			}
 
-			if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(model.User{}, "ID", "CreatedAt")); diff != "" {
+			if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(model.User{}, "ID", "PersonalTokenCreatedAt", "CreatedAt")); diff != "" {
 				t.Errorf("store.NonTx().CreateUser mismatch (-want +got):\\n%s", diff)
 			}
 		}
@@ -193,7 +193,7 @@ func TestGetUserByUsername(t *testing.T) {
 				Role:     tc.role,
 			}
 
-			if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(model.User{}, "ID", "CreatedAt")); diff != "" {
+			if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(model.User{}, "ID", "PersonalTokenCreatedAt", "CreatedAt")); diff != "" {
 				t.Fatalf("GetUserByUsername mismatch (-want +got):\n%s", diff)
 			}
 
@@ -281,6 +281,67 @@ func TestUpdateUserRole(t *testing.T) {
 	}
 }
 
+func TestGetUserByPersonalTokenHash(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewTestSqlConn(t)
+	if err != nil {
+		t.Fatalf("failed to open test connection: %v", err)
+	}
+
+	u, err := store.NonTx().CreateUser("johndoe", model.RoleUser)
+	if err != nil {
+		t.Fatalf("CreateUser: failed to seed user: %v", err)
+	}
+
+	hash := crypto.HashToken("personal-token")
+	if err := store.NonTx().UpdateUserPersonalToken(u.ID, hash, time.Now().UTC()); err != nil {
+		t.Fatalf("UpdateUserPersonalToken: unexpected error: %v", err)
+	}
+
+	got, err := store.NonTx().GetUserByPersonalTokenHash(hash)
+	if err != nil {
+		t.Fatalf("GetUserByPersonalTokenHash: unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("GetUserByPersonalTokenHash: expected user, got nil")
+	}
+	if got.ID != u.ID {
+		t.Fatalf("GetUserByPersonalTokenHash: id mismatch want=%d got=%d", u.ID, got.ID)
+	}
+}
+
+func TestUpdateUserPersonalToken(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewTestSqlConn(t)
+	if err != nil {
+		t.Fatalf("failed to open test connection: %v", err)
+	}
+
+	u, err := store.NonTx().CreateUser("janedoe", model.RoleUser)
+	if err != nil {
+		t.Fatalf("CreateUser: failed to seed user: %v", err)
+	}
+
+	hash := crypto.HashToken("new-personal-token")
+	now := time.Now().UTC()
+	if err := store.NonTx().UpdateUserPersonalToken(u.ID, hash, now); err != nil {
+		t.Fatalf("UpdateUserPersonalToken: unexpected error: %v", err)
+	}
+
+	got, err := store.NonTx().GetUserByID(u.ID)
+	if err != nil {
+		t.Fatalf("GetUserByID: unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("GetUserByID: expected user, got nil")
+	}
+	if got.PersonalTokenHash != hash {
+		t.Fatalf("UpdateUserPersonalToken: hash mismatch")
+	}
+}
+
 func TestListUsers(t *testing.T) {
 	t.Parallel()
 
@@ -328,7 +389,7 @@ func TestListUsers(t *testing.T) {
 				t.Fatalf("ListUsers: unexpected error: %v", err)
 			}
 
-			if diff := cmp.Diff(tc.users, users, cmpopts.IgnoreFields(model.User{}, "ID", "CreatedAt")); diff != "" {
+			if diff := cmp.Diff(tc.users, users, cmpopts.IgnoreFields(model.User{}, "ID", "PersonalTokenCreatedAt", "CreatedAt")); diff != "" {
 				t.Fatalf("ListUsers mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -15,10 +15,12 @@ var ErrInvalidRole = errors.New("invalid role: must be user (0), moderator (1), 
 
 // User represents a registered user.
 type User struct {
-	ID        int64     `json:"id"`
-	Username  string    `json:"username"`
-	Role      Role      `json:"role"`
-	CreatedAt time.Time `json:"created_at"`
+	ID                     int64     `json:"id"`
+	Username               string    `json:"username"`
+	Role                   Role      `json:"role"`
+	PersonalTokenHash      string    `json:"-"`
+	PersonalTokenCreatedAt time.Time `json:"-"`
+	CreatedAt              time.Time `json:"created_at"`
 }
 
 // ValidateUsername checks that a username is 1-32 ASCII alphanumeric, underscore,

--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -136,93 +137,93 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 		return
 	}
 
-	// Validate token
 	authReq := msg.AuthRequest
-
-	// Validate username
-	if !isValidUsername(authReq.Username) {
-		sendError(conn, 2, "invalid username: must be 1-32 alphanumeric/underscore characters")
-		return
-	}
-
-	var tokenRole model.Role
-	var autoToken string // set when server generates a token for token-less join
-
-	if authReq.Token == "" {
-		// Token-less join
-		if !s.cfg.AllowNoToken {
-			s.metrics.FailedAuths.Add(1)
-			sendError(conn, 2, "authentication failed: token required")
-			return
-		}
-		tokenRole = model.RoleUser
-	} else {
-		tokenHash := crypto.HashToken(authReq.Token)
-		var err error
-
-		ctx := context.Background()
-		tx, err := st.Tx(ctx)
-		if err != nil {
-			sendError(conn, 3, "could not establish transaction: "+err.Error())
-			return
-		}
-
-		committed := false
-		defer func() {
-			if !committed {
-				// We never made it to commit, roll it back
-				if err := tx.Rollback(); err != nil {
-					// Rollback failures are almost never the root problem
-					// for a failure here and returning an error would mask
-					// the root problem, so we'll log the failure for observation
-					slog.Warn("tx rollback failed", "err", err)
-				}
-			}
-		}()
-
-		tokenRole, err = tx.ValidateToken(tokenHash)
-		if err != nil {
-			s.metrics.FailedAuths.Add(1)
-			sendError(conn, 2, "authentication failed: "+err.Error())
-			return
-		}
-		if err := tx.Commit(); err != nil {
-			sendError(conn, 3, "error committing transaction: "+err.Error())
-			return
-		}
-		committed = true
-	}
-
-	// Create or get user — existing users keep their stored role
-	user, err := st.NonTx().GetUserByUsername(authReq.Username)
-	if err != nil {
-		sendError(conn, 3, "internal error")
-		return
+	var tokenHash string
+	if authReq.Token != "" {
+		tokenHash = crypto.HashToken(authReq.Token)
 	}
 
 	var sessionRole model.Role
-	if user == nil {
+	var autoToken string // set when server generates a personal token
+
+	var user *model.User
+	if tokenHash != "" {
+		user, err = st.NonTx().GetUserByPersonalTokenHash(tokenHash)
+		if err != nil {
+			sendError(conn, 3, "internal error")
+			return
+		}
+	}
+
+	var tokenRole model.Role
+	if user != nil {
+		sessionRole = user.Role
+	} else {
+		if !isValidUsername(authReq.Username) {
+			sendError(conn, 2, "invalid username: must be 1-32 alphanumeric/underscore characters")
+			return
+		}
+
 		// New user: role comes from the token
+		if authReq.Token == "" {
+			if !s.cfg.AllowNoToken {
+				s.metrics.FailedAuths.Add(1)
+				sendError(conn, 2, "authentication failed: token required")
+				return
+			}
+			tokenRole = model.RoleUser
+		} else {
+			ctx := context.Background()
+			tx, err := st.Tx(ctx)
+			if err != nil {
+				sendError(conn, 3, "could not establish transaction: "+err.Error())
+				return
+			}
+
+			committed := false
+			defer func() {
+				if !committed {
+					if err := tx.Rollback(); err != nil {
+						slog.Warn("tx rollback failed", "err", err)
+					}
+				}
+			}()
+
+			tokenRole, err = tx.ValidateToken(tokenHash)
+			if err != nil {
+				s.metrics.FailedAuths.Add(1)
+				sendError(conn, 2, "authentication failed: "+err.Error())
+				return
+			}
+			if err := tx.Commit(); err != nil {
+				sendError(conn, 3, "error committing transaction: "+err.Error())
+				return
+			}
+			committed = true
+		}
+
 		user, err = st.NonTx().CreateUser(authReq.Username, tokenRole)
 		if err != nil {
+			if errors.Is(err, datastore.ErrUsernameTaken) {
+				s.metrics.FailedAuths.Add(1)
+				sendError(conn, 2, "authentication failed: personal token required")
+				return
+			}
 			sendError(conn, 3, "failed to create user: "+err.Error())
 			return
 		}
 		sessionRole = tokenRole
 
-		// Auto-generate a personal token for identification (token-less join)
-		if authReq.Token == "" {
-			rawToken, err := crypto.GenerateToken()
-			if err == nil {
-				hash := crypto.HashToken(rawToken)
-				_ = st.NonTx().CreateToken(hash, model.RoleUser, 0, 0, 0, st.NonTx().ZeroTime()) // unlimited, no expiry
-				autoToken = rawToken
-				slog.Debug("auto-generated token for token-less user", "user", user.Username)
-			}
+		rawToken, err := crypto.GenerateToken()
+		if err != nil {
+			sendError(conn, 3, "failed to generate personal token")
+			return
 		}
-	} else {
-		// Existing user: use their stored/persisted role (honors SetUserRole changes)
-		sessionRole = user.Role
+		if err := st.NonTx().UpdateUserPersonalToken(user.ID, crypto.HashToken(rawToken), time.Now().UTC()); err != nil {
+			sendError(conn, 3, "failed to store personal token")
+			return
+		}
+		autoToken = rawToken
 	}
 
 	// Check ban

--- a/pkg/server/run.go
+++ b/pkg/server/run.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/NicolasHaas/gospeak/pkg/crypto"
 	"github.com/NicolasHaas/gospeak/pkg/datastore"
@@ -61,11 +60,10 @@ func (s *Server) Run() error {
 		"voice", s.cfg.VoiceAddr,
 	)
 
-	// Start Prometheus metrics HTTP endpoint
-	s.StartMetricsHTTP()
-
-	// Start periodic metrics logging (every 60s)
-	s.metrics.StartPeriodicLog(60*time.Second, s.ctx.Done())
+	if s.cfg.MetricsAddr != "" {
+		// Start Prometheus metrics HTTP endpoint
+		s.StartMetricsHTTP()
+	}
 
 	// Wait for shutdown signal
 	sigCh := make(chan os.Signal, 1)


### PR DESCRIPTION
Rebased on top of #10 (datastore refactor + message persistence) to resolve conflicts and adopt the new datastore interfaces.

While testing I noticed a security issue: on open servers, you could join with an existing username (even admin) and inherit the role. That prompted the PAT-first refactor so identities are tied to personal tokens.


**Personal-token auth**
Personal tokens are now the primary identity on reconnect. New users receive an auto-generated token on first login; returning users must present it. The ErrUsernameTaken sentinel error keeps the uniqueness check backend-agnostic.

**Connect dialog UX**
Default host, address normalization (IPv4/IPv6), advanced voice override behind an accordion, bookmarks sorted by last-used, paste/copy helpers for tokens.

**Datastore additions**
GetUserByPersonalTokenHash, UpdateUserPersonalToken, and the personal_token_hash / personal_token_created_at columns (migrations v3–v4) added against the new datastore package from #10.

**Metrics**
StartMetricsHTTP gated behind a non-empty MetricsAddr; periodic log spam removed.

**Docs**
Protocol, security, architecture, and building docs updated to reflect the invite-token → personal-token flow.