### PR TITLE
fix: serialize control connection writes

### DIFF
--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -90,14 +90,22 @@ func WriteControlMessage(w io.Writer, msg *pb.ControlMessage) error {
 		return fmt.Errorf("protocol: message too large: %d bytes", len(data))
 	}
 
-	// Write length prefix
-	lenBuf := make([]byte, 4)
-	binary.BigEndian.PutUint32(lenBuf, uint32(len(data))) //nolint:gosec // length already bounds-checked above
-	if _, err := w.Write(lenBuf); err != nil {
-		return fmt.Errorf("protocol: write length: %w", err)
-	}
-	if _, err := w.Write(data); err != nil {
-		return fmt.Errorf("protocol: write payload: %w", err)
+	frame := make([]byte, 4+len(data))
+	binary.BigEndian.PutUint32(frame[:4], uint32(len(data))) //nolint:gosec // length already bounds-checked above
+	copy(frame[4:], data)
+
+	for len(frame) > 0 {
+		n, writeErr := w.Write(frame)
+		if n < 0 || n > len(frame) {
+			return fmt.Errorf("protocol: invalid write count: %d", n)
+		}
+		frame = frame[n:]
+		if writeErr != nil {
+			return fmt.Errorf("protocol: write frame: %w", writeErr)
+		}
+		if n == 0 {
+			return fmt.Errorf("protocol: write frame: %w", io.ErrShortWrite)
+		}
 	}
 	return nil
 }

--- a/pkg/protocol/protocol_test.go
+++ b/pkg/protocol/protocol_test.go
@@ -1,0 +1,37 @@
+package protocol
+
+import (
+	"bytes"
+	"testing"
+
+	pb "github.com/NicolasHaas/gospeak/pkg/protocol/pb"
+)
+
+type shortWriter struct {
+	bytes.Buffer
+	max int
+}
+
+func (w *shortWriter) Write(p []byte) (int, error) {
+	if len(p) > w.max {
+		p = p[:w.max]
+	}
+	return w.Buffer.Write(p)
+}
+
+func TestWriteControlMessageHandlesShortWrites(t *testing.T) {
+	want := &pb.ControlMessage{Ping: &pb.Ping{Timestamp: 42}}
+	writer := &shortWriter{max: 3}
+
+	if err := WriteControlMessage(writer, want); err != nil {
+		t.Fatalf("WriteControlMessage: %v", err)
+	}
+
+	got, err := ReadControlMessage(bytes.NewReader(writer.Bytes()))
+	if err != nil {
+		t.Fatalf("ReadControlMessage: %v", err)
+	}
+	if got.Ping == nil || got.Ping.Timestamp != want.Ping.Timestamp {
+		t.Fatalf("Ping mismatch: got %#v, want timestamp %d", got.Ping, want.Ping.Timestamp)
+	}
+}

--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -26,7 +26,7 @@ type ControlHandler struct {
 	server  *Server
 	store   datastore.DataProviderFactory
 	mu      sync.RWMutex
-	connMap map[uint32]net.Conn // sessionID -> TLS conn for sending events
+	connMap map[uint32]*controlClient // sessionID -> serialized outbound connection
 
 	// Rate limiting for temp sub-channel creation: userID -> last creation time
 	tempChanMu    sync.Mutex
@@ -38,7 +38,117 @@ const (
 	screenShareIdleSweep   = 5 * time.Second
 	authRateLimitAttempts  = 30
 	authRateLimitWindow    = 1 * time.Minute
+	controlWriteTimeout    = 5 * time.Second
+	controlSendQueueSize   = 64
 )
+
+var (
+	errControlClientClosed = errors.New("control client closed")
+	errControlQueueFull    = errors.New("control client send queue full")
+)
+
+type queuedControlMessage struct {
+	message *pb.ControlMessage
+	result  chan error
+}
+
+type controlClient struct {
+	net.Conn
+	sessionID uint32
+	sendQueue chan queuedControlMessage
+	done      chan struct{}
+	mu        sync.Mutex
+	closed    bool
+}
+
+func newControlClient(sessionID uint32, conn net.Conn) *controlClient {
+	client := &controlClient{
+		Conn:      conn,
+		sessionID: sessionID,
+		sendQueue: make(chan queuedControlMessage, controlSendQueueSize),
+		done:      make(chan struct{}),
+	}
+	go client.writeLoop()
+	return client
+}
+
+func (c *controlClient) send(msg *pb.ControlMessage) error {
+	return c.enqueue(queuedControlMessage{message: msg})
+}
+
+func (c *controlClient) sendAndClose(msg *pb.ControlMessage) {
+	result := make(chan error, 1)
+	if err := c.enqueue(queuedControlMessage{message: msg, result: result}); err == nil {
+		select {
+		case <-result:
+		case <-time.After(controlWriteTimeout):
+		}
+	}
+	_ = c.Close()
+}
+
+func (c *controlClient) enqueue(item queuedControlMessage) error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return errControlClientClosed
+	}
+	select {
+	case c.sendQueue <- item:
+		c.mu.Unlock()
+		return nil
+	default:
+		c.mu.Unlock()
+		_ = c.Close()
+		return errControlQueueFull
+	}
+}
+
+func (c *controlClient) writeLoop() {
+	for {
+		select {
+		case <-c.done:
+			return
+		case item := <-c.sendQueue:
+			err := c.SetWriteDeadline(time.Now().Add(controlWriteTimeout))
+			if err == nil {
+				err = protocol.WriteControlMessage(c.Conn, item.message)
+			}
+			_ = c.SetWriteDeadline(time.Time{})
+			if item.result != nil {
+				item.result <- err
+			}
+			if err != nil {
+				slog.Error("control write failed", "session", c.sessionID, "err", err)
+				_ = c.Close()
+				return
+			}
+		}
+	}
+}
+
+func (c *controlClient) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	close(c.done)
+	c.mu.Unlock()
+	return c.Conn.Close()
+}
+
+func writeControlMessage(conn net.Conn, msg *pb.ControlMessage) error {
+	if client, ok := conn.(*controlClient); ok {
+		return client.send(msg)
+	}
+	if err := conn.SetWriteDeadline(time.Now().Add(controlWriteTimeout)); err != nil {
+		return fmt.Errorf("set control write deadline: %w", err)
+	}
+	defer func() { _ = conn.SetWriteDeadline(time.Time{}) }()
+	return protocol.WriteControlMessage(conn, msg)
+}
 
 // authRateLimiter limits authentication attempts per remote address.
 type authRateLimiter struct {
@@ -84,33 +194,43 @@ func newControlHandler(srv *Server, st datastore.DataProviderFactory) *ControlHa
 	return &ControlHandler{
 		server:        srv,
 		store:         st,
-		connMap:       make(map[uint32]net.Conn),
+		connMap:       make(map[uint32]*controlClient),
 		tempChanTimes: make(map[int64]time.Time),
 	}
 }
 
-// setConn registers a TLS connection for a session (for sending events).
-func (ch *ControlHandler) setConn(sessionID uint32, conn net.Conn) {
+// setConn registers a connection with a dedicated serialized writer.
+func (ch *ControlHandler) setConn(sessionID uint32, conn net.Conn) *controlClient {
+	client := newControlClient(sessionID, conn)
 	ch.mu.Lock()
-	ch.connMap[sessionID] = conn
+	previous := ch.connMap[sessionID]
+	ch.connMap[sessionID] = client
 	ch.mu.Unlock()
+	if previous != nil {
+		_ = previous.Close()
+	}
+	return client
 }
 
-// removeConn removes a session's connection.
+// removeConn removes and closes a session's connection.
 func (ch *ControlHandler) removeConn(sessionID uint32) {
 	ch.mu.Lock()
+	client := ch.connMap[sessionID]
 	delete(ch.connMap, sessionID)
 	ch.mu.Unlock()
+	if client != nil {
+		_ = client.Close()
+	}
 }
 
 func (ch *ControlHandler) sendToSession(sessionID uint32, msg *pb.ControlMessage) bool {
 	ch.mu.RLock()
-	conn, ok := ch.connMap[sessionID]
+	client, ok := ch.connMap[sessionID]
 	ch.mu.RUnlock()
 	if !ok {
 		return false
 	}
-	if err := protocol.WriteControlMessage(conn, msg); err != nil {
+	if err := client.send(msg); err != nil {
 		slog.Error("direct write failed", "session", sessionID, "err", err)
 		return false
 	}
@@ -120,16 +240,20 @@ func (ch *ControlHandler) sendToSession(sessionID uint32, msg *pb.ControlMessage
 // broadcastToChannel sends a control message to all sessions in a channel.
 func (ch *ControlHandler) broadcastToChannel(channelID int64, msg *pb.ControlMessage, excludeSession uint32) {
 	members := ch.server.channels.Members(channelID)
+	clients := make(map[uint32]*controlClient, len(members))
 	ch.mu.RLock()
-	defer ch.mu.RUnlock()
 	for _, sid := range members {
-		if sid == excludeSession {
-			continue
-		}
-		if conn, ok := ch.connMap[sid]; ok {
-			if err := protocol.WriteControlMessage(conn, msg); err != nil {
-				slog.Error("broadcast write failed", "session", sid, "err", err)
+		if sid != excludeSession {
+			if client, ok := ch.connMap[sid]; ok {
+				clients[sid] = client
 			}
+		}
+	}
+	ch.mu.RUnlock()
+
+	for sid, client := range clients {
+		if err := client.send(msg); err != nil {
+			slog.Error("broadcast write failed", "session", sid, "err", err)
 		}
 	}
 }
@@ -346,7 +470,6 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 	session := s.sessions.Create(user.ID, user.Username, sessionRole)
 	sessionID := session.ID
 
-	handler.setConn(sessionID, conn)
 	defer func() {
 		stopEvent, stopped := s.screenShare.StopBySession(sessionID)
 		// Cleanup on disconnect
@@ -401,10 +524,11 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 			AutoToken:          autoToken,
 		},
 	}
-	if err := protocol.WriteControlMessage(conn, authResp); err != nil {
+	if err := writeControlMessage(conn, authResp); err != nil {
 		slog.Error("auth response write failed", "err", err)
 		return
 	}
+	conn = handler.setConn(sessionID, conn)
 
 	slog.Info("client authenticated", "user", user.Username, "role", sessionRole, "session", sessionID)
 	s.metrics.SuccessfulAuths.Add(1)
@@ -488,7 +612,7 @@ func (s *Server) handleMessage(handler *ControlHandler, sessionID uint32, msg *p
 		s.handleImportChannels(sessionID, msg.ImportChannelsReq, st, conn, handler)
 
 	case msg.Ping != nil:
-		_ = protocol.WriteControlMessage(conn, &pb.ControlMessage{
+		_ = writeControlMessage(conn, &pb.ControlMessage{
 			Pong: &pb.Pong{Timestamp: msg.Ping.Timestamp},
 		})
 	}
@@ -596,7 +720,7 @@ func (s *Server) handleLeaveChannel(handler *ControlHandler, sessionID uint32, s
 func (s *Server) handleChannelList(st datastore.DataProviderFactory, conn net.Conn) {
 	channels, _ := st.NonTx().ListChannels()
 	infos := s.buildChannelInfos(channels)
-	_ = protocol.WriteControlMessage(conn, &pb.ControlMessage{
+	_ = writeControlMessage(conn, &pb.ControlMessage{
 		ChannelListResponse: &pb.ChannelListResponse{Channels: infos},
 	})
 }
@@ -739,7 +863,7 @@ func (s *Server) handleCreateToken(sessionID uint32, req *pb.CreateTokenRequest,
 	slog.Info("token created", "role", role, "by", session.Username)
 	s.metrics.TokensCreated.Add(1)
 
-	_ = protocol.WriteControlMessage(conn, &pb.ControlMessage{
+	_ = writeControlMessage(conn, &pb.ControlMessage{
 		CreateTokenResp: &pb.CreateTokenResponse{Token: rawToken},
 	})
 }
@@ -771,8 +895,9 @@ func (s *Server) handleKickUser(handler *ControlHandler, sessionID uint32, req *
 	targetConn, ok := handler.connMap[target.ID]
 	handler.mu.RUnlock()
 	if ok {
-		sendError(targetConn, 99, "you have been kicked: "+reason)
-		_ = targetConn.Close()
+		targetConn.sendAndClose(&pb.ControlMessage{
+			ErrorResponse: &pb.ErrorResponse{Code: 99, Message: "you have been kicked: " + reason},
+		})
 	}
 
 	slog.Info("user kicked", "target", target.Username, "by", session.Username, "reason", reason)
@@ -811,8 +936,9 @@ func (s *Server) handleBanUser(handler *ControlHandler, sessionID uint32, req *p
 		targetConn, ok := handler.connMap[target.ID]
 		handler.mu.RUnlock()
 		if ok {
-			sendError(targetConn, 99, "you have been banned: "+reason)
-			_ = targetConn.Close()
+			targetConn.sendAndClose(&pb.ControlMessage{
+				ErrorResponse: &pb.ErrorResponse{Code: 99, Message: "you have been banned: " + reason},
+			})
 		}
 	}
 
@@ -906,7 +1032,7 @@ func (s *Server) handleSetUserRole(handler *ControlHandler, sessionID uint32, re
 
 	slog.Info("user role changed", "target_user", req.TargetUserID, "new_role", newRole, "by", session.Username)
 
-	_ = protocol.WriteControlMessage(conn, &pb.ControlMessage{
+	_ = writeControlMessage(conn, &pb.ControlMessage{
 		SetUserRoleResp: &pb.SetUserRoleResponse{Success: true, Message: "role updated"},
 	})
 
@@ -918,7 +1044,7 @@ func (s *Server) handleSetUserRole(handler *ControlHandler, sessionID uint32, re
 func (s *Server) sendServerState(st datastore.DataProviderFactory, conn net.Conn) {
 	channels, _ := st.NonTx().ListChannels()
 	infos := s.buildChannelInfos(channels)
-	_ = protocol.WriteControlMessage(conn, &pb.ControlMessage{
+	_ = writeControlMessage(conn, &pb.ControlMessage{
 		ServerStateEvent: &pb.ServerStateEvent{Channels: infos, ScreenShareEnabled: s.cfg.EnableScreenShare},
 	})
 }
@@ -931,10 +1057,14 @@ func (s *Server) broadcastServerState(st datastore.DataProviderFactory, handler 
 		ServerStateEvent: &pb.ServerStateEvent{Channels: infos, ScreenShareEnabled: s.cfg.EnableScreenShare},
 	}
 	handler.mu.RLock()
-	for _, conn := range handler.connMap {
-		_ = protocol.WriteControlMessage(conn, msg)
+	clients := make([]*controlClient, 0, len(handler.connMap))
+	for _, client := range handler.connMap {
+		clients = append(clients, client)
 	}
 	handler.mu.RUnlock()
+	for _, client := range clients {
+		_ = client.send(msg)
+	}
 }
 
 // buildChannelInfos converts model channels to protocol channel infos.
@@ -981,7 +1111,7 @@ func (s *Server) cleanupTempChannel(channelID int64, st datastore.DataProviderFa
 }
 
 func sendError(conn net.Conn, code int32, message string) {
-	_ = protocol.WriteControlMessage(conn, &pb.ControlMessage{
+	_ = writeControlMessage(conn, &pb.ControlMessage{
 		ErrorResponse: &pb.ErrorResponse{Code: code, Message: message},
 	})
 }
@@ -1041,7 +1171,7 @@ func (s *Server) handleExportData(sessionID uint32, req *pb.ExportDataRequest, s
 		return
 	}
 
-	_ = protocol.WriteControlMessage(conn, &pb.ControlMessage{
+	_ = writeControlMessage(conn, &pb.ControlMessage{
 		ExportDataResp: &pb.ExportDataResponse{
 			Type: req.Type,
 			Data: string(data),
@@ -1061,7 +1191,7 @@ func (s *Server) handleImportChannels(sessionID uint32, req *pb.ImportChannelsRe
 	}
 
 	if err := ImportChannelsFromYAML([]byte(req.YAML), st); err != nil {
-		_ = protocol.WriteControlMessage(conn, &pb.ControlMessage{
+		_ = writeControlMessage(conn, &pb.ControlMessage{
 			ImportChannelsResp: &pb.ImportChannelsResponse{
 				Success: false,
 				Message: "import failed: " + err.Error(),
@@ -1072,7 +1202,7 @@ func (s *Server) handleImportChannels(sessionID uint32, req *pb.ImportChannelsRe
 
 	slog.Info("channels imported via UI", "by", session.Username)
 
-	_ = protocol.WriteControlMessage(conn, &pb.ControlMessage{
+	_ = writeControlMessage(conn, &pb.ControlMessage{
 		ImportChannelsResp: &pb.ImportChannelsResponse{
 			Success: true,
 			Message: "channels imported successfully",

--- a/pkg/server/control_writer_test.go
+++ b/pkg/server/control_writer_test.go
@@ -1,0 +1,190 @@
+package server
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/NicolasHaas/gospeak/pkg/protocol"
+	pb "github.com/NicolasHaas/gospeak/pkg/protocol/pb"
+)
+
+type blockingWriteConn struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+
+	active       atomic.Int32
+	firstWrite   sync.Once
+	firstEntered chan struct{}
+	releaseFirst chan struct{}
+	concurrent   chan struct{}
+	concurrentMu sync.Once
+	closed       chan struct{}
+	closeOnce    sync.Once
+}
+
+func newBlockingWriteConn() *blockingWriteConn {
+	return &blockingWriteConn{
+		firstEntered: make(chan struct{}),
+		releaseFirst: make(chan struct{}),
+		concurrent:   make(chan struct{}),
+		closed:       make(chan struct{}),
+	}
+}
+
+func (c *blockingWriteConn) Read(_ []byte) (int, error) { return 0, io.EOF }
+
+func (c *blockingWriteConn) Write(p []byte) (int, error) {
+	if c.active.Add(1) > 1 {
+		c.concurrentMu.Do(func() { close(c.concurrent) })
+	}
+	defer c.active.Add(-1)
+
+	blocked := false
+	c.firstWrite.Do(func() {
+		blocked = true
+		close(c.firstEntered)
+	})
+	if blocked {
+		<-c.releaseFirst
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.Write(p)
+}
+
+func (c *blockingWriteConn) Close() error {
+	c.closeOnce.Do(func() { close(c.closed) })
+	return nil
+}
+func (c *blockingWriteConn) LocalAddr() net.Addr                { return &net.IPAddr{} }
+func (c *blockingWriteConn) RemoteAddr() net.Addr               { return &net.IPAddr{} }
+func (c *blockingWriteConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *blockingWriteConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *blockingWriteConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+func (c *blockingWriteConn) bytes() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return bytes.Clone(c.buf.Bytes())
+}
+
+func TestControlHandlerSerializesConcurrentWrites(t *testing.T) {
+	_, _, handler := newTestServer(t)
+	conn := newBlockingWriteConn()
+	handler.setConn(1, conn)
+	defer handler.removeConn(1)
+
+	messages := []*pb.ControlMessage{
+		{Ping: &pb.Ping{Timestamp: 1}},
+		{Ping: &pb.Ping{Timestamp: 2}},
+	}
+
+	var wg sync.WaitGroup
+	for _, msg := range messages {
+		wg.Add(1)
+		go func(msg *pb.ControlMessage) {
+			defer wg.Done()
+			if !handler.sendToSession(1, msg) {
+				t.Errorf("sendToSession returned false")
+			}
+		}(msg)
+		<-conn.firstEntered
+	}
+
+	select {
+	case <-conn.concurrent:
+		close(conn.releaseFirst)
+		wg.Wait()
+		t.Fatal("control connection received concurrent Write calls")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(conn.releaseFirst)
+	wg.Wait()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		reader := bytes.NewReader(conn.bytes())
+		first, firstErr := protocol.ReadControlMessage(reader)
+		second, secondErr := protocol.ReadControlMessage(reader)
+		if firstErr == nil && secondErr == nil {
+			if first.Ping == nil || second.Ping == nil {
+				t.Fatalf("unexpected messages: %#v %#v", first, second)
+			}
+			got := map[int64]bool{first.Ping.Timestamp: true, second.Ping.Timestamp: true}
+			if !got[1] || !got[2] {
+				t.Fatalf("timestamps = %v, want 1 and 2", got)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("two valid control frames not written: first=%v second=%v bytes=%d", firstErr, secondErr, len(conn.bytes()))
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestControlClientClosesWhenSendQueueIsFull(t *testing.T) {
+	_, _, handler := newTestServer(t)
+	conn := newBlockingWriteConn()
+	handler.setConn(1, conn)
+	defer close(conn.releaseFirst)
+
+	if !handler.sendToSession(1, &pb.ControlMessage{Ping: &pb.Ping{Timestamp: 1}}) {
+		t.Fatal("initial send failed")
+	}
+	<-conn.firstEntered
+
+	for i := 0; i < controlSendQueueSize; i++ {
+		if !handler.sendToSession(1, &pb.ControlMessage{Ping: &pb.Ping{Timestamp: int64(i + 2)}}) {
+			t.Fatalf("queue rejected message %d before reaching capacity", i)
+		}
+	}
+	if handler.sendToSession(1, &pb.ControlMessage{Ping: &pb.Ping{Timestamp: 999}}) {
+		t.Fatal("send succeeded after queue reached capacity")
+	}
+
+	select {
+	case <-conn.closed:
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("slow control connection was not closed after queue overflow")
+	}
+}
+
+func TestBroadcastDoesNotHoldConnectionMapLockDuringWrite(t *testing.T) {
+	srv, _, handler := newTestServer(t)
+	slow := newBlockingWriteConn()
+	handler.setConn(1, slow)
+	defer handler.removeConn(1)
+	srv.channels.Join(1, 7)
+
+	done := make(chan struct{})
+	go func() {
+		handler.broadcastToChannel(7, &pb.ControlMessage{Ping: &pb.Ping{Timestamp: 1}}, 0)
+		close(done)
+	}()
+	<-slow.firstEntered
+
+	registered := make(chan struct{})
+	go func() {
+		handler.setConn(2, &nopConn{})
+		close(registered)
+	}()
+
+	select {
+	case <-registered:
+	case <-time.After(50 * time.Millisecond):
+		close(slow.releaseFirst)
+		t.Fatal("setConn blocked behind a slow control write")
+	}
+
+	close(slow.releaseFirst)
+	<-done
+	handler.removeConn(2)
+}


### PR DESCRIPTION
## Summary

This PR makes control-message writes safe under concurrent writes and slow clients.

- writes the length prefix and payload as a single frame
- handles short writes correctly
- serializes outbound messages per control connection
- uses a bounded send queue with a write timeout
- disconnects slow clients when their queue overflows
- performs network I/O outside the global connection-map lock
- ensures kick and ban notifications are written before disconnecting

## Tests

- added regression tests for short writes
- added concurrent control-write coverage
- added slow-client queue-overflow coverage