### PR TITLE
fix: bound unauthenticated connections and rate limits

### DIFF
--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -34,12 +34,13 @@ type ControlHandler struct {
 }
 
 const (
-	screenShareIdleTimeout = 15 * time.Second
-	screenShareIdleSweep   = 5 * time.Second
-	authRateLimitAttempts  = 30
-	authRateLimitWindow    = 1 * time.Minute
-	controlWriteTimeout    = 5 * time.Second
-	controlSendQueueSize   = 64
+	screenShareIdleTimeout  = 15 * time.Second
+	screenShareIdleSweep    = 5 * time.Second
+	authRateLimitAttempts   = 30
+	authRateLimitWindow     = 1 * time.Minute
+	authRateLimitMaxEntries = 4096
+	controlWriteTimeout     = 5 * time.Second
+	controlSendQueueSize    = 64
 )
 
 var (
@@ -150,17 +151,20 @@ func writeControlMessage(conn net.Conn, msg *pb.ControlMessage) error {
 	return protocol.WriteControlMessage(conn, msg)
 }
 
-// authRateLimiter limits authentication attempts per remote address.
+// authRateLimiter limits failed authentication attempts per remote IP.
 type authRateLimiter struct {
 	mu          sync.Mutex
 	entries     map[string]*authEntry
 	maxAttempts int
 	window      time.Duration
+	maxEntries  int
+	now         func() time.Time
 }
 
 type authEntry struct {
-	count   int
-	resetAt time.Time
+	count    int
+	inFlight int
+	resetAt  time.Time
 }
 
 func newAuthRateLimiter(maxAttempts int, window time.Duration) *authRateLimiter {
@@ -168,6 +172,8 @@ func newAuthRateLimiter(maxAttempts int, window time.Duration) *authRateLimiter 
 		entries:     make(map[string]*authEntry),
 		maxAttempts: maxAttempts,
 		window:      window,
+		maxEntries:  authRateLimitMaxEntries,
+		now:         time.Now,
 	}
 }
 
@@ -175,18 +181,60 @@ func (rl *authRateLimiter) Allow(key string) bool {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	now := time.Now()
+	now := rl.now()
 	entry, ok := rl.entries[key]
-	if !ok || now.After(entry.resetAt) {
-		rl.entries[key] = &authEntry{
-			count:   1,
-			resetAt: now.Add(rl.window),
-		}
-		return true
+	if ok && !now.Before(entry.resetAt) {
+		delete(rl.entries, key)
+		entry = nil
+		ok = false
 	}
+	if !ok {
+		if len(rl.entries) >= rl.maxEntries {
+			for entryKey, candidate := range rl.entries {
+				if !now.Before(candidate.resetAt) {
+					delete(rl.entries, entryKey)
+				}
+			}
+			if len(rl.entries) >= rl.maxEntries {
+				return false
+			}
+		}
+		entry = &authEntry{resetAt: now.Add(rl.window)}
+		rl.entries[key] = entry
+	}
+	if entry.count+entry.inFlight >= rl.maxAttempts {
+		return false
+	}
+	entry.inFlight++
+	return true
+}
 
-	entry.count++
-	return entry.count <= rl.maxAttempts
+func (rl *authRateLimiter) RecordFailure(key string) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	if entry, ok := rl.entries[key]; ok {
+		if entry.inFlight > 0 {
+			entry.inFlight--
+		}
+		entry.count++
+	}
+}
+
+func (rl *authRateLimiter) Reset(key string) {
+	rl.mu.Lock()
+	delete(rl.entries, key)
+	rl.mu.Unlock()
+}
+
+func authRateLimitKey(addr net.Addr) string {
+	if tcpAddr, ok := addr.(*net.TCPAddr); ok {
+		return tcpAddr.IP.String()
+	}
+	host, _, err := net.SplitHostPort(addr.String())
+	if err == nil {
+		return host
+	}
+	return addr.String()
 }
 
 // newControlHandler creates a control handler.
@@ -294,6 +342,11 @@ func (s *Server) StartControl(st datastore.DataProviderFactory) error {
 					continue
 				}
 			}
+			if !s.beginPreAuth(conn, preAuthControl) {
+				slog.Warn("control pre-auth connection limit reached", "remote", conn.RemoteAddr())
+				_ = conn.Close()
+				continue
+			}
 			go s.handleControlConn(handler, conn, st)
 		}
 	}()
@@ -336,20 +389,31 @@ func (s *Server) runScreenShareJanitor(handler *ControlHandler) {
 // handleControlConn handles a single control connection lifecycle.
 func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st datastore.DataProviderFactory) {
 	defer func() { _ = conn.Close() }()
+	if !s.beginPreAuth(conn, preAuthControl) {
+		return
+	}
+	defer s.forgetAcceptedConn(conn)
 
 	remoteAddr := conn.RemoteAddr().String()
+	rateLimitKey := authRateLimitKey(conn.RemoteAddr())
 	s.metrics.TotalConnections.Add(1)
 	s.metrics.ActiveConnections.Add(1)
 	slog.Debug("new control connection", "remote", remoteAddr)
 
-	// Rate limit per remote address
-	if !s.authLimiter.Allow(remoteAddr) {
+	// Rate limit failed authentication attempts per remote IP.
+	if !s.authLimiter.Allow(rateLimitKey) {
 		slog.Warn("rate limited", "remote", remoteAddr)
 		return
 	}
+	authenticated := false
+	defer func() {
+		if !authenticated {
+			s.authLimiter.RecordFailure(rateLimitKey)
+		}
+	}()
 
-	// First message must be AuthRequest
-	_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	// First message must be AuthRequest.
+	_ = conn.SetReadDeadline(time.Now().Add(s.cfg.PreAuthTimeout))
 	msg, err := protocol.ReadControlMessage(conn)
 	if err != nil {
 		slog.Error("auth read failed", "remote", remoteAddr, "err", err)
@@ -528,6 +592,9 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 		slog.Error("auth response write failed", "err", err)
 		return
 	}
+	authenticated = true
+	s.authLimiter.Reset(rateLimitKey)
+	s.finishPreAuth(conn)
 	conn = handler.setConn(sessionID, conn)
 
 	slog.Info("client authenticated", "user", user.Username, "role", sessionRole, "session", sessionID)

--- a/pkg/server/preauth_test.go
+++ b/pkg/server/preauth_test.go
@@ -1,0 +1,153 @@
+package server
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+type testAddr string
+
+func (a testAddr) Network() string { return "tcp" }
+func (a testAddr) String() string  { return string(a) }
+
+func TestAuthRateLimiterNormalizesSourcePorts(t *testing.T) {
+	limiter := newAuthRateLimiter(2, time.Minute)
+	first := authRateLimitKey(testAddr("192.0.2.10:41000"))
+	second := authRateLimitKey(testAddr("192.0.2.10:41001"))
+
+	if first != second {
+		t.Fatalf("rate limit keys differ by source port: %q != %q", first, second)
+	}
+	for i := 0; i < 2; i++ {
+		if !limiter.Allow(first) {
+			t.Fatalf("Allow attempt %d = false, want true", i+1)
+		}
+		limiter.RecordFailure(first)
+	}
+	if limiter.Allow(second) {
+		t.Fatal("Allow after two failures from the same IP = true, want false")
+	}
+}
+
+func TestAuthRateLimiterPrunesExpiredEntriesAndStaysBounded(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	limiter := newAuthRateLimiter(3, time.Minute)
+	limiter.maxEntries = 2
+	limiter.now = func() time.Time { return now }
+
+	for _, key := range []string{"192.0.2.1", "192.0.2.2"} {
+		if !limiter.Allow(key) {
+			t.Fatalf("Allow(%q) = false, want true", key)
+		}
+		limiter.RecordFailure(key)
+	}
+	if limiter.Allow("192.0.2.3") {
+		t.Fatal("Allow at entry capacity = true, want false")
+	}
+	if got := len(limiter.entries); got != 2 {
+		t.Fatalf("entry count = %d, want 2", got)
+	}
+
+	now = now.Add(time.Minute + time.Nanosecond)
+	if !limiter.Allow("192.0.2.3") {
+		t.Fatal("Allow after entries expired = false, want true")
+	}
+	if got := len(limiter.entries); got != 1 {
+		t.Fatalf("entry count after prune = %d, want 1", got)
+	}
+}
+
+func TestAuthRateLimiterClearsSuccessfulAuthentication(t *testing.T) {
+	limiter := newAuthRateLimiter(1, time.Minute)
+	const key = "192.0.2.10"
+
+	if !limiter.Allow(key) {
+		t.Fatal("initial Allow = false, want true")
+	}
+	limiter.RecordFailure(key)
+	if limiter.Allow(key) {
+		t.Fatal("Allow after failure = true, want false")
+	}
+
+	limiter.Reset(key)
+	if !limiter.Allow(key) {
+		t.Fatal("Allow after Reset = false, want true")
+	}
+}
+
+func TestSilentScreenConnectionTimesOut(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.PreAuthTimeout = 20 * time.Millisecond
+	srv := New(cfg, Dependencies{})
+	serverConn, clientConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+
+	done := make(chan struct{})
+	go func() {
+		srv.handleScreenConn(serverConn)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		_ = clientConn.Close()
+		<-done
+		t.Fatal("silent screen connection did not time out")
+	}
+}
+
+func TestPreAuthConnectionsAreBoundedAndClosedOnShutdown(t *testing.T) {
+	for _, plane := range []preAuthPlane{preAuthControl, preAuthScreen} {
+		t.Run(string(plane), func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.MaxPreAuthConnections = 1
+			srv := New(cfg, Dependencies{})
+			firstServer, firstClient := net.Pipe()
+			defer func() { _ = firstClient.Close() }()
+			secondServer, secondClient := net.Pipe()
+			defer func() { _ = secondServer.Close() }()
+			defer func() { _ = secondClient.Close() }()
+
+			if !srv.beginPreAuth(firstServer, plane) {
+				t.Fatal("first pre-auth connection rejected")
+			}
+			if srv.beginPreAuth(secondServer, plane) {
+				t.Fatal("second pre-auth connection accepted above configured limit")
+			}
+
+			srv.Shutdown()
+			_ = firstClient.SetReadDeadline(time.Now().Add(time.Second))
+			if _, err := firstClient.Read(make([]byte, 1)); err == nil {
+				t.Fatal("tracked pre-auth connection remained open after Shutdown")
+			}
+		})
+	}
+}
+
+func TestAuthenticatedConnectionReleasesPreAuthSlotAndClosesOnShutdown(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxPreAuthConnections = 1
+	srv := New(cfg, Dependencies{})
+	firstServer, firstClient := net.Pipe()
+	defer func() { _ = firstClient.Close() }()
+	secondServer, secondClient := net.Pipe()
+	defer func() { _ = secondClient.Close() }()
+
+	if !srv.beginPreAuth(firstServer, preAuthControl) {
+		t.Fatal("first pre-auth connection rejected")
+	}
+	srv.finishPreAuth(firstServer)
+	if !srv.beginPreAuth(secondServer, preAuthControl) {
+		t.Fatal("authenticated connection did not release its pre-auth slot")
+	}
+
+	srv.Shutdown()
+	for i, client := range []net.Conn{firstClient, secondClient} {
+		_ = client.SetReadDeadline(time.Now().Add(time.Second))
+		if _, err := client.Read(make([]byte, 1)); err == nil {
+			t.Fatalf("tracked connection %d remained open after Shutdown", i+1)
+		}
+	}
+}

--- a/pkg/server/run.go
+++ b/pkg/server/run.go
@@ -104,6 +104,7 @@ func (s *Server) Shutdown() {
 	if s.screenConn != nil {
 		_ = s.screenConn.Close()
 	}
+	s.closeAcceptedConns()
 	s.closeScreenConns()
 }
 

--- a/pkg/server/screen.go
+++ b/pkg/server/screen.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"time"
 
 	"github.com/NicolasHaas/gospeak/pkg/protocol"
 )
@@ -41,6 +42,11 @@ func (s *Server) StartScreen() error {
 					continue
 				}
 			}
+			if !s.beginPreAuth(conn, preAuthScreen) {
+				slog.Warn("screen pre-auth connection limit reached", "remote", conn.RemoteAddr())
+				_ = conn.Close()
+				continue
+			}
 			go s.handleScreenConn(conn)
 		}
 	}()
@@ -50,6 +56,14 @@ func (s *Server) StartScreen() error {
 
 func (s *Server) handleScreenConn(conn net.Conn) {
 	defer func() { _ = conn.Close() }()
+	if !s.beginPreAuth(conn, preAuthScreen) {
+		return
+	}
+	defer s.forgetAcceptedConn(conn)
+	if err := conn.SetDeadline(time.Now().Add(s.cfg.PreAuthTimeout)); err != nil {
+		slog.Error("set screen auth deadline", "err", err)
+		return
+	}
 
 	auth, err := protocol.ReadScreenAuth(conn)
 	if err != nil {
@@ -60,6 +74,11 @@ func (s *Server) handleScreenConn(conn net.Conn) {
 		slog.Warn("screen auth rejected", "session", auth.SessionID)
 		return
 	}
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		slog.Error("clear screen auth deadline", "session", auth.SessionID, "err", err)
+		return
+	}
+	s.finishPreAuth(conn)
 
 	s.setScreenConn(auth.SessionID, conn)
 	defer s.removeScreenConn(auth.SessionID, conn)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -25,17 +25,19 @@ import (
 
 // Config holds server configuration.
 type Config struct {
-	ControlAddr       string // TCP/TLS bind address (e.g. ":9600")
-	VoiceAddr         string // UDP bind address (e.g. ":9601")
-	ScreenAddr        string // TCP/TLS screen-share bind address (e.g. ":9603")
-	DBPath            string // SQLite database path
-	CertFile          string // TLS certificate file path
-	KeyFile           string // TLS private key file path
-	DataDir           string // directory for generated certs and data
-	AllowNoToken      bool   // allow users to join without a token (open server)
-	EnableScreenShare bool   // enable per-channel screen sharing support
-	ChannelsFile      string // YAML file defining channels to create on startup
-	MetricsAddr       string // HTTP bind address for /metrics endpoint (empty = disabled)
+	ControlAddr           string        // TCP/TLS bind address (e.g. ":9600")
+	VoiceAddr             string        // UDP bind address (e.g. ":9601")
+	ScreenAddr            string        // TCP/TLS screen-share bind address (e.g. ":9603")
+	DBPath                string        // SQLite database path
+	CertFile              string        // TLS certificate file path
+	KeyFile               string        // TLS private key file path
+	DataDir               string        // directory for generated certs and data
+	AllowNoToken          bool          // allow users to join without a token (open server)
+	EnableScreenShare     bool          // enable per-channel screen sharing support
+	ChannelsFile          string        // YAML file defining channels to create on startup
+	MetricsAddr           string        // HTTP bind address for /metrics endpoint (empty = disabled)
+	PreAuthTimeout        time.Duration // maximum TLS handshake and authentication time
+	MaxPreAuthConnections int           // maximum concurrent unauthenticated connections per TCP plane
 
 	// CLI-only actions (run and exit)
 	ExportUsers    bool // export all users as YAML and exit
@@ -51,12 +53,14 @@ type Dependencies struct {
 // DefaultConfig returns a config with sensible defaults.
 func DefaultConfig() Config {
 	return Config{
-		ControlAddr: ":9600",
-		VoiceAddr:   ":9601",
-		ScreenAddr:  ":9603",
-		MetricsAddr: ":9602",
-		DBPath:      "gospeak.db",
-		DataDir:     ".",
+		ControlAddr:           ":9600",
+		VoiceAddr:             ":9601",
+		ScreenAddr:            ":9603",
+		MetricsAddr:           ":9602",
+		DBPath:                "gospeak.db",
+		DataDir:               ".",
+		PreAuthTimeout:        10 * time.Second,
+		MaxPreAuthConnections: 64,
 	}
 }
 
@@ -140,19 +144,22 @@ func loadOrGenerateTLS(cfg Config) (tls.Certificate, error) {
 
 // Server is the main GoSpeak server.
 type Server struct {
-	cfg         Config
-	sessions    *SessionManager
-	channels    *ChannelManager
-	screenShare *ScreenShareManager
-	metrics     *Metrics
-	store       datastore.DataProviderFactory
-	controlConn net.Listener
-	voiceConn   *net.UDPConn
-	screenConn  net.Listener
-	screenMu    sync.RWMutex
-	screenConns map[uint32]net.Conn
-	voiceKey    []byte // shared AES-128 key for all voice encryption
-	authLimiter *authRateLimiter
+	cfg           Config
+	sessions      *SessionManager
+	channels      *ChannelManager
+	screenShare   *ScreenShareManager
+	metrics       *Metrics
+	store         datastore.DataProviderFactory
+	controlConn   net.Listener
+	voiceConn     *net.UDPConn
+	screenConn    net.Listener
+	screenMu      sync.RWMutex
+	screenConns   map[uint32]net.Conn
+	voiceKey      []byte // shared AES-128 key for all voice encryption
+	authLimiter   *authRateLimiter
+	preAuthMu     sync.Mutex
+	acceptedConns map[net.Conn]trackedConn
+	preAuthCount  map[preAuthPlane]int
 
 	// Per-session voice debug counters (reset each debug interval; only used when debug is enabled)
 	voiceDebugEnabled bool
@@ -165,19 +172,88 @@ type Server struct {
 
 // New creates a new Server instance.
 func New(cfg Config, deps Dependencies) *Server {
+	if cfg.PreAuthTimeout <= 0 {
+		cfg.PreAuthTimeout = 10 * time.Second
+	}
+	if cfg.MaxPreAuthConnections <= 0 {
+		cfg.MaxPreAuthConnections = 64
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Server{
-		cfg:         cfg,
-		sessions:    NewSessionManager(),
-		channels:    NewChannelManager(),
-		screenShare: NewScreenShareManager(),
-		metrics:     NewMetrics(),
-		screenConns: make(map[uint32]net.Conn),
-		voiceStats:  make(map[uint32]*perSessionVoiceStat),
-		store:       deps.Store,
-		authLimiter: newAuthRateLimiter(authRateLimitAttempts, authRateLimitWindow),
-		ctx:         ctx,
-		cancel:      cancel,
+		cfg:           cfg,
+		sessions:      NewSessionManager(),
+		channels:      NewChannelManager(),
+		screenShare:   NewScreenShareManager(),
+		metrics:       NewMetrics(),
+		screenConns:   make(map[uint32]net.Conn),
+		voiceStats:    make(map[uint32]*perSessionVoiceStat),
+		store:         deps.Store,
+		authLimiter:   newAuthRateLimiter(authRateLimitAttempts, authRateLimitWindow),
+		acceptedConns: make(map[net.Conn]trackedConn),
+		preAuthCount:  make(map[preAuthPlane]int),
+		ctx:           ctx,
+		cancel:        cancel,
+	}
+}
+
+type preAuthPlane string
+
+type trackedConn struct {
+	plane   preAuthPlane
+	preAuth bool
+}
+
+const (
+	preAuthControl preAuthPlane = "control"
+	preAuthScreen  preAuthPlane = "screen"
+)
+
+func (s *Server) beginPreAuth(conn net.Conn, plane preAuthPlane) bool {
+	s.preAuthMu.Lock()
+	defer s.preAuthMu.Unlock()
+	if _, ok := s.acceptedConns[conn]; ok {
+		return true
+	}
+	if s.ctx.Err() != nil || s.preAuthCount[plane] >= s.cfg.MaxPreAuthConnections {
+		return false
+	}
+	s.acceptedConns[conn] = trackedConn{plane: plane, preAuth: true}
+	s.preAuthCount[plane]++
+	return true
+}
+
+func (s *Server) finishPreAuth(conn net.Conn) {
+	s.preAuthMu.Lock()
+	if tracked, ok := s.acceptedConns[conn]; ok && tracked.preAuth {
+		tracked.preAuth = false
+		s.acceptedConns[conn] = tracked
+		s.preAuthCount[tracked.plane]--
+	}
+	s.preAuthMu.Unlock()
+}
+
+func (s *Server) forgetAcceptedConn(conn net.Conn) {
+	s.preAuthMu.Lock()
+	if tracked, ok := s.acceptedConns[conn]; ok {
+		delete(s.acceptedConns, conn)
+		if tracked.preAuth {
+			s.preAuthCount[tracked.plane]--
+		}
+	}
+	s.preAuthMu.Unlock()
+}
+
+func (s *Server) closeAcceptedConns() {
+	s.preAuthMu.Lock()
+	conns := make([]net.Conn, 0, len(s.acceptedConns))
+	for conn := range s.acceptedConns {
+		conns = append(conns, conn)
+	}
+	s.acceptedConns = make(map[net.Conn]trackedConn)
+	s.preAuthCount = make(map[preAuthPlane]int)
+	s.preAuthMu.Unlock()
+	for _, conn := range conns {
+		_ = conn.Close()
 	}
 }
 


### PR DESCRIPTION
## Summary

Hardens unauthenticated control and screen connections against resource-exhaustion attacks.

- limits concurrent pre-auth connections
- applies configurable pre-auth deadlines
- rate-limits failed authentication attempts by IP instead of source port
- bounds and cleans up rate-limit state
- closes pending connections during shutdown

## Tests

Added regression coverage for connection limits, timeouts, IP-based rate limiting, bounded limiter state, and shutdown cleanup.