### PR TITLE
fix: apply user moderation to every active session

### DIFF
--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -285,6 +285,21 @@ func (ch *ControlHandler) sendToSession(sessionID uint32, msg *pb.ControlMessage
 	return true
 }
 
+func (ch *ControlHandler) sendAndCloseSessions(sessions []SessionSnapshot, msg *pb.ControlMessage) {
+	clients := make([]*controlClient, 0, len(sessions))
+	ch.mu.RLock()
+	for _, session := range sessions {
+		if client, ok := ch.connMap[session.ID]; ok {
+			clients = append(clients, client)
+		}
+	}
+	ch.mu.RUnlock()
+
+	for _, client := range clients {
+		client.sendAndClose(msg)
+	}
+}
+
 // broadcastToChannel sends a control message to all sessions in a channel.
 func (ch *ControlHandler) broadcastToChannel(channelID int64, msg *pb.ControlMessage, excludeSession uint32) {
 	members := ch.server.channels.Members(channelID)
@@ -951,23 +966,18 @@ func (s *Server) handleKickUser(handler *ControlHandler, sessionID uint32, req *
 		reason = reason[:256]
 	}
 
-	target, ok := s.sessions.GetByUserIDSnapshot(req.UserID)
-	if !ok {
+	targets := s.sessions.GetAllByUserIDSnapshots(req.UserID)
+	if len(targets) == 0 {
 		sendError(conn, 32, "user not online")
 		return
 	}
 
-	// Close their connection (will trigger cleanup in handleControlConn)
-	handler.mu.RLock()
-	targetConn, ok := handler.connMap[target.ID]
-	handler.mu.RUnlock()
-	if ok {
-		targetConn.sendAndClose(&pb.ControlMessage{
-			ErrorResponse: &pb.ErrorResponse{Code: 99, Message: "you have been kicked: " + reason},
-		})
-	}
+	// Close every connection for the user (each handleControlConn cleans up its session).
+	handler.sendAndCloseSessions(targets, &pb.ControlMessage{
+		ErrorResponse: &pb.ErrorResponse{Code: 99, Message: "you have been kicked: " + reason},
+	})
 
-	slog.Info("user kicked", "target", target.Username, "by", session.Username, "reason", reason)
+	slog.Info("user kicked", "target", targets[0].Username, "sessions", len(targets), "by", session.Username, "reason", reason)
 	s.metrics.KickCount.Add(1)
 }
 
@@ -997,17 +1007,11 @@ func (s *Server) handleBanUser(handler *ControlHandler, sessionID uint32, req *p
 		return
 	}
 
-	// Also kick them if online
-	if target, ok := s.sessions.GetByUserIDSnapshot(req.UserID); ok {
-		handler.mu.RLock()
-		targetConn, ok := handler.connMap[target.ID]
-		handler.mu.RUnlock()
-		if ok {
-			targetConn.sendAndClose(&pb.ControlMessage{
-				ErrorResponse: &pb.ErrorResponse{Code: 99, Message: "you have been banned: " + reason},
-			})
-		}
-	}
+	// Also kick every active session for the banned user.
+	targets := s.sessions.GetAllByUserIDSnapshots(req.UserID)
+	handler.sendAndCloseSessions(targets, &pb.ControlMessage{
+		ErrorResponse: &pb.ErrorResponse{Code: 99, Message: "you have been banned: " + reason},
+	})
 
 	slog.Info("user banned", "user_id", req.UserID, "by", session.Username)
 	s.metrics.BanCount.Add(1)
@@ -1092,10 +1096,8 @@ func (s *Server) handleSetUserRole(handler *ControlHandler, sessionID uint32, re
 		return
 	}
 
-	// Update the session if the target user is online
-	if target, ok := s.sessions.GetByUserIDSnapshot(req.TargetUserID); ok {
-		s.sessions.UpdateRole(target.ID, newRole)
-	}
+	// Apply revocation immediately to every active session for the user.
+	s.sessions.UpdateRoleByUserID(req.TargetUserID, newRole)
 
 	slog.Info("user role changed", "target_user", req.TargetUserID, "new_role", newRole, "by", session.Username)
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,13 +1,17 @@
 package server
 
 import (
+	"bytes"
 	"io"
 	"net"
+	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/NicolasHaas/gospeak/pkg/datastore"
 	"github.com/NicolasHaas/gospeak/pkg/model"
+	"github.com/NicolasHaas/gospeak/pkg/protocol"
 	pb "github.com/NicolasHaas/gospeak/pkg/protocol/pb"
 )
 
@@ -22,9 +26,33 @@ func (c *nopConn) SetDeadline(_ time.Time) error      { return nil }
 func (c *nopConn) SetReadDeadline(_ time.Time) error  { return nil }
 func (c *nopConn) SetWriteDeadline(_ time.Time) error { return nil }
 
+type closeTrackingConn struct {
+	nopConn
+	once   sync.Once
+	closed chan struct{}
+}
+
+type bufferConn struct {
+	nopConn
+	buffer bytes.Buffer
+}
+
+func (c *bufferConn) Read(p []byte) (int, error)  { return c.buffer.Read(p) }
+func (c *bufferConn) Write(p []byte) (int, error) { return c.buffer.Write(p) }
+
+func newCloseTrackingConn() *closeTrackingConn {
+	return &closeTrackingConn{closed: make(chan struct{})}
+}
+
+func (c *closeTrackingConn) Close() error {
+	c.once.Do(func() { close(c.closed) })
+	return nil
+}
+
 func newTestServer(t *testing.T) (*Server, datastore.DataProviderFactory, *ControlHandler) {
 	t.Helper()
 	cfg := DefaultConfig()
+	cfg.DBPath = filepath.Join(t.TempDir(), "gospeak.db")
 	st, err := datastore.NewProviderFactory(cfg.DBPath)
 	if err != nil {
 		t.Fatalf("Could not start datastore: %v", err)
@@ -32,6 +60,21 @@ func newTestServer(t *testing.T) (*Server, datastore.DataProviderFactory, *Contr
 	srv := New(cfg, Dependencies{Store: st})
 	handler := newControlHandler(srv, st)
 	return srv, st, handler
+}
+
+func registerTestConn(handler *ControlHandler, sessionID uint32) *closeTrackingConn {
+	conn := newCloseTrackingConn()
+	handler.setConn(sessionID, conn)
+	return conn
+}
+
+func requireClosed(t *testing.T, conn *closeTrackingConn) {
+	t.Helper()
+	select {
+	case <-conn.closed:
+	case <-time.After(time.Second):
+		t.Fatal("connection was not closed")
+	}
 }
 
 func TestHandleJoinLeaveChannel(t *testing.T) {
@@ -87,5 +130,78 @@ func TestHandleUserState(t *testing.T) {
 	}
 	if !snap.Muted || !snap.Deafened {
 		t.Fatalf("HandleUserState: expected muted/deafened true, got muted=%t deafened=%t", snap.Muted, snap.Deafened)
+	}
+}
+
+func TestHandleKickUserClosesEverySession(t *testing.T) {
+	srv, _, handler := newTestServer(t)
+	admin := srv.sessions.Create(1, "admin", model.RoleAdmin)
+	targetOne := srv.sessions.Create(2, "target", model.RoleUser)
+	targetTwo := srv.sessions.Create(2, "target", model.RoleUser)
+	connOne := registerTestConn(handler, targetOne.ID)
+	connTwo := registerTestConn(handler, targetTwo.ID)
+
+	srv.handleKickUser(handler, admin.ID, &pb.KickUserRequest{UserID: 2, Reason: "test"}, &nopConn{})
+
+	requireClosed(t, connOne)
+	requireClosed(t, connTwo)
+}
+
+func TestHandleBanUserClosesEverySession(t *testing.T) {
+	srv, st, handler := newTestServer(t)
+	adminUser, err := st.NonTx().CreateUser("admin", model.RoleAdmin)
+	if err != nil {
+		t.Fatalf("CreateUser(admin): %v", err)
+	}
+	targetUser, err := st.NonTx().CreateUser("target", model.RoleUser)
+	if err != nil {
+		t.Fatalf("CreateUser(target): %v", err)
+	}
+	admin := srv.sessions.Create(adminUser.ID, adminUser.Username, adminUser.Role)
+	targetOne := srv.sessions.Create(targetUser.ID, targetUser.Username, targetUser.Role)
+	targetTwo := srv.sessions.Create(targetUser.ID, targetUser.Username, targetUser.Role)
+	connOne := registerTestConn(handler, targetOne.ID)
+	connTwo := registerTestConn(handler, targetTwo.ID)
+
+	srv.handleBanUser(handler, admin.ID, &pb.BanUserRequest{UserID: targetUser.ID, Reason: "test"}, st, &nopConn{})
+
+	requireClosed(t, connOne)
+	requireClosed(t, connTwo)
+}
+
+func TestHandleSetUserRoleUpdatesEverySession(t *testing.T) {
+	srv, st, handler := newTestServer(t)
+	adminUser, err := st.NonTx().CreateUser("admin", model.RoleAdmin)
+	if err != nil {
+		t.Fatalf("CreateUser(admin): %v", err)
+	}
+	targetUser, err := st.NonTx().CreateUser("target", model.RoleAdmin)
+	if err != nil {
+		t.Fatalf("CreateUser(target): %v", err)
+	}
+	admin := srv.sessions.Create(adminUser.ID, adminUser.Username, adminUser.Role)
+	targetOne := srv.sessions.Create(targetUser.ID, targetUser.Username, targetUser.Role)
+	targetTwo := srv.sessions.Create(targetUser.ID, targetUser.Username, targetUser.Role)
+
+	srv.handleSetUserRole(handler, admin.ID, &pb.SetUserRoleRequest{TargetUserID: targetUser.ID, NewRole: model.RoleUser.String()}, st, &nopConn{})
+
+	for _, sessionID := range []uint32{targetOne.ID, targetTwo.ID} {
+		snapshot, ok := srv.sessions.GetSnapshot(sessionID)
+		if !ok {
+			t.Fatalf("session %d not found", sessionID)
+		}
+		if snapshot.Role != model.RoleUser {
+			t.Errorf("session %d role = %s, want %s", sessionID, snapshot.Role, model.RoleUser)
+		}
+	}
+
+	responseConn := &bufferConn{}
+	srv.handleCreateToken(targetTwo.ID, &pb.CreateTokenRequest{Role: model.RoleUser.String()}, st, responseConn)
+	response, err := protocol.ReadControlMessage(responseConn)
+	if err != nil {
+		t.Fatalf("ReadControlMessage: %v", err)
+	}
+	if response.ErrorResponse == nil || response.ErrorResponse.Code != 30 {
+		t.Fatalf("demoted second session received %#v, want permission error", response)
 	}
 }

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -88,13 +88,14 @@ func (sm *SessionManager) GetSnapshot(sessionID uint32) (SessionSnapshot, bool) 
 	}, true
 }
 
-// GetByUserIDSnapshot retrieves a session snapshot by user ID.
-func (sm *SessionManager) GetByUserIDSnapshot(userID int64) (SessionSnapshot, bool) {
+// GetAllByUserIDSnapshots retrieves immutable snapshots for every session of a user.
+func (sm *SessionManager) GetAllByUserIDSnapshots(userID int64) []SessionSnapshot {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
+	snapshots := make([]SessionSnapshot, 0)
 	for _, s := range sm.sessions {
 		if s.UserID == userID {
-			return SessionSnapshot{
+			snapshots = append(snapshots, SessionSnapshot{
 				ID:              s.ID,
 				UserID:          s.UserID,
 				Username:        s.Username,
@@ -104,10 +105,10 @@ func (sm *SessionManager) GetByUserIDSnapshot(userID int64) (SessionSnapshot, bo
 				UDPAddr:         cloneUDPAddr(s.UDPAddr),
 				Muted:           s.Muted,
 				Deafened:        s.Deafened,
-			}, true
+			})
 		}
 	}
-	return SessionSnapshot{}, false
+	return snapshots
 }
 
 // ValidateScreenAuth reports whether the session exists and the auth token matches.
@@ -153,12 +154,14 @@ func (sm *SessionManager) SetChannel(id uint32, channelID int64) {
 	}
 }
 
-// UpdateRole updates the role for a session.
-func (sm *SessionManager) UpdateRole(id uint32, role model.Role) {
+// UpdateRoleByUserID updates the role for every active session of a user.
+func (sm *SessionManager) UpdateRoleByUserID(userID int64, role model.Role) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	if s, ok := sm.sessions[id]; ok {
-		s.Role = role
+	for _, s := range sm.sessions {
+		if s.UserID == userID {
+			s.Role = role
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Ensures moderation and role changes apply to every active session belonging to a user.

- kick and ban actions now disconnect all matching sessions
- role changes update every active session immediately
- prevents secondary sessions from retaining stale permissions
- adds regression tests for multi-session kicks, bans and role revocation
- isolates server tests using temporary databases