### PR TITLE
fix: close datastore at lifecycle boundaries

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -42,43 +43,41 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Handle export commands (run and exit)
-	if cfg.ExportUsers || cfg.ExportChannels {
-		st, err := datastore.NewProviderFactory(cfg.DBPath)
-		if err != nil {
-			slog.Error("open database", "err", err)
-			os.Exit(1)
-		}
-		defer st.DB.Close()
-
-		if cfg.ExportUsers {
-			data, err := server.ExportUsersYAML(st)
-			if err != nil {
-				slog.Error("export users", "err", err)
-				os.Exit(1)
-			}
-			fmt.Print(string(data))
-		}
-		if cfg.ExportChannels {
-			data, err := server.ExportChannelsYAML(st)
-			if err != nil {
-				slog.Error("export channels", "err", err)
-				os.Exit(1)
-			}
-			fmt.Print(string(data))
-		}
-		return
-	}
-
-	st, err := datastore.NewProviderFactory(cfg.DBPath)
-	if err != nil {
-		slog.Error("open database", "err", err)
-		os.Exit(1)
-	}
-
-	srv := server.New(cfg, server.Dependencies{Store: st})
-	if err := srv.Run(); err != nil {
+	if err := run(cfg); err != nil {
 		slog.Error("server error", "err", err)
 		os.Exit(1)
 	}
+}
+
+func run(cfg server.Config) (err error) {
+	st, err := datastore.NewProviderFactory(cfg.DBPath)
+	if err != nil {
+		return fmt.Errorf("open database: %w", err)
+	}
+	defer func() {
+		if closeErr := st.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close database: %w", closeErr))
+		}
+	}()
+
+	if cfg.ExportUsers {
+		data, exportErr := server.ExportUsersYAML(st)
+		if exportErr != nil {
+			return fmt.Errorf("export users: %w", exportErr)
+		}
+		fmt.Print(string(data))
+	}
+	if cfg.ExportChannels {
+		data, exportErr := server.ExportChannelsYAML(st)
+		if exportErr != nil {
+			return fmt.Errorf("export channels: %w", exportErr)
+		}
+		fmt.Print(string(data))
+	}
+	if cfg.ExportUsers || cfg.ExportChannels {
+		return nil
+	}
+
+	srv := server.New(cfg, server.Dependencies{Store: st})
+	return srv.Run()
 }

--- a/pkg/datastore/sql.go
+++ b/pkg/datastore/sql.go
@@ -104,9 +104,12 @@ func NewProviderFactory(dbPath string) (*ProviderFactory, error) {
 	return s, nil
 }
 
-// Close closes the database connection.
+// Close closes the database connection pool.
 func (s *ProviderFactory) Close() error {
-	return nil
+	if s == nil || s.DB == nil {
+		return nil
+	}
+	return s.DB.Close()
 }
 
 func (s *ProviderFactory) migrate() error {

--- a/pkg/datastore/sql_test.go
+++ b/pkg/datastore/sql_test.go
@@ -31,7 +31,7 @@ func NewTestSqlConn(t *testing.T) (*datastore.ProviderFactory, error) {
 
 	t.Cleanup(func() {
 		if err := st.Close(); err != nil {
-			fmt.Printf("Error closing database: %v\n", err)
+			t.Errorf("Close datastore: %v", err)
 		}
 	})
 
@@ -50,6 +50,24 @@ func generateRandomSafeString(t *testing.T, byteLength int) string {
 
 	encoded := base64.URLEncoding.EncodeToString(bytes)
 	return encoded
+}
+
+func TestProviderFactoryCloseClosesDatabase(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "close.db")
+	store, err := datastore.NewProviderFactory(dbPath)
+	if err != nil {
+		t.Fatalf("NewProviderFactory: %v", err)
+	}
+	if _, err := store.NonTx().ListUsers(); err != nil {
+		t.Fatalf("ListUsers before Close: %v", err)
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := store.NonTx().ListUsers(); err == nil {
+		t.Fatal("ListUsers after Close succeeded, want closed database error")
+	}
 }
 
 func TestZeroTime(t *testing.T) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -45,7 +45,7 @@ type Config struct {
 }
 
 // Dependencies holds external dependencies for the server.
-// Server assumes ownership of Store and will Close() it on shutdown.
+// The caller retains ownership of Store and must close it after Run returns.
 type Dependencies struct {
 	Store datastore.DataProviderFactory
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -57,6 +57,11 @@ func newTestServer(t *testing.T) (*Server, datastore.DataProviderFactory, *Contr
 	if err != nil {
 		t.Fatalf("Could not start datastore: %v", err)
 	}
+	t.Cleanup(func() {
+		if err := st.Close(); err != nil {
+			t.Errorf("Close datastore: %v", err)
+		}
+	})
 	srv := New(cfg, Dependencies{Store: st})
 	handler := newControlHandler(srv, st)
 	return srv, st, handler


### PR DESCRIPTION
## Summary

Fixes a datastore lifecycle bug where `ProviderFactory.Close()` returned successfully without closing the SQLite connection pool.

- closes the underlying `sql.DB` pool
- makes the composition root responsible for datastore ownership
- guarantees cleanup after shutdown, startup errors, and export operations
- removes direct access to the internal database handle
- closes databases created by shared test helpers
- documents the datastore ownership contract
- adds regression coverage verifying that operations fail after closure