### PR TITLE
fix: enforce channel scope on invite tokens

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -142,7 +142,7 @@ graph TB
 
 - Tokens are 256-bit random values (64 hex characters)
 - Only the SHA-256 hash is stored in the database (invite + personal tokens). Personal tokens are stored on the user record and are shown only once.
-- Tokens can have: role assignment, channel scope, max uses, expiration
+- Invite tokens can have: role assignment, channel scope, max uses, expiration. A non-zero channel scope is enforced by the server: the client auto-joins that channel and cannot join another channel. The generated personal token retains this restriction on later logins. Existing users and unscoped tokens remain server-wide. Older clients remain wire-compatible but must be upgraded to select the scoped channel automatically.
 - On first server run, an admin token is automatically generated and logged
 
 ### Open Server Mode

--- a/pkg/client/engine.go
+++ b/pkg/client/engine.go
@@ -253,11 +253,10 @@ func (e *Engine) Connect(controlAddr, voiceAddr, token, username string) error {
 		e.OnChannelsUpdate(authResp.Channels)
 	}
 
-	// Auto-join the first available channel so the user isn't stuck in "no channel"
-	if len(authResp.Channels) > 0 {
-		firstCh := authResp.Channels[0]
-		if err := e.JoinChannel(firstCh.ID); err != nil {
-			slog.Warn("auto-join channel failed", "channel", firstCh.Name, "err", err)
+	// Auto-join the invite scope, or the first channel for server-wide users.
+	if autoJoin, ok := selectAutoJoinChannel(authResp.Channels, authResp.ChannelScope); ok {
+		if err := e.JoinChannel(autoJoin.ID); err != nil {
+			slog.Warn("auto-join channel failed", "channel", autoJoin.Name, "err", err)
 		}
 	}
 
@@ -296,6 +295,21 @@ func (e *Engine) Connect(controlAddr, voiceAddr, token, username string) error {
 	}()
 
 	return nil
+}
+
+func selectAutoJoinChannel(channels []pb.ChannelInfo, channelScope int64) (pb.ChannelInfo, bool) {
+	if channelScope == 0 {
+		if len(channels) == 0 {
+			return pb.ChannelInfo{}, false
+		}
+		return channels[0], true
+	}
+	for _, channel := range channels {
+		if channel.ID == channelScope {
+			return channel, true
+		}
+	}
+	return pb.ChannelInfo{}, false
 }
 
 // initAudioDefault initializes PortAudio devices and Opus codec (the default backend).

--- a/pkg/client/engine_test.go
+++ b/pkg/client/engine_test.go
@@ -37,6 +37,22 @@ func TestResolveAdvertisedAddr(t *testing.T) {
 	}
 }
 
+func TestSelectAutoJoinChannelHonorsScope(t *testing.T) {
+	channels := []pb.ChannelInfo{{ID: 1, Name: "first"}, {ID: 2, Name: "scoped"}}
+
+	got, ok := selectAutoJoinChannel(channels, 2)
+	if !ok || got.ID != 2 {
+		t.Fatalf("selectAutoJoinChannel(scope=2) = (%#v, %t), want channel 2", got, ok)
+	}
+	got, ok = selectAutoJoinChannel(channels, 0)
+	if !ok || got.ID != 1 {
+		t.Fatalf("selectAutoJoinChannel(scope=0) = (%#v, %t), want first channel", got, ok)
+	}
+	if _, ok := selectAutoJoinChannel(channels, 3); ok {
+		t.Fatal("selectAutoJoinChannel accepted a missing scoped channel")
+	}
+}
+
 func TestClearScreenShareStateResetsCallbacks(t *testing.T) {
 	e := NewEngine()
 	e.activeScreenShare = &pb.ScreenShareEvent{Active: true, SessionID: 10, ChannelID: 1}

--- a/pkg/datastore/interface.go
+++ b/pkg/datastore/interface.go
@@ -62,6 +62,7 @@ type UserReadProvider interface {
 
 type UserWriteProvider interface {
 	CreateUser(username string, role model.Role) (*model.User, error)
+	CreateUserWithChannelScope(username string, role model.Role, channelScope int64) (*model.User, error)
 	UpdateUserRole(userID int64, role model.Role) error
 	UpdateUserPersonalToken(userID int64, hash string, createdAt time.Time) error
 }
@@ -86,7 +87,7 @@ type TokenWriteProvider interface {
 }
 
 type TokenTransactionProvider interface {
-	ValidateToken(hash string) (model.Role, error)
+	ValidateToken(hash string) (*model.Token, error)
 }
 
 type BanReadProvider interface {

--- a/pkg/datastore/sql.go
+++ b/pkg/datastore/sql.go
@@ -206,6 +206,12 @@ func (s *ProviderFactory) migrate() error {
 			},
 			ignoreErrors: true,
 		},
+		{
+			version: 5,
+			statements: []string{
+				"ALTER TABLE users ADD COLUMN channel_scope INTEGER NOT NULL DEFAULT 0",
+			},
+		},
 	}
 
 	for _, m := range migrations {
@@ -278,6 +284,11 @@ func parseDBTime(value string) (time.Time, error) {
 // CreateUser creates a new user and returns it with the assigned ID.
 // It validates the username format and role before inserting.
 func (s *baseProvider) CreateUser(username string, role model.Role) (*model.User, error) {
+	return s.CreateUserWithChannelScope(username, role, 0)
+}
+
+// CreateUserWithChannelScope creates a user whose personal token retains an invite's channel restriction.
+func (s *baseProvider) CreateUserWithChannelScope(username string, role model.Role, channelScope int64) (*model.User, error) {
 	if err := model.ValidateUsername(username); err != nil {
 		return nil, fmt.Errorf("datastore: create user: %w", err)
 	}
@@ -286,9 +297,10 @@ func (s *baseProvider) CreateUser(username string, role model.Role) (*model.User
 	}
 	res, err := s.ExecContext(
 		context.Background(),
-		"INSERT INTO users (username, role, personal_token_hash, personal_token_created_at) VALUES (?, ?, ?, ?)",
+		"INSERT INTO users (username, role, channel_scope, personal_token_hash, personal_token_created_at) VALUES (?, ?, ?, ?, ?)",
 		username,
 		int(role),
+		channelScope,
 		"",
 		formatDBTime(time.Now().UTC()),
 	)
@@ -300,10 +312,11 @@ func (s *baseProvider) CreateUser(username string, role model.Role) (*model.User
 	}
 	id, _ := res.LastInsertId()
 	return &model.User{
-		ID:        id,
-		Username:  username,
-		Role:      role,
-		CreatedAt: time.Now().UTC(),
+		ID:           id,
+		Username:     username,
+		Role:         role,
+		ChannelScope: channelScope,
+		CreatedAt:    time.Now().UTC(),
 	}, nil
 }
 
@@ -315,9 +328,9 @@ func (s *baseProvider) GetUserByUsername(username string) (*model.User, error) {
 	var personalTokenCreatedAt string
 	err := s.QueryRowContext(
 		context.Background(),
-		"SELECT id, username, role, personal_token_hash, personal_token_created_at, created_at FROM users WHERE username = ?",
+		"SELECT id, username, role, channel_scope, personal_token_hash, personal_token_created_at, created_at FROM users WHERE username = ?",
 		username,
-	).Scan(&u.ID, &u.Username, &roleInt, &u.PersonalTokenHash, &personalTokenCreatedAt, &createdAt)
+	).Scan(&u.ID, &u.Username, &roleInt, &u.ChannelScope, &u.PersonalTokenHash, &personalTokenCreatedAt, &createdAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -345,9 +358,9 @@ func (s *baseProvider) GetUserByID(id int64) (*model.User, error) {
 	var personalTokenCreatedAt string
 	err := s.QueryRowContext(
 		context.Background(),
-		"SELECT id, username, role, personal_token_hash, personal_token_created_at, created_at FROM users WHERE id = ?",
+		"SELECT id, username, role, channel_scope, personal_token_hash, personal_token_created_at, created_at FROM users WHERE id = ?",
 		id,
-	).Scan(&u.ID, &u.Username, &roleInt, &u.PersonalTokenHash, &personalTokenCreatedAt, &createdAt)
+	).Scan(&u.ID, &u.Username, &roleInt, &u.ChannelScope, &u.PersonalTokenHash, &personalTokenCreatedAt, &createdAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -374,9 +387,9 @@ func (s *baseProvider) GetUserByPersonalTokenHash(hash string) (*model.User, err
 	var personalTokenCreatedAt string
 	err := s.QueryRowContext(
 		context.Background(),
-		"SELECT id, username, role, personal_token_hash, personal_token_created_at, created_at FROM users WHERE personal_token_hash = ?",
+		"SELECT id, username, role, channel_scope, personal_token_hash, personal_token_created_at, created_at FROM users WHERE personal_token_hash = ?",
 		hash,
-	).Scan(&u.ID, &u.Username, &roleInt, &u.PersonalTokenHash, &personalTokenCreatedAt, &createdAt)
+	).Scan(&u.ID, &u.Username, &roleInt, &u.ChannelScope, &u.PersonalTokenHash, &personalTokenCreatedAt, &createdAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -427,7 +440,7 @@ func (s *baseProvider) UpdateUserPersonalToken(userID int64, hash string, create
 
 // ListUsers returns all users.
 func (s *baseProvider) ListUsers() ([]model.User, error) {
-	rows, err := s.QueryContext(context.Background(), "SELECT id, username, role, personal_token_hash, personal_token_created_at, created_at FROM users ORDER BY id")
+	rows, err := s.QueryContext(context.Background(), "SELECT id, username, role, channel_scope, personal_token_hash, personal_token_created_at, created_at FROM users ORDER BY id")
 	if err != nil {
 		return nil, fmt.Errorf("datastore: list users: %w", err)
 	}
@@ -439,7 +452,7 @@ func (s *baseProvider) ListUsers() ([]model.User, error) {
 		var roleInt int
 		var createdAt string
 		var personalTokenCreatedAt string
-		if err := rows.Scan(&u.ID, &u.Username, &roleInt, &u.PersonalTokenHash, &personalTokenCreatedAt, &createdAt); err != nil {
+		if err := rows.Scan(&u.ID, &u.Username, &roleInt, &u.ChannelScope, &u.PersonalTokenHash, &personalTokenCreatedAt, &createdAt); err != nil {
 			return nil, fmt.Errorf("datastore: scan user: %w", err)
 		}
 		u.Role = model.Role(roleInt)
@@ -605,46 +618,54 @@ func (s *baseProvider) CreateToken(hash string, role model.Role, channelScope in
 	return nil
 }
 
-// ValidateToken checks if a token hash is valid and returns the associated role.
+// ValidateToken checks if a token hash is valid and returns its authorization data.
 // It increments the use count atomically.
-func (s *txProvider) ValidateToken(hash string) (model.Role, error) {
+func (s *txProvider) ValidateToken(hash string) (*model.Token, error) {
 	ctx := context.Background()
 
 	var roleInt int
+	var channelScope int64
 	var maxUses, useCount int
 	var expiresAt *string
 	err := s.QueryRowContext(ctx,
-		"SELECT role, max_uses, use_count, expires_at FROM tokens WHERE hash = ?", hash).
-		Scan(&roleInt, &maxUses, &useCount, &expiresAt)
+		"SELECT role, channel_scope, max_uses, use_count, expires_at FROM tokens WHERE hash = ?", hash).
+		Scan(&roleInt, &channelScope, &maxUses, &useCount, &expiresAt)
 	if err == sql.ErrNoRows {
-		return 0, fmt.Errorf("datastore: invalid token")
+		return nil, fmt.Errorf("datastore: invalid token")
 	}
 	if err != nil {
-		return 0, fmt.Errorf("datastore: validate token: %w", err)
+		return nil, fmt.Errorf("datastore: validate token: %w", err)
 	}
 
-	// Check expiration
 	if expiresAt != nil {
 		exp, err := parseDBTime(*expiresAt)
 		if err != nil {
-			return 0, fmt.Errorf("datastore: validate token: %w", err)
+			return nil, fmt.Errorf("datastore: validate token: %w", err)
 		}
 		if time.Now().After(exp) {
-			return 0, fmt.Errorf("datastore: token expired")
+			return nil, fmt.Errorf("datastore: token expired")
 		}
 	}
 
-	// Check uses
 	if maxUses > 0 && useCount >= maxUses {
-		return 0, fmt.Errorf("datastore: token exhausted")
+		return nil, fmt.Errorf("datastore: token exhausted")
 	}
 
-	// Increment use count
+	if channelScope != 0 {
+		var exists int
+		if err := s.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM channels WHERE id = ?)", channelScope).Scan(&exists); err != nil {
+			return nil, fmt.Errorf("datastore: validate token scope: %w", err)
+		}
+		if exists == 0 {
+			return nil, fmt.Errorf("datastore: token channel scope does not exist")
+		}
+	}
+
 	if _, err := s.ExecContext(ctx, "UPDATE tokens SET use_count = use_count + 1 WHERE hash = ?", hash); err != nil {
-		return 0, fmt.Errorf("datastore: increment use: %w", err)
+		return nil, fmt.Errorf("datastore: increment use: %w", err)
 	}
 
-	return model.Role(roleInt), nil
+	return &model.Token{Role: model.Role(roleInt), ChannelScope: channelScope}, nil
 }
 
 // ---- Bans ----

--- a/pkg/datastore/sql_test.go
+++ b/pkg/datastore/sql_test.go
@@ -945,6 +945,15 @@ func TestValidateToken(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to open test connection: %v", err)
 			}
+			if tc.token.channelScope != 0 {
+				channel := model.NewChannel()
+				if err := store.NonTx().CreateChannel(channel); err != nil {
+					t.Fatalf("CreateChannel: %v", err)
+				}
+				if channel.ID != tc.token.channelScope {
+					t.Fatalf("seeded channel ID = %d, want scope %d", channel.ID, tc.token.channelScope)
+				}
+			}
 
 			if err := store.NonTx().CreateToken(tc.token.hash, tc.token.role, tc.token.channelScope, tc.token.createdBy, tc.token.maxUses, tc.token.expiresAt); err != nil {
 				t.Fatalf("CreateToken: failed to create token: %v", err)
@@ -982,6 +991,88 @@ func TestValidateToken(t *testing.T) {
 				t.Fatalf("Tx: Commit: %v", err)
 			}
 		})
+	}
+}
+
+func TestValidateTokenReturnsChannelScope(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewTestSqlConn(t)
+	if err != nil {
+		t.Fatalf("failed to open test connection: %v", err)
+	}
+
+	channel := model.NewChannel()
+	if err := store.NonTx().CreateChannel(channel); err != nil {
+		t.Fatalf("CreateChannel: %v", err)
+	}
+	hash := crypto.HashToken("scoped-token")
+	if err := store.NonTx().CreateToken(hash, model.RoleUser, channel.ID, 1, 1, time.Time{}); err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+
+	tx, err := store.Tx(context.Background())
+	if err != nil {
+		t.Fatalf("Tx: %v", err)
+	}
+	token, err := tx.ValidateToken(hash)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if token.Role != model.RoleUser || token.ChannelScope != channel.ID {
+		t.Fatalf("ValidateToken returned role=%s scope=%d, want role=%s scope=%d", token.Role, token.ChannelScope, model.RoleUser, channel.ID)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+}
+
+func TestValidateTokenRejectsMissingChannelScope(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewTestSqlConn(t)
+	if err != nil {
+		t.Fatalf("failed to open test connection: %v", err)
+	}
+	hash := crypto.HashToken("missing-channel-token")
+	if err := store.NonTx().CreateToken(hash, model.RoleUser, 999, 1, 1, time.Time{}); err != nil {
+		t.Fatalf("CreateToken: %v", err)
+	}
+
+	tx, err := store.Tx(context.Background())
+	if err != nil {
+		t.Fatalf("Tx: %v", err)
+	}
+	if _, err := tx.ValidateToken(hash); err == nil {
+		t.Fatal("ValidateToken accepted a token scoped to a missing channel")
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+}
+
+func TestScopedUserPersonalTokenPreservesChannelScope(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewTestSqlConn(t)
+	if err != nil {
+		t.Fatalf("failed to open test connection: %v", err)
+	}
+	user, err := store.NonTx().CreateUserWithChannelScope("scoped-user", model.RoleUser, 42)
+	if err != nil {
+		t.Fatalf("CreateUserWithChannelScope: %v", err)
+	}
+	hash := crypto.HashToken("personal-token")
+	if err := store.NonTx().UpdateUserPersonalToken(user.ID, hash, time.Now().UTC()); err != nil {
+		t.Fatalf("UpdateUserPersonalToken: %v", err)
+	}
+
+	got, err := store.NonTx().GetUserByPersonalTokenHash(hash)
+	if err != nil {
+		t.Fatalf("GetUserByPersonalTokenHash: %v", err)
+	}
+	if got == nil || got.ChannelScope != 42 {
+		t.Fatalf("personal-token user scope = %v, want 42", got)
 	}
 }
 

--- a/pkg/model/session.go
+++ b/pkg/model/session.go
@@ -8,6 +8,7 @@ type Session struct {
 	UserID          int64
 	Username        string
 	Role            Role
+	ChannelScope    int64
 	ChannelID       int64
 	ScreenAuthToken string
 	UDPAddr         *net.UDPAddr

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -20,6 +20,7 @@ type User struct {
 	ID                     int64     `json:"id"`
 	Username               string    `json:"username"`
 	Role                   Role      `json:"role"`
+	ChannelScope           int64     `json:"channel_scope"` // 0 = server-wide
 	PersonalTokenHash      string    `json:"-"`
 	PersonalTokenCreatedAt time.Time `json:"-"`
 	CreatedAt              time.Time `json:"created_at"`

--- a/pkg/protocol/pb/messages.go
+++ b/pkg/protocol/pb/messages.go
@@ -52,6 +52,7 @@ type AuthResponse struct {
 	SessionID          uint32        `json:"session_id"`
 	Username           string        `json:"username"`
 	Role               string        `json:"role"`
+	ChannelScope       int64         `json:"channel_scope,omitempty"`
 	EncryptionKey      []byte        `json:"encryption_key"`
 	Channels           []ChannelInfo `json:"channels"`
 	ScreenAddr         string        `json:"screen_addr,omitempty"`

--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -460,8 +460,10 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 	}
 
 	var tokenRole model.Role
+	var channelScope int64
 	if user != nil {
 		sessionRole = user.Role
+		channelScope = user.ChannelScope
 	} else {
 		if !isValidUsername(authReq.Username) {
 			sendError(conn, 2, "invalid username: must be 1-32 letters, digits, underscores, or hyphens")
@@ -494,13 +496,16 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 				}
 			}()
 
-			tokenRole, err = tx.ValidateToken(tokenHash)
+			tokenAuth, validateErr := tx.ValidateToken(tokenHash)
+			err = validateErr
 			if err != nil {
 				s.metrics.FailedAuths.Add(1)
 				slog.Warn("auth failed", "err", err)
 				sendError(conn, 2, "authentication failed")
 				return
 			}
+			tokenRole = tokenAuth.Role
+			channelScope = tokenAuth.ChannelScope
 			if err := tx.Commit(); err != nil {
 				slog.Error("commit transaction", "err", err)
 				sendError(conn, 3, "database error")
@@ -509,7 +514,7 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 			committed = true
 		}
 
-		user, err = st.NonTx().CreateUser(authReq.Username, tokenRole)
+		user, err = st.NonTx().CreateUserWithChannelScope(authReq.Username, tokenRole, channelScope)
 		if err != nil {
 			if errors.Is(err, datastore.ErrUsernameTaken) {
 				s.metrics.FailedAuths.Add(1)
@@ -546,7 +551,7 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 	}
 
 	// Create session (voice key is shared server-wide for SFU model)
-	session := s.sessions.Create(user.ID, user.Username, sessionRole)
+	session := s.sessions.CreateWithChannelScope(user.ID, user.Username, sessionRole, channelScope)
 	sessionID := session.ID
 
 	defer func() {
@@ -595,6 +600,7 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 			SessionID:          sessionID,
 			Username:           user.Username,
 			Role:               sessionRole.String(),
+			ChannelScope:       channelScope,
 			EncryptionKey:      s.voiceKey,
 			Channels:           channelInfos,
 			ScreenAddr:         s.cfg.ScreenAddr,
@@ -704,6 +710,10 @@ func (s *Server) handleJoinChannel(handler *ControlHandler, sessionID uint32, re
 	session, ok := s.sessions.GetSnapshot(sessionID)
 	if !ok {
 		sendError(conn, 3, "session not found")
+		return
+	}
+	if session.ChannelScope != 0 && req.ChannelID != session.ChannelScope {
+		sendError(conn, 12, "channel is outside your invite scope")
 		return
 	}
 	// Verify channel exists

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -122,6 +122,39 @@ func TestHandleJoinLeaveChannel(t *testing.T) {
 	}
 }
 
+func TestHandleJoinChannelEnforcesSessionScope(t *testing.T) {
+	srv, st, handler := newTestServer(t)
+	scopedChannel := model.NewChannel()
+	scopedChannel.Name = "scoped"
+	if err := st.NonTx().CreateChannel(scopedChannel); err != nil {
+		t.Fatalf("CreateChannel(scoped): %v", err)
+	}
+	otherChannel := model.NewChannel()
+	otherChannel.Name = "other"
+	if err := st.NonTx().CreateChannel(otherChannel); err != nil {
+		t.Fatalf("CreateChannel(other): %v", err)
+	}
+
+	session := srv.sessions.CreateWithChannelScope(1, "scoped-user", model.RoleUser, scopedChannel.ID)
+	rejection := &bufferConn{}
+	srv.handleJoinChannel(handler, session.ID, &pb.JoinChannelRequest{ChannelID: otherChannel.ID}, st, rejection)
+	response, err := protocol.ReadControlMessage(rejection)
+	if err != nil {
+		t.Fatalf("ReadControlMessage: %v", err)
+	}
+	if response.ErrorResponse == nil || response.ErrorResponse.Code != 12 {
+		t.Fatalf("out-of-scope join returned %#v, want error code 12", response)
+	}
+	if got := srv.channels.ChannelOf(session.ID); got != 0 {
+		t.Fatalf("out-of-scope join moved session to channel %d", got)
+	}
+
+	srv.handleJoinChannel(handler, session.ID, &pb.JoinChannelRequest{ChannelID: scopedChannel.ID}, st, &nopConn{})
+	if got := srv.channels.ChannelOf(session.ID); got != scopedChannel.ID {
+		t.Fatalf("scoped join moved session to channel %d, want %d", got, scopedChannel.ID)
+	}
+}
+
 func TestHandleUserState(t *testing.T) {
 	srv, st, handler := newTestServer(t)
 

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -22,6 +22,7 @@ type SessionSnapshot struct {
 	UserID          int64
 	Username        string
 	Role            model.Role
+	ChannelScope    int64
 	ChannelID       int64
 	ScreenAuthToken string
 	UDPAddr         *net.UDPAddr
@@ -38,6 +39,11 @@ func NewSessionManager() *SessionManager {
 
 // Create creates a new session for an authenticated user.
 func (sm *SessionManager) Create(userID int64, username string, role model.Role) *model.Session {
+	return sm.CreateWithChannelScope(userID, username, role, 0)
+}
+
+// CreateWithChannelScope creates a session with a persistent invite restriction.
+func (sm *SessionManager) CreateWithChannelScope(userID int64, username string, role model.Role, channelScope int64) *model.Session {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
@@ -61,6 +67,7 @@ func (sm *SessionManager) Create(userID int64, username string, role model.Role)
 		UserID:          userID,
 		Username:        username,
 		Role:            role,
+		ChannelScope:    channelScope,
 		ScreenAuthToken: newScreenAuthToken(),
 	}
 	sm.sessions[id] = sess
@@ -80,6 +87,7 @@ func (sm *SessionManager) GetSnapshot(sessionID uint32) (SessionSnapshot, bool) 
 		UserID:          s.UserID,
 		Username:        s.Username,
 		Role:            s.Role,
+		ChannelScope:    s.ChannelScope,
 		ChannelID:       s.ChannelID,
 		ScreenAuthToken: s.ScreenAuthToken,
 		UDPAddr:         cloneUDPAddr(s.UDPAddr),
@@ -100,6 +108,7 @@ func (sm *SessionManager) GetAllByUserIDSnapshots(userID int64) []SessionSnapsho
 				UserID:          s.UserID,
 				Username:        s.Username,
 				Role:            s.Role,
+				ChannelScope:    s.ChannelScope,
 				ChannelID:       s.ChannelID,
 				ScreenAuthToken: s.ScreenAuthToken,
 				UDPAddr:         cloneUDPAddr(s.UDPAddr),


### PR DESCRIPTION
## Summary

Enforces channel restrictions configured on invite tokens.

- validates that scoped channels exist
- persists the scope on created users and personal-token logins
- prevents scoped sessions from joining other channels
- automatically joins scoped clients to the correct channel
- keeps existing users and unscoped tokens server-wide
- adds regression coverage for persistence, validation, join restrictions and client auto-join behavior