### PR TITLE
fix: authenticate udp endpoint registration

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -63,13 +63,13 @@ sequenceDiagram
         S->>S: Create user + personal token
         S->>S: Check bans
         S->>S: Generate session
-        S->>C: AuthResponse{sessionID, role, encryptionKey, screenAddr, screenAuthToken, channels, autoToken}
+        S->>C: AuthResponse{sessionID, role, encryptionKey, voiceRegistrationKey, screenAddr, screenAuthToken, channels, autoToken}
         Note over C: Store personal token for reconnect
     else Existing user
         S->>S: Require personal token
         S->>S: Check bans
         S->>S: Generate session
-        S->>C: AuthResponse{sessionID, role, encryptionKey, screenAddr, screenAuthToken, channels}
+        S->>C: AuthResponse{sessionID, role, encryptionKey, voiceRegistrationKey, screenAddr, screenAuthToken, channels}
     else Invalid token / banned
         S->>C: ErrorResponse{code, message}
         S->>S: Close connection
@@ -156,6 +156,18 @@ The control plane carries screen-share lifecycle messages only:
 - **Transport**: Raw UDP
 - **Encryption**: AES-128-GCM (shared key distributed in `AuthResponse`)
 - **Codec**: Opus at 48 kHz mono, 20ms frames (960 samples)
+
+### Authenticated Endpoint Registration
+
+A voice endpoint is not learned from an ordinary voice packet. During control authentication, the server creates a random 32-byte `voice_registration_key` for that session and returns it inside the TLS-protected `AuthResponse`. The client immediately sends this registration datagram and refreshes it every five seconds:
+
+```
+[Magic "GSR1":4B][SessionID:4B][Counter:8B][HMAC-SHA-256:32B]
+```
+
+The HMAC covers the first 16 bytes. The server accepts only a valid proof for the named active session with a counter greater than every previously accepted counter. Once a registration is accepted, the same datagram cannot be replayed. A source-address change requires a fresh proof and is accepted at most once per five seconds; this permits controlled NAT rebinding without STUN or TURN. Voice packets from unregistered or mismatched endpoints are dropped.
+
+This field is required: clients and servers from before authenticated UDP registration are not voice-compatible with this protocol revision and fail closed rather than falling back to first-packet binding.
 
 ### Packet Format
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -12,6 +12,7 @@ GoSpeak is designed with security as a core principle. All communication is encr
 | Server compromise (media) | Server holds the generated media keys and _could_ decrypt — see note above. Mitigated by running your own trusted server |
 | Replay attacks | Deterministic nonces from SessionID + SeqNum prevent replay |
 | Unauthorized access | Token-based auth with SHA-256 hashed storage, RBAC |
+| UDP endpoint hijacking | Per-session HMAC registration proof from the TLS control channel, monotonic registration counters, and rate-limited rebinding |
 | Brute force tokens | Tokens are 256-bit random (64-char hex), hashed with SHA-256 |
 | Password attacks | Argon2id with hardened parameters (64MB memory, 4 iterations) |
 | Privilege escalation | Server-side RBAC checks on every admin operation |
@@ -82,6 +83,12 @@ sequenceDiagram
 - One shared key per server session (generated at server startup)
 - Key is distributed to each client during authentication, inside the encrypted TLS tunnel
 - All clients in the server share the same voice key
+
+### UDP Endpoint Registration
+
+The shared media key does not authorize a UDP source address. Each control session receives a separate random 256-bit registration key in `AuthResponse`, protected by TLS. The client sends an HMAC-SHA-256 registration proof immediately and every five seconds. A monotonic 64-bit counter makes accepted proofs one-use, and the server rate-limits authenticated endpoint changes to one per five seconds. Ordinary voice packets never establish or change the endpoint.
+
+This prevents another client from binding a victim's visible session ID to the attacker's UDP address. It does not prevent an on-path attacker from dropping UDP traffic, and it does not add NAT traversal: connectivity remains direct UDP with no STUN or TURN service.
 
 ### Encryption Process
 

--- a/pkg/client/engine.go
+++ b/pkg/client/engine.go
@@ -187,7 +187,7 @@ func (e *Engine) Connect(controlAddr, voiceAddr, token, username string) error {
 	)
 
 	// Set up voice connection
-	voice, err := NewVoiceClient(voiceAddr, authResp.SessionID, authResp.EncryptionKey)
+	voice, err := NewVoiceClient(voiceAddr, authResp.SessionID, authResp.EncryptionKey, authResp.VoiceRegistrationKey)
 	if err != nil {
 		_ = ctrl.Close()
 		e.setState(StateDisconnected)
@@ -597,10 +597,23 @@ func (e *Engine) keepaliveLoop() {
 		case <-e.ctx.Done():
 			return
 		case <-e.keepaliveNow:
+			e.tryRegisterVoiceEndpoint()
 			// Immediate keepalive (e.g. just joined a channel); ignore recency.
 			e.trySendKeepalive(&timestamp, false)
 		case <-ticker.C:
+			e.tryRegisterVoiceEndpoint()
 			e.trySendKeepalive(&timestamp, true)
+		}
+	}
+}
+
+func (e *Engine) tryRegisterVoiceEndpoint() {
+	e.mu.RLock()
+	voice := e.voice
+	e.mu.RUnlock()
+	if voice != nil {
+		if err := voice.SendRegistration(); err != nil {
+			slog.Debug("voice endpoint registration error", "err", err)
 		}
 	}
 }

--- a/pkg/client/voice.go
+++ b/pkg/client/voice.go
@@ -12,13 +12,15 @@ import (
 
 // VoiceClient manages the UDP voice connection.
 type VoiceClient struct {
-	conn       *net.UDPConn
-	serverAddr *net.UDPAddr
-	sessionID  uint32
-	channelID  uint16
-	cipher     *gospeakCrypto.VoiceCipher
-	seqNum     uint32
-	mu         sync.Mutex
+	conn                *net.UDPConn
+	serverAddr          *net.UDPAddr
+	sessionID           uint32
+	channelID           uint16
+	cipher              *gospeakCrypto.VoiceCipher
+	seqNum              uint32
+	registrationKey     []byte
+	registrationCounter uint64
+	mu                  sync.Mutex
 
 	// Incoming voice packets are sent here
 	IncomingPackets chan *protocol.VoicePacket
@@ -27,7 +29,7 @@ type VoiceClient struct {
 }
 
 // NewVoiceClient creates a new UDP voice client.
-func NewVoiceClient(serverAddr string, sessionID uint32, encKey []byte) (*VoiceClient, error) {
+func NewVoiceClient(serverAddr string, sessionID uint32, encKey, registrationKey []byte) (*VoiceClient, error) {
 	addr, err := net.ResolveUDPAddr("udp", serverAddr)
 	if err != nil {
 		return nil, fmt.Errorf("client: resolve voice addr: %w", err)
@@ -48,14 +50,33 @@ func NewVoiceClient(serverAddr string, sessionID uint32, encKey []byte) (*VoiceC
 	_ = conn.SetReadBuffer(512 * 1024)
 	_ = conn.SetWriteBuffer(512 * 1024)
 
-	return &VoiceClient{
+	client := &VoiceClient{
 		conn:            conn,
 		serverAddr:      addr,
 		sessionID:       sessionID,
 		cipher:          cipher,
+		registrationKey: append([]byte(nil), registrationKey...),
 		IncomingPackets: make(chan *protocol.VoicePacket, 100),
 		done:            make(chan struct{}),
-	}, nil
+	}
+	if err := client.SendRegistration(); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("client: register voice endpoint: %w", err)
+	}
+	return client, nil
+}
+
+// SendRegistration proves ownership of this session from the current UDP endpoint.
+func (v *VoiceClient) SendRegistration() error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.registrationCounter++
+	packet, err := protocol.MarshalVoiceRegistration(v.sessionID, v.registrationCounter, v.registrationKey)
+	if err != nil {
+		return err
+	}
+	_, err = v.conn.Write(packet)
+	return err
 }
 
 // SetChannel sets the current channel ID for outgoing packets.

--- a/pkg/client/voice_test.go
+++ b/pkg/client/voice_test.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/NicolasHaas/gospeak/pkg/protocol"
+)
+
+func TestNewVoiceClientRegistersEndpointImmediately(t *testing.T) {
+	listener, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("ListenUDP: %v", err)
+	}
+	defer listener.Close()
+
+	registrationKey := bytes.Repeat([]byte{0x42}, protocol.VoiceRegistrationKeySize)
+	voiceKey := bytes.Repeat([]byte{0x24}, 16)
+	client, err := NewVoiceClient(listener.LocalAddr().String(), 1234, voiceKey, registrationKey)
+	if err != nil {
+		t.Fatalf("NewVoiceClient: %v", err)
+	}
+	defer client.Close()
+
+	if err := listener.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	buf := make([]byte, protocol.VoiceRegistrationPacketSize)
+	n, _, err := listener.ReadFromUDP(buf)
+	if err != nil {
+		t.Fatalf("ReadFromUDP: %v", err)
+	}
+	registration, err := protocol.UnmarshalVoiceRegistration(buf[:n])
+	if err != nil {
+		t.Fatalf("UnmarshalVoiceRegistration: %v", err)
+	}
+	if registration.SessionID != 1234 || registration.Counter != 1 || !registration.Verify(registrationKey) {
+		t.Fatalf("invalid initial registration: %#v", registration)
+	}
+
+	if err := client.SendRegistration(); err != nil {
+		t.Fatalf("SendRegistration: %v", err)
+	}
+	n, _, err = listener.ReadFromUDP(buf)
+	if err != nil {
+		t.Fatalf("ReadFromUDP(refresh): %v", err)
+	}
+	registration, err = protocol.UnmarshalVoiceRegistration(buf[:n])
+	if err != nil {
+		t.Fatalf("UnmarshalVoiceRegistration(refresh): %v", err)
+	}
+	if registration.Counter != 2 || !registration.Verify(registrationKey) {
+		t.Fatalf("invalid refreshed registration: %#v", registration)
+	}
+}

--- a/pkg/model/session.go
+++ b/pkg/model/session.go
@@ -1,17 +1,23 @@
 package model
 
-import "net"
+import (
+	"net"
+	"time"
+)
 
 // Session represents an active client session (in-memory only).
 type Session struct {
-	ID              uint32
-	UserID          int64
-	Username        string
-	Role            Role
-	ChannelScope    int64
-	ChannelID       int64
-	ScreenAuthToken string
-	UDPAddr         *net.UDPAddr
-	Muted           bool
-	Deafened        bool
+	ID                       uint32
+	UserID                   int64
+	Username                 string
+	Role                     Role
+	ChannelScope             int64
+	ChannelID                int64
+	ScreenAuthToken          string
+	VoiceRegistrationKey     []byte
+	VoiceRegistrationCounter uint64
+	VoiceEndpointUpdatedAt   time.Time
+	UDPAddr                  *net.UDPAddr
+	Muted                    bool
+	Deafened                 bool
 }

--- a/pkg/protocol/pb/messages.go
+++ b/pkg/protocol/pb/messages.go
@@ -49,16 +49,17 @@ type AuthRequest struct {
 }
 
 type AuthResponse struct {
-	SessionID          uint32        `json:"session_id"`
-	Username           string        `json:"username"`
-	Role               string        `json:"role"`
-	ChannelScope       int64         `json:"channel_scope,omitempty"`
-	EncryptionKey      []byte        `json:"encryption_key"`
-	Channels           []ChannelInfo `json:"channels"`
-	ScreenAddr         string        `json:"screen_addr,omitempty"`
-	ScreenAuthToken    string        `json:"screen_auth_token,omitempty"`
-	ScreenShareEnabled bool          `json:"screen_share_enabled,omitempty"`
-	AutoToken          string        `json:"auto_token,omitempty"` // set when server generated a token for this user
+	SessionID            uint32        `json:"session_id"`
+	Username             string        `json:"username"`
+	Role                 string        `json:"role"`
+	ChannelScope         int64         `json:"channel_scope,omitempty"`
+	EncryptionKey        []byte        `json:"encryption_key"`
+	VoiceRegistrationKey []byte        `json:"voice_registration_key"`
+	Channels             []ChannelInfo `json:"channels"`
+	ScreenAddr           string        `json:"screen_addr,omitempty"`
+	ScreenAuthToken      string        `json:"screen_auth_token,omitempty"`
+	ScreenShareEnabled   bool          `json:"screen_share_enabled,omitempty"`
+	AutoToken            string        `json:"auto_token,omitempty"` // set when server generated a token for this user
 }
 
 // ----- Channels -----

--- a/pkg/protocol/voice_registration.go
+++ b/pkg/protocol/voice_registration.go
@@ -1,0 +1,83 @@
+package protocol
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+const (
+	// VoiceRegistrationMagic distinguishes endpoint-registration datagrams from voice packets.
+	// Session IDs must never use this value.
+	VoiceRegistrationMagic uint32 = 0x47535231 // "GSR1"
+
+	// VoiceRegistrationKeySize is the size of the per-session registration secret.
+	VoiceRegistrationKeySize = 32
+
+	// VoiceRegistrationPacketSize is [magic(4)|sessionID(4)|counter(8)|HMAC-SHA-256(32)].
+	VoiceRegistrationPacketSize = 48
+)
+
+// VoiceRegistration proves that a UDP endpoint belongs to an authenticated control session.
+type VoiceRegistration struct {
+	SessionID uint32
+	Counter   uint64
+	proof     [sha256.Size]byte
+	signed    [16]byte
+}
+
+// MarshalVoiceRegistration creates an authenticated endpoint-registration datagram.
+func MarshalVoiceRegistration(sessionID uint32, counter uint64, key []byte) ([]byte, error) {
+	if len(key) != VoiceRegistrationKeySize {
+		return nil, fmt.Errorf("protocol: invalid voice registration key length: %d", len(key))
+	}
+	if sessionID == 0 || sessionID == VoiceRegistrationMagic {
+		return nil, errors.New("protocol: invalid voice registration session ID")
+	}
+	if counter == 0 {
+		return nil, errors.New("protocol: invalid voice registration counter")
+	}
+
+	packet := make([]byte, VoiceRegistrationPacketSize)
+	binary.BigEndian.PutUint32(packet[0:4], VoiceRegistrationMagic)
+	binary.BigEndian.PutUint32(packet[4:8], sessionID)
+	binary.BigEndian.PutUint64(packet[8:16], counter)
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write(packet[:16])
+	copy(packet[16:], mac.Sum(nil))
+	return packet, nil
+}
+
+// IsVoiceRegistration reports whether data has the registration datagram marker and size.
+func IsVoiceRegistration(data []byte) bool {
+	return len(data) == VoiceRegistrationPacketSize && binary.BigEndian.Uint32(data[:4]) == VoiceRegistrationMagic
+}
+
+// UnmarshalVoiceRegistration parses a registration datagram. Call Verify before trusting it.
+func UnmarshalVoiceRegistration(data []byte) (*VoiceRegistration, error) {
+	if !IsVoiceRegistration(data) {
+		return nil, errors.New("protocol: invalid voice registration packet")
+	}
+	registration := &VoiceRegistration{
+		SessionID: binary.BigEndian.Uint32(data[4:8]),
+		Counter:   binary.BigEndian.Uint64(data[8:16]),
+	}
+	if registration.SessionID == 0 || registration.SessionID == VoiceRegistrationMagic || registration.Counter == 0 {
+		return nil, errors.New("protocol: invalid voice registration fields")
+	}
+	copy(registration.signed[:], data[:16])
+	copy(registration.proof[:], data[16:])
+	return registration, nil
+}
+
+// Verify authenticates the registration with the session secret.
+func (r *VoiceRegistration) Verify(key []byte) bool {
+	if r == nil || len(key) != VoiceRegistrationKeySize {
+		return false
+	}
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write(r.signed[:])
+	return hmac.Equal(r.proof[:], mac.Sum(nil))
+}

--- a/pkg/protocol/voice_registration_test.go
+++ b/pkg/protocol/voice_registration_test.go
@@ -1,0 +1,67 @@
+package protocol
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestVoiceRegistrationRoundTripAndAuthentication(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, VoiceRegistrationKeySize)
+
+	data, err := MarshalVoiceRegistration(1234, 7, key)
+	if err != nil {
+		t.Fatalf("MarshalVoiceRegistration: %v", err)
+	}
+	registration, err := UnmarshalVoiceRegistration(data)
+	if err != nil {
+		t.Fatalf("UnmarshalVoiceRegistration: %v", err)
+	}
+	if registration.SessionID != 1234 || registration.Counter != 7 {
+		t.Fatalf("registration mismatch: got session=%d counter=%d", registration.SessionID, registration.Counter)
+	}
+	if !registration.Verify(key) {
+		t.Fatal("valid registration proof was rejected")
+	}
+
+	data[len(data)-1] ^= 0xff
+	tampered, err := UnmarshalVoiceRegistration(data)
+	if err != nil {
+		t.Fatalf("UnmarshalVoiceRegistration(tampered): %v", err)
+	}
+	if tampered.Verify(key) {
+		t.Fatal("tampered registration proof was accepted")
+	}
+}
+
+func TestVoiceRegistrationRejectsWrongKeyAndMalformedPackets(t *testing.T) {
+	key := bytes.Repeat([]byte{0x11}, VoiceRegistrationKeySize)
+	wrongKey := bytes.Repeat([]byte{0x22}, VoiceRegistrationKeySize)
+	data, err := MarshalVoiceRegistration(99, 1, key)
+	if err != nil {
+		t.Fatalf("MarshalVoiceRegistration: %v", err)
+	}
+	registration, err := UnmarshalVoiceRegistration(data)
+	if err != nil {
+		t.Fatalf("UnmarshalVoiceRegistration: %v", err)
+	}
+	if registration.Verify(wrongKey) {
+		t.Fatal("registration proof verified with the wrong session key")
+	}
+
+	wrongSession := append([]byte(nil), data...)
+	wrongSession[7] ^= 0x01
+	wrongSessionRegistration, err := UnmarshalVoiceRegistration(wrongSession)
+	if err != nil {
+		t.Fatalf("UnmarshalVoiceRegistration(wrong session): %v", err)
+	}
+	if wrongSessionRegistration.Verify(key) {
+		t.Fatal("registration proof verified after changing the session ID")
+	}
+
+	if _, err := UnmarshalVoiceRegistration(data[:len(data)-1]); err == nil {
+		t.Fatal("short registration packet was accepted")
+	}
+	if _, err := MarshalVoiceRegistration(99, 1, key[:len(key)-1]); err == nil {
+		t.Fatal("invalid registration key length was accepted")
+	}
+}

--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -597,16 +597,17 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 	// Send auth response
 	authResp := &pb.ControlMessage{
 		AuthResponse: &pb.AuthResponse{
-			SessionID:          sessionID,
-			Username:           user.Username,
-			Role:               sessionRole.String(),
-			ChannelScope:       channelScope,
-			EncryptionKey:      s.voiceKey,
-			Channels:           channelInfos,
-			ScreenAddr:         s.cfg.ScreenAddr,
-			ScreenAuthToken:    session.ScreenAuthToken,
-			ScreenShareEnabled: s.cfg.EnableScreenShare,
-			AutoToken:          autoToken,
+			SessionID:            sessionID,
+			Username:             user.Username,
+			Role:                 sessionRole.String(),
+			ChannelScope:         channelScope,
+			EncryptionKey:        s.voiceKey,
+			VoiceRegistrationKey: append([]byte(nil), session.VoiceRegistrationKey...),
+			Channels:             channelInfos,
+			ScreenAddr:           s.cfg.ScreenAddr,
+			ScreenAuthToken:      session.ScreenAuthToken,
+			ScreenShareEnabled:   s.cfg.EnableScreenShare,
+			AutoToken:            autoToken,
 		},
 	}
 	if err := writeControlMessage(conn, authResp); err != nil {

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -6,8 +6,10 @@ import (
 	"encoding/hex"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/NicolasHaas/gospeak/pkg/model"
+	"github.com/NicolasHaas/gospeak/pkg/protocol"
 )
 
 // SessionManager manages active client sessions.
@@ -47,28 +49,31 @@ func (sm *SessionManager) CreateWithChannelScope(userID int64, username string, 
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	// Generate random session ID
+	// Generate random session ID and its independent UDP registration secret.
 	var id uint32
+	var registrationKey []byte
 	for {
-		b := make([]byte, 4)
+		b := make([]byte, 4+protocol.VoiceRegistrationKeySize)
 		if _, err := rand.Read(b); err != nil {
 			panic("crypto/rand failure: " + err.Error())
 		}
 		id = binary.BigEndian.Uint32(b)
-		if id != 0 {
+		if id != 0 && id != protocol.VoiceRegistrationMagic {
 			if _, exists := sm.sessions[id]; !exists {
+				registrationKey = append([]byte(nil), b[4:]...)
 				break
 			}
 		}
 	}
 
 	sess := &model.Session{
-		ID:              id,
-		UserID:          userID,
-		Username:        username,
-		Role:            role,
-		ChannelScope:    channelScope,
-		ScreenAuthToken: newScreenAuthToken(),
+		ID:                   id,
+		UserID:               userID,
+		Username:             username,
+		Role:                 role,
+		ChannelScope:         channelScope,
+		ScreenAuthToken:      newScreenAuthToken(),
+		VoiceRegistrationKey: registrationKey,
 	}
 	sm.sessions[id] = sess
 	return sess
@@ -135,13 +140,24 @@ func (sm *SessionManager) Remove(id uint32) {
 	delete(sm.sessions, id)
 }
 
-// SetUDPAddr sets the UDP address for a session (called after first voice packet).
-func (sm *SessionManager) SetUDPAddr(id uint32, addr *net.UDPAddr) {
+// RegisterUDPAddr authenticates and atomically updates a session's UDP endpoint.
+func (sm *SessionManager) RegisterUDPAddr(id uint32, registration *protocol.VoiceRegistration, addr *net.UDPAddr, now time.Time, rebindInterval time.Duration) bool {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	if s, ok := sm.sessions[id]; ok {
-		s.UDPAddr = cloneUDPAddr(addr)
+	s, ok := sm.sessions[id]
+	if !ok || registration == nil || registration.SessionID != id || !registration.Verify(s.VoiceRegistrationKey) {
+		return false
 	}
+	if registration.Counter <= s.VoiceRegistrationCounter {
+		return false
+	}
+	if s.UDPAddr != nil && !udpAddrEqual(s.UDPAddr, addr) && now.Sub(s.VoiceEndpointUpdatedAt) < rebindInterval {
+		return false
+	}
+	s.UDPAddr = cloneUDPAddr(addr)
+	s.VoiceRegistrationCounter = registration.Counter
+	s.VoiceEndpointUpdatedAt = now
+	return true
 }
 
 // UpdateUserState updates muted/deafened for a session.
@@ -190,6 +206,10 @@ func cloneUDPAddr(addr *net.UDPAddr) *net.UDPAddr {
 		clone.IP = append([]byte(nil), addr.IP...)
 	}
 	return &clone
+}
+
+func udpAddrEqual(left, right *net.UDPAddr) bool {
+	return left != nil && right != nil && left.IP.Equal(right.IP) && left.Port == right.Port && left.Zone == right.Zone
 }
 
 func newScreenAuthToken() string {

--- a/pkg/server/voice.go
+++ b/pkg/server/voice.go
@@ -9,6 +9,8 @@ import (
 	"github.com/NicolasHaas/gospeak/pkg/protocol"
 )
 
+const voiceRebindInterval = 5 * time.Second
+
 // StartVoice starts the UDP voice forwarder.
 func (s *Server) StartVoice() error {
 	addr, err := net.ResolveUDPAddr("udp", s.cfg.VoiceAddr)
@@ -59,6 +61,13 @@ func (s *Server) voiceLoop() {
 			}
 		}
 
+		if protocol.IsVoiceRegistration(buf[:n]) {
+			if !s.handleVoiceRegistration(buf[:n], remoteAddr, time.Now()) {
+				s.metrics.VoicePacketsDropped.Add(1)
+			}
+			continue
+		}
+
 		if n < protocol.VoiceHeaderSize {
 			s.metrics.VoicePacketsDropped.Add(1)
 			continue // too short, discard
@@ -80,13 +89,10 @@ func (s *Server) voiceLoop() {
 			continue // unknown session, discard
 		}
 
-		// Verify UDP source matches registered address (prevent session hijacking).
-		// Only the first packet from a session registers the address; subsequent
-		// packets from different sources are rejected.
-		if session.UDPAddr == nil {
-			s.sessions.SetUDPAddr(pkt.SessionID, remoteAddr)
-		} else if !session.UDPAddr.IP.Equal(remoteAddr.IP) || session.UDPAddr.Port != remoteAddr.Port {
-			continue // source mismatch, drop (prevents UDP session hijack)
+		// Voice is accepted only after a control-authenticated registration proof.
+		if !udpAddrEqual(session.UDPAddr, remoteAddr) {
+			s.metrics.VoicePacketsDropped.Add(1)
+			continue // unregistered or mismatched source
 		}
 
 		// Don't forward if muted
@@ -140,4 +146,12 @@ func (s *Server) voiceLoop() {
 			}
 		}
 	}
+}
+
+func (s *Server) handleVoiceRegistration(data []byte, remoteAddr *net.UDPAddr, now time.Time) bool {
+	registration, err := protocol.UnmarshalVoiceRegistration(data)
+	if err != nil {
+		return false
+	}
+	return s.sessions.RegisterUDPAddr(registration.SessionID, registration, remoteAddr, now, voiceRebindInterval)
 }

--- a/pkg/server/voice_test.go
+++ b/pkg/server/voice_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/NicolasHaas/gospeak/pkg/model"
+	"github.com/NicolasHaas/gospeak/pkg/protocol"
+)
+
+func TestVoiceEndpointRequiresAuthenticatedRegistration(t *testing.T) {
+	srv, _, _ := newTestServer(t)
+	session := srv.sessions.Create(1, "speaker", model.RoleUser)
+	legitimate := &net.UDPAddr{IP: net.ParseIP("192.0.2.10"), Port: 40000}
+	attacker := &net.UDPAddr{IP: net.ParseIP("198.51.100.20"), Port: 50000}
+
+	voice := (&protocol.VoicePacket{SessionID: session.ID, SeqNum: 1}).Marshal()
+	if srv.handleVoiceRegistration(voice, attacker, time.Now()) {
+		t.Fatal("ordinary voice packet registered an endpoint")
+	}
+	if snapshot, _ := srv.sessions.GetSnapshot(session.ID); snapshot.UDPAddr != nil {
+		t.Fatalf("foreign first voice packet bound endpoint to %v", snapshot.UDPAddr)
+	}
+
+	wrongKey := bytes.Repeat([]byte{0x55}, protocol.VoiceRegistrationKeySize)
+	forged, err := protocol.MarshalVoiceRegistration(session.ID, 1, wrongKey)
+	if err != nil {
+		t.Fatalf("MarshalVoiceRegistration(forged): %v", err)
+	}
+	if srv.handleVoiceRegistration(forged, attacker, time.Now()) {
+		t.Fatal("forged registration was accepted")
+	}
+
+	valid, err := protocol.MarshalVoiceRegistration(session.ID, 1, session.VoiceRegistrationKey)
+	if err != nil {
+		t.Fatalf("MarshalVoiceRegistration(valid): %v", err)
+	}
+	if !srv.handleVoiceRegistration(valid, legitimate, time.Now()) {
+		t.Fatal("valid registration was rejected")
+	}
+	if snapshot, _ := srv.sessions.GetSnapshot(session.ID); !udpAddrEqual(snapshot.UDPAddr, legitimate) {
+		t.Fatalf("endpoint = %v, want %v", snapshot.UDPAddr, legitimate)
+	}
+}
+
+func TestVoiceRegistrationRejectsReplayAndRateLimitsRebind(t *testing.T) {
+	srv, _, _ := newTestServer(t)
+	session := srv.sessions.Create(1, "speaker", model.RoleUser)
+	first := &net.UDPAddr{IP: net.ParseIP("192.0.2.10"), Port: 40000}
+	rebound := &net.UDPAddr{IP: net.ParseIP("192.0.2.10"), Port: 40001}
+	now := time.Now()
+
+	registration1, err := protocol.MarshalVoiceRegistration(session.ID, 1, session.VoiceRegistrationKey)
+	if err != nil {
+		t.Fatalf("MarshalVoiceRegistration(1): %v", err)
+	}
+	if !srv.handleVoiceRegistration(registration1, first, now) {
+		t.Fatal("initial registration was rejected")
+	}
+	if srv.handleVoiceRegistration(registration1, rebound, now.Add(time.Second)) {
+		t.Fatal("replayed registration was accepted")
+	}
+
+	registration2, err := protocol.MarshalVoiceRegistration(session.ID, 2, session.VoiceRegistrationKey)
+	if err != nil {
+		t.Fatalf("MarshalVoiceRegistration(2): %v", err)
+	}
+	if srv.handleVoiceRegistration(registration2, rebound, now.Add(time.Second)) {
+		t.Fatal("rapid endpoint rebind was accepted")
+	}
+	if !srv.handleVoiceRegistration(registration2, rebound, now.Add(voiceRebindInterval)) {
+		t.Fatal("authenticated endpoint rebind after rate limit was rejected")
+	}
+}


### PR DESCRIPTION
# Summary

Prevents attackers from binding another session’s voice endpoint using a forged first UDP packet.

- distributes a random per-session registration key over the authenticated control channel
- requires an HMAC-SHA-256 proof before accepting voice packets
- rejects invalid and replayed registration packets
- rate-limits authenticated endpoint rebinding
- preserves direct UDP connectivity without STUN or TURN
- adds protocol, client, aswell as server regression tests

## Breaking Change

Older clients and servers are not voice-compatible with authenticated UDP registration, this is intentional in preparation with other fixes to get gospeak to a v 1.0.0.