### PR TITLE
fix: authenticate tls servers with pki or tofu pins

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,12 +41,6 @@ linters:
         linters:
           - gosec
 
-      # Ignore "G402: TLS InsecureSkipVerify" in client (self-signed certs)
-      - path: pkg/client/
-        linters:
-          - gosec
-        text: "G402"
-
 formatters:
   enable:
     - gofmt

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GoSpeak uses a selective forwarding architecture: the control plane handles sign
 
 - **Real-time voice chat**: Opus codec at 48 kHz, 20ms frames via PortAudio
 - **Encrypted voice**: AES-128-GCM with authenticated headers; server relays without decoding (see [Security](docs/security.md) for key model caveats)
-- **TLS 1.3 control plane**: auto-generated self-signed certificates or bring your own
+- **Authenticated TLS 1.3 control plane**: system PKI for public certificates and explicit TOFU fingerprint pinning for self-signed servers
 - **Channel system**: hierarchical channels with sub-channels, temporary channels, max-user limits
 - **Role-based access control**: Admin, Moderator, User roles with granular permissions
 - **Token-based authentication**: 256-bit random tokens, SHA-256 hashed storage
@@ -60,6 +60,10 @@ Download the appropriate binary for your platform from [Releases](https://github
 ```
 
 Enter the server address, your username, and (optionally) an invite token to connect. On first login the server issues a personal token; keep it to reconnect with the same username.
+
+For a self-signed server, the client displays its SHA-256 public-key fingerprint before sending credentials. Verify that fingerprint with the server operator through a trusted channel, then choose **Trust and Connect**. The saved pin is checked for both control and screen connections. A later identity change is a hard connection failure and requires an explicit **Re-trust and Connect** confirmation after the new fingerprint has been verified. Publicly trusted certificates are validated with the operating system's CA store and hostname checks without a TOFU prompt.
+
+Existing bookmark files remain compatible. They gain a `trusted_server_pins` section after the first self-signed server is trusted; no pin is silently created during migration.
 
 ## Architecture
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,6 +9,7 @@ GoSpeak is designed with security as a core principle. All communication is encr
 | Threat | Mitigation |
 |--------|-----------|
 | Network eavesdropping | TLS 1.3 for control and screen planes, AES-128-GCM for voice and screen media |
+| Active network MITM | System-PKI hostname verification or an explicitly confirmed TOFU public-key pin, shared by control and screen connections |
 | Server compromise (media) | Server holds the generated media keys and _could_ decrypt — see note above. Mitigated by running your own trusted server |
 | Replay attacks | Deterministic nonces from SessionID + SeqNum prevent replay |
 | Unauthorized access | Token-based auth with SHA-256 hashed storage, RBAC |
@@ -53,7 +54,9 @@ graph TB
 - Custom matching certificate/key pairs, including self-signed pairs, can be provided via `-cert` and `-key`
 - Certificate handling fails closed: partial configuration, missing files, malformed PEM, mismatched keys, or damaged automatic files stop startup without overwriting existing material
 - Automatically generated files are published without replacing existing paths; the private key is created with mode `0600`
-- Client currently uses `InsecureSkipVerify` for self-signed certs (suitable for private deployments)
+- Clients first try normal system-PKI and hostname verification. A certificate that is not publicly trusted is rejected until the user verifies and explicitly accepts its SHA-256 SubjectPublicKeyInfo fingerprint
+- Accepted TOFU pins are stored by normalized control address in the bookmark file. Subsequent control connections require the same public key; screen connections require the exact identity established by the control connection
+- A changed TOFU pin is treated as a possible MITM and blocks the connection. Replacing it requires an explicit re-trust confirmation that displays both fingerprints
 
 ### TLS Configuration
 
@@ -63,6 +66,12 @@ tlsCfg := &tls.Config{
     MinVersion:   tls.VersionTLS13,
 }
 ```
+
+The client uses `VerifyConnection` as the mandatory verification path. Public certificates are checked against the operating-system roots and requested hostname. For a saved self-signed server, the callback compares the peer's SHA-256 SPKI fingerprint to the stored pin and also rejects certificates outside their validity period. `InsecureSkipVerify` is set only to delegate the built-in verification to that non-optional callback; it never means unconditional acceptance.
+
+### Self-Signed Upgrade and Recovery
+
+Existing bookmarks load without a pin and therefore prompt on their first connection after upgrading. Compare the displayed fingerprint with a value obtained directly from the server operator before accepting it. If a server certificate or key is intentionally replaced, the next connection fails with an identity-change warning. Verify the new fingerprint independently before using the explicit re-trust action. Do not re-trust an unexpected change merely to restore connectivity.
 
 ## Voice Encryption (AES-128-GCM)
 

--- a/pkg/client/bookmarks.go
+++ b/pkg/client/bookmarks.go
@@ -19,8 +19,9 @@ type Bookmark struct {
 
 // BookmarkStore manages server bookmarks stored next to the binary.
 type BookmarkStore struct {
-	path      string
-	Bookmarks []Bookmark `yaml:"bookmarks"`
+	path              string
+	Bookmarks         []Bookmark        `yaml:"bookmarks"`
+	TrustedServerPins map[string]string `yaml:"trusted_server_pins,omitempty"`
 }
 
 // NewBookmarkStore creates a bookmark store using a file next to the executable.
@@ -54,7 +55,24 @@ func (bs *BookmarkStore) Save() error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(bs.path, data, 0600)
+	if err := os.WriteFile(bs.path, data, 0600); err != nil {
+		return err
+	}
+	return os.Chmod(bs.path, 0600)
+}
+
+// PinForAddr returns the saved TOFU identity for a control address.
+func (bs *BookmarkStore) PinForAddr(controlAddr string) string {
+	return bs.TrustedServerPins[controlAddr]
+}
+
+// TrustServer records an explicitly accepted TOFU identity for a control
+// address. Calling it again is the explicit re-trust operation.
+func (bs *BookmarkStore) TrustServer(controlAddr, fingerprint string) {
+	if bs.TrustedServerPins == nil {
+		bs.TrustedServerPins = make(map[string]string)
+	}
+	bs.TrustedServerPins[controlAddr] = fingerprint
 }
 
 // Add adds or updates a bookmark. Returns true if it was a new entry.

--- a/pkg/client/bookmarks_test.go
+++ b/pkg/client/bookmarks_test.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBookmarkStorePersistsTrustedServerPin(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "servers.yaml")
+	store := &BookmarkStore{path: path}
+	store.TrustServer("example.test:9600", "SHA256:abc")
+	if err := store.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded := &BookmarkStore{path: path}
+	if err := loaded.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if got := loaded.PinForAddr("example.test:9600"); got != "SHA256:abc" {
+		t.Fatalf("PinForAddr() = %q, want %q", got, "SHA256:abc")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("bookmark mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestBookmarkStoreLoadsFileWithoutTrustPins(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "servers.yaml")
+	if err := os.WriteFile(path, []byte("bookmarks:\n  - name: old\n    control_addr: old.test:9600\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	store := &BookmarkStore{path: path}
+	if err := store.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.PinForAddr("old.test:9600"); got != "" {
+		t.Fatalf("PinForAddr() = %q, want empty", got)
+	}
+}

--- a/pkg/client/control.go
+++ b/pkg/client/control.go
@@ -23,17 +23,18 @@ type EventHandler func(msg *pb.ControlMessage)
 
 // ControlClient manages the TCP/TLS control plane connection.
 type ControlClient struct {
-	conn    net.Conn
-	mu      sync.Mutex
-	handler EventHandler
-	done    chan struct{}
+	conn           net.Conn
+	serverIdentity string
+	mu             sync.Mutex
+	handler        EventHandler
+	done           chan struct{}
 }
 
 // NewControlClient connects to the server's control plane via TLS.
-func NewControlClient(addr string) (*ControlClient, error) {
-	tlsCfg := &tls.Config{
-		InsecureSkipVerify: true, // MVP: accept self-signed certs (TOFU model)
-		MinVersion:         tls.VersionTLS13,
+func NewControlClient(addr, expectedPin string) (*ControlClient, error) {
+	tlsCfg, err := tlsConfig(addr, expectedPin)
+	if err != nil {
+		return nil, err
 	}
 
 	dialer := &tls.Dialer{Config: tlsCfg}
@@ -43,10 +44,16 @@ func NewControlClient(addr string) (*ControlClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("client: connect control: %w", err)
 	}
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok || len(tlsConn.ConnectionState().PeerCertificates) == 0 {
+		_ = conn.Close()
+		return nil, fmt.Errorf("client: control connection has no TLS peer identity")
+	}
 
 	return &ControlClient{
-		conn: conn,
-		done: make(chan struct{}),
+		conn:           conn,
+		serverIdentity: SPKIFingerprint(tlsConn.ConnectionState().PeerCertificates[0]),
+		done:           make(chan struct{}),
 	}, nil
 }
 

--- a/pkg/client/engine.go
+++ b/pkg/client/engine.go
@@ -154,7 +154,7 @@ func (f *defaultDecoderFactory) NewDecoder() (audio.AudioDecoder, error) {
 }
 
 // Connect authenticates to the server and starts audio/voice pipelines.
-func (e *Engine) Connect(controlAddr, voiceAddr, token, username string) error {
+func (e *Engine) Connect(controlAddr, voiceAddr, token, username, serverPin string) error {
 	e.mu.Lock()
 	if e.state != StateDisconnected {
 		e.mu.Unlock()
@@ -166,7 +166,7 @@ func (e *Engine) Connect(controlAddr, voiceAddr, token, username string) error {
 	e.notifyStateChange(StateConnecting)
 
 	// Connect control plane
-	ctrl, err := NewControlClient(controlAddr)
+	ctrl, err := NewControlClient(controlAddr, serverPin)
 	if err != nil {
 		e.setState(StateDisconnected)
 		return err
@@ -211,7 +211,7 @@ func (e *Engine) Connect(controlAddr, voiceAddr, token, username string) error {
 			e.setState(StateDisconnected)
 			return fmt.Errorf("resolve screen address: %w", err)
 		} else {
-			screen, err = NewScreenClient(screenAddr, authResp.SessionID, authResp.ScreenAuthToken)
+			screen, err = NewScreenClient(screenAddr, authResp.SessionID, authResp.ScreenAuthToken, ctrl.serverIdentity)
 			if err != nil {
 				_ = ctrl.Close()
 				_ = voice.Close()

--- a/pkg/client/screen.go
+++ b/pkg/client/screen.go
@@ -22,10 +22,10 @@ type ScreenClient struct {
 	done    chan struct{}
 }
 
-func NewScreenClient(addr string, sessionID uint32, authToken string) (*ScreenClient, error) {
-	tlsCfg := &tls.Config{
-		InsecureSkipVerify: true,
-		MinVersion:         tls.VersionTLS13,
+func NewScreenClient(addr string, sessionID uint32, authToken, serverIdentity string) (*ScreenClient, error) {
+	tlsCfg, err := tlsConfig(addr, serverIdentity)
+	if err != nil {
+		return nil, err
 	}
 
 	dialer := &tls.Dialer{Config: tlsCfg}

--- a/pkg/client/tlstrust.go
+++ b/pkg/client/tlstrust.go
@@ -1,0 +1,99 @@
+package client
+
+import (
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// UntrustedServerError reports a certificate that is not trusted by the
+// platform PKI and has no saved TOFU pin.
+type UntrustedServerError struct {
+	Addr        string
+	Fingerprint string
+}
+
+func (e *UntrustedServerError) Error() string {
+	return fmt.Sprintf("server %s is not trusted; certificate fingerprint %s", e.Addr, e.Fingerprint)
+}
+
+// ServerIdentityChangedError reports that a server no longer presents its
+// saved TOFU identity. Callers must require an explicit re-trust action.
+type ServerIdentityChangedError struct {
+	Addr     string
+	Expected string
+	Received string
+}
+
+func (e *ServerIdentityChangedError) Error() string {
+	return fmt.Sprintf("server identity changed for %s (expected %s, received %s)", e.Addr, e.Expected, e.Received)
+}
+
+// SPKIFingerprint returns a stable SHA-256 fingerprint of a certificate's
+// SubjectPublicKeyInfo. Pinning the public key tolerates certificate renewal
+// with the same key while detecting an unexpected server identity.
+func SPKIFingerprint(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	return "SHA256:" + base64.StdEncoding.EncodeToString(sum[:])
+}
+
+func newTLSConfig(addr, expectedPin string, roots *x509.CertPool) (*tls.Config, error) {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("client: invalid TLS address %q: %w", addr, err)
+	}
+	host = strings.Trim(host, "[]")
+
+	cfg := &tls.Config{
+		MinVersion:         tls.VersionTLS13,
+		ServerName:         host,
+		RootCAs:            roots,
+		InsecureSkipVerify: true, //nolint:gosec // VerifyConnection below enforces PKI or an exact TOFU pin.
+	}
+	cfg.VerifyConnection = func(state tls.ConnectionState) error {
+		if len(state.PeerCertificates) == 0 {
+			return fmt.Errorf("client: server %s provided no certificate", addr)
+		}
+		leaf := state.PeerCertificates[0]
+		fingerprint := SPKIFingerprint(leaf)
+
+		if expectedPin != "" {
+			if fingerprint != expectedPin {
+				return &ServerIdentityChangedError{Addr: addr, Expected: expectedPin, Received: fingerprint}
+			}
+			pinnedRoots := x509.NewCertPool()
+			pinnedRoots.AddCert(leaf)
+			if _, err := leaf.Verify(x509.VerifyOptions{
+				Roots:     pinnedRoots,
+				KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			}); err != nil {
+				return fmt.Errorf("client: pinned certificate for %s is invalid: %w", addr, err)
+			}
+			return nil
+		}
+
+		intermediates := x509.NewCertPool()
+		for _, cert := range state.PeerCertificates[1:] {
+			intermediates.AddCert(cert)
+		}
+		_, verifyErr := leaf.Verify(x509.VerifyOptions{
+			DNSName:       host,
+			Roots:         roots,
+			Intermediates: intermediates,
+			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		})
+		if verifyErr == nil {
+			return nil
+		}
+		return &UntrustedServerError{Addr: addr, Fingerprint: fingerprint}
+	}
+	return cfg, nil
+}
+
+func tlsConfig(addr, expectedPin string) (*tls.Config, error) {
+	return newTLSConfig(addr, expectedPin, nil)
+}

--- a/pkg/client/tlstrust_test.go
+++ b/pkg/client/tlstrust_test.go
@@ -1,0 +1,129 @@
+package client
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func TestTLSConfigAcceptsSystemPKI(t *testing.T) {
+	root, rootKey := newTestCertificate(t, nil, nil, true, "root", time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	leaf, _ := newTestCertificate(t, root, rootKey, false, "server.test", time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	roots := x509.NewCertPool()
+	roots.AddCert(root)
+
+	cfg, err := newTLSConfig("server.test:9600", "", roots)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.VerifyConnection(connectionState(leaf, root)); err != nil {
+		t.Fatalf("VerifyConnection() = %v, want valid PKI certificate accepted", err)
+	}
+}
+
+func TestTLSConfigRequiresTrustForSelfSignedCertificate(t *testing.T) {
+	cert, _ := newTestCertificate(t, nil, nil, true, "private.test", time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	cfg, err := newTLSConfig("private.test:9600", "", x509.NewCertPool())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cfg.VerifyConnection(connectionState(cert))
+	var untrusted *UntrustedServerError
+	if !errors.As(err, &untrusted) {
+		t.Fatalf("VerifyConnection() error = %v, want UntrustedServerError", err)
+	}
+	if untrusted.Fingerprint != SPKIFingerprint(cert) {
+		t.Fatalf("fingerprint = %q, want %q", untrusted.Fingerprint, SPKIFingerprint(cert))
+	}
+}
+
+func TestTLSConfigAcceptsPinnedSelfSignedCertificate(t *testing.T) {
+	cert, _ := newTestCertificate(t, nil, nil, true, "private.test", time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	cfg, err := newTLSConfig("private.test:9600", SPKIFingerprint(cert), x509.NewCertPool())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.VerifyConnection(connectionState(cert)); err != nil {
+		t.Fatalf("VerifyConnection() = %v, want pinned certificate accepted", err)
+	}
+}
+
+func TestTLSConfigRejectsChangedPin(t *testing.T) {
+	oldCert, _ := newTestCertificate(t, nil, nil, true, "private.test", time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	newCert, _ := newTestCertificate(t, nil, nil, true, "private.test", time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	cfg, err := newTLSConfig("private.test:9600", SPKIFingerprint(oldCert), x509.NewCertPool())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cfg.VerifyConnection(connectionState(newCert))
+	var changed *ServerIdentityChangedError
+	if !errors.As(err, &changed) {
+		t.Fatalf("VerifyConnection() error = %v, want ServerIdentityChangedError", err)
+	}
+	if changed.Expected != SPKIFingerprint(oldCert) || changed.Received != SPKIFingerprint(newCert) {
+		t.Fatalf("changed identity = %#v", changed)
+	}
+}
+
+func TestTLSConfigRejectsExpiredPinnedCertificate(t *testing.T) {
+	cert, _ := newTestCertificate(t, nil, nil, true, "private.test", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+	cfg, err := newTLSConfig("private.test:9600", SPKIFingerprint(cert), x509.NewCertPool())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.VerifyConnection(connectionState(cert)); err == nil {
+		t.Fatal("VerifyConnection() = nil, want expired certificate rejected")
+	}
+}
+
+func connectionState(certs ...*x509.Certificate) tls.ConnectionState {
+	return tls.ConnectionState{PeerCertificates: certs}
+}
+
+func newTestCertificate(t *testing.T, parent *x509.Certificate, parentKey *ecdsa.PrivateKey, isCA bool, dnsName string, notBefore, notAfter time.Time) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: dnsName},
+		DNSNames:              []string{dnsName},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		BasicConstraintsValid: true,
+		IsCA:                  isCA,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	if isCA {
+		tmpl.KeyUsage |= x509.KeyUsageCertSign
+	}
+	if parent == nil {
+		parent = tmpl
+		parentKey = key
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, parent, &key.PublicKey, parentKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert, key
+}

--- a/ui/app.go
+++ b/ui/app.go
@@ -2,6 +2,7 @@
 package ui
 
 import (
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -900,31 +901,72 @@ func (a *App) showConnectDialog() {
 			a.connectServer = controlAddr
 			a.connectVoice = voiceAddr
 
-			go func() {
-				if err := a.engine.Connect(controlAddr, voiceAddr, token, username); err != nil {
-					slog.Error("connect failed", "err", err)
-					fyne.Do(func() {
-						dialog.ShowError(fmt.Errorf("connection failed: %v", err), a.window)
-					})
-					return
-				}
-				if saveCheck.Checked {
-					a.saveCurrentBookmark(username)
-					return
-				}
-				if selectedBookmark != nil {
-					if a.bookmarks.Touch(selectedBookmark.ControlAddr, selectedBookmark.Username, time.Now().Unix()) {
-						if err := a.bookmarks.Save(); err != nil {
-							slog.Error("failed to save bookmark", "err", err)
+			saveServer := saveCheck.Checked
+			var connect func(string)
+			connect = func(serverPin string) {
+				go func() {
+					if err := a.engine.Connect(controlAddr, voiceAddr, token, username, serverPin); err != nil {
+						var untrusted *client.UntrustedServerError
+						var changed *client.ServerIdentityChangedError
+						if errors.As(err, &untrusted) {
+							fyne.Do(func() {
+								a.confirmServerTrust(controlAddr, untrusted.Fingerprint, "", connect)
+							})
+							return
+						}
+						if errors.As(err, &changed) {
+							fyne.Do(func() {
+								a.confirmServerTrust(controlAddr, changed.Received, changed.Expected, connect)
+							})
+							return
+						}
+						slog.Error("connect failed", "err", err)
+						fyne.Do(func() {
+							dialog.ShowError(fmt.Errorf("connection failed: %v", err), a.window)
+						})
+						return
+					}
+					if saveServer {
+						a.saveCurrentBookmark(username)
+						return
+					}
+					if selectedBookmark != nil {
+						if a.bookmarks.Touch(selectedBookmark.ControlAddr, selectedBookmark.Username, time.Now().Unix()) {
+							if err := a.bookmarks.Save(); err != nil {
+								slog.Error("failed to save bookmark", "err", err)
+							}
 						}
 					}
-				}
-			}()
+				}()
+			}
+			connect(a.bookmarks.PinForAddr(controlAddr))
 		},
 		a.window,
 	)
 	d.Resize(fyne.NewSize(420, 420))
 	d.Show()
+}
+
+func (a *App) confirmServerTrust(controlAddr, received, expected string, connect func(string)) {
+	title := "Trust New Server Identity"
+	confirm := "Trust and Connect"
+	message := fmt.Sprintf("Verify this server fingerprint through a trusted channel before continuing:\n\n%s\n\nServer: %s", received, controlAddr)
+	if expected != "" {
+		title = "Server Identity Changed"
+		confirm = "Re-trust and Connect"
+		message = fmt.Sprintf("WARNING: the saved server identity changed. This can indicate a man-in-the-middle attack. Re-trust only after verifying the new fingerprint through a trusted channel.\n\nSaved: %s\nNew:   %s\n\nServer: %s", expected, received, controlAddr)
+	}
+	dialog.NewCustomConfirm(title, confirm, "Cancel", widget.NewLabel(message), func(ok bool) {
+		if !ok {
+			return
+		}
+		a.bookmarks.TrustServer(controlAddr, received)
+		if err := a.bookmarks.Save(); err != nil {
+			dialog.ShowError(fmt.Errorf("save trusted server identity: %w", err), a.window)
+			return
+		}
+		connect(received)
+	}, a.window).Show()
 }
 
 // ----- Admin / Settings dialogs -----


### PR DESCRIPTION
## Summary

Authenticates TLS server identities instead of accepting arbitrary certificates.

- validates publicly trusted certificates using the system CA store and hostname checks
- adds explicit TOFU pinning for self-signed servers using SHA-256 SPKI fingerprints
- prompts users to verify a fingerprint before sending credentials
- blocks changed server identities until they are explicitly trusted
- requires control and screen connections to use the same trusted identity
- stores pins per server while keeping existing bookmark files compatible
- documents first trust, certificate changes, and recovery behavior
- adds regression coverage for PKI validation, TOFU pins, identity changes, expired certificates and bookmark persistence
