### PR TITLE
fix: guarantee unique voice gcm nonces

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -226,14 +226,15 @@ The server does **not** decode voice packets. It:
 
 ### Nonce Construction
 
-The AES-128-GCM nonce (12 bytes) is deterministic and never reused:
+The AES-128-GCM nonce (12 bytes) is deterministic and never reused while a voice key is active:
 
 ```
 Nonce = [SessionID (4B)] [SeqNum (4B)] [0x00 0x00 0x00 0x00 (4B)]
 ```
 
-- `SessionID` is unique per connection (assigned by server)
-- `SeqNum` is a monotonically increasing `uint32` per sender (~994 days at 50 packets/sec before wrap)
+- `SessionID` is allocated from a random starting point and is never issued again during the server lifecycle, even after its session disconnects
+- the shared voice key is generated for that same server lifecycle, so historical sessions cannot repeat a nonce under the same key
+- `SeqNum` starts at one and increases monotonically per sender; the client refuses to send after `uint32` exhaustion and requires a reconnect instead of wrapping to zero
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -11,7 +11,7 @@ GoSpeak is designed with security as a core principle. All communication is encr
 | Network eavesdropping | TLS 1.3 for control and screen planes, AES-128-GCM for voice and screen media |
 | Active network MITM | System-PKI hostname verification or an explicitly confirmed TOFU public-key pin, shared by control and screen connections |
 | Server compromise (media) | Server holds the generated media keys and _could_ decrypt — see note above. Mitigated by running your own trusted server |
-| Replay attacks | Deterministic nonces from SessionID + SeqNum prevent replay |
+| GCM nonce reuse | Session IDs are never reissued while a voice key is active, and clients fail closed before sequence-number wrap |
 | Unauthorized access | Token-based auth with SHA-256 hashed storage, RBAC |
 | UDP endpoint hijacking | Per-session HMAC registration proof from the TLS control channel, monotonic registration counters, and rate-limited rebinding |
 | Brute force tokens | Tokens are 256-bit random (64-char hex), hashed with SHA-256 |
@@ -110,15 +110,17 @@ For each voice packet:
    - Bytes 4-7: `SeqNum` (uint32, big-endian)
    - Bytes 8-11: `0x00000000` (padding)
 
+   Session IDs are allocated without reuse for the lifetime of the shared voice key, including after disconnect. Sequence numbers start at one and may not wrap; an exhausted sender must reconnect before sending more voice data.
+
 2. **Authenticated encryption**:
    - **Algorithm**: AES-128-GCM
    - **Plaintext**: Opus-encoded audio frame
-   - **Additional Data (AD)**: 8-byte packet header (SessionID + SeqNum)
+   - **Additional Data (AD)**: 14-byte packet header (SessionID + SeqNum + Timestamp + ChannelID)
    - **Output**: Ciphertext + 16-byte authentication tag
 
 3. **Packet assembly**:
    ```
-   [SessionID:4B][SeqNum:4B][Ciphertext + AuthTag]
+   [SessionID:4B][SeqNum:4B][Timestamp:4B][ChannelID:2B][Ciphertext + AuthTag]
    ```
 
 ### Security Properties
@@ -127,8 +129,8 @@ For each voice packet:
 |----------|------------------|
 | **Confidentiality** | AES-128-GCM encryption of Opus frames |
 | **Integrity** | GCM authentication tag (16 bytes) |
-| **Authenticity** | Header (SessionID + SeqNum) is authenticated as additional data |
-| **Anti-replay** | Monotonic sequence numbers in nonce prevent reuse |
+| **Authenticity** | The complete 14-byte voice header is authenticated as additional data |
+| **Nonce uniqueness** | Session IDs are not reissued under the same key, and sequence wrap fails closed |
 | **Forward secrecy** | New key generated on each server restart |
 
 ## Screen Share Encryption (AES-128-GCM)

--- a/pkg/client/voice.go
+++ b/pkg/client/voice.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -9,6 +10,8 @@ import (
 	gospeakCrypto "github.com/NicolasHaas/gospeak/pkg/crypto"
 	"github.com/NicolasHaas/gospeak/pkg/protocol"
 )
+
+var ErrVoiceSequenceExhausted = errors.New("client: voice sequence exhausted; reconnect required")
 
 // VoiceClient manages the UDP voice connection.
 type VoiceClient struct {
@@ -89,6 +92,10 @@ func (v *VoiceClient) SetChannel(channelID int64) {
 // SendVoice encrypts and sends an Opus frame over UDP.
 func (v *VoiceClient) SendVoice(opusData []byte, timestamp uint32) error {
 	v.mu.Lock()
+	if v.seqNum == ^uint32(0) {
+		v.mu.Unlock()
+		return ErrVoiceSequenceExhausted
+	}
 	v.seqNum++
 	seqNum := v.seqNum
 	channelID := v.channelID

--- a/pkg/client/voice_test.go
+++ b/pkg/client/voice_test.go
@@ -2,12 +2,35 @@ package client
 
 import (
 	"bytes"
+	"errors"
+	"math"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/NicolasHaas/gospeak/pkg/protocol"
 )
+
+func TestSendVoiceRefusesSequenceWrap(t *testing.T) {
+	listener, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("ListenUDP: %v", err)
+	}
+	defer listener.Close()
+
+	registrationKey := bytes.Repeat([]byte{0x42}, protocol.VoiceRegistrationKeySize)
+	voiceKey := bytes.Repeat([]byte{0x24}, 16)
+	client, err := NewVoiceClient(listener.LocalAddr().String(), 1234, voiceKey, registrationKey)
+	if err != nil {
+		t.Fatalf("NewVoiceClient: %v", err)
+	}
+	defer client.Close()
+
+	client.seqNum = math.MaxUint32
+	if err := client.SendVoice([]byte("frame"), 1); !errors.Is(err, ErrVoiceSequenceExhausted) {
+		t.Fatalf("SendVoice error = %v, want %v", err, ErrVoiceSequenceExhausted)
+	}
+}
 
 func TestNewVoiceClientRegistersEndpointImmediately(t *testing.T) {
 	listener, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -67,8 +67,9 @@ func NewVoiceCipher(key []byte) (*VoiceCipher, error) {
 }
 
 // buildNonce constructs a 12-byte nonce from sessionID and seqNum.
-// Format: [sessionID(4) | seqNum(4) | zeros(4)]
-// uint32 seqNum gives ~994 days at 50 pkt/s before wrap (vs ~21 min with uint16).
+// Format: [sessionID(4) | seqNum(4) | zeros(4)].
+// The server never reissues a session ID during a voice-key lifetime, and the
+// client refuses to send when the uint32 sequence space is exhausted.
 func buildNonce(sessionID uint32, seqNum uint32) []byte {
 	nonce := make([]byte, 12)
 	binary.BigEndian.PutUint32(nonce[0:4], sessionID)

--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -551,7 +551,12 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 	}
 
 	// Create session (voice key is shared server-wide for SFU model)
-	session := s.sessions.CreateWithChannelScope(user.ID, user.Username, sessionRole, channelScope)
+	session, err := s.sessions.CreateWithChannelScope(user.ID, user.Username, sessionRole, channelScope)
+	if err != nil {
+		slog.Error("create session", "err", err)
+		sendError(conn, 3, "could not create session")
+		return
+	}
 	sessionID := session.ID
 
 	defer func() {

--- a/pkg/server/screenshare_test.go
+++ b/pkg/server/screenshare_test.go
@@ -124,7 +124,7 @@ func TestScreenShareManager_ExpireInactiveStopsShare(t *testing.T) {
 
 func TestSessionManager_ValidateScreenAuth(t *testing.T) {
 	sm := NewSessionManager()
-	session := sm.Create(1, "alice", 0)
+	session := mustCreateSession(t, sm, 1, "alice", 0)
 
 	if !sm.ValidateScreenAuth(session.ID, session.ScreenAuthToken) {
 		t.Fatalf("ValidateScreenAuth(valid) = false, want true")

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -91,7 +91,7 @@ func TestHandleJoinLeaveChannel(t *testing.T) {
 		t.Fatalf("CreateChannel: %v", err)
 	}
 
-	session := srv.sessions.Create(1, "johndoe", model.RoleUser)
+	session := mustCreateSession(t, srv.sessions, 1, "johndoe", model.RoleUser)
 
 	srv.handleJoinChannel(handler, session.ID, &pb.JoinChannelRequest{ChannelID: ch.ID}, st, conn)
 	joinedChannel := srv.channels.ChannelOf(session.ID)
@@ -135,7 +135,7 @@ func TestHandleJoinChannelEnforcesSessionScope(t *testing.T) {
 		t.Fatalf("CreateChannel(other): %v", err)
 	}
 
-	session := srv.sessions.CreateWithChannelScope(1, "scoped-user", model.RoleUser, scopedChannel.ID)
+	session := mustCreateScopedSession(t, srv.sessions, 1, "scoped-user", model.RoleUser, scopedChannel.ID)
 	rejection := &bufferConn{}
 	srv.handleJoinChannel(handler, session.ID, &pb.JoinChannelRequest{ChannelID: otherChannel.ID}, st, rejection)
 	response, err := protocol.ReadControlMessage(rejection)
@@ -158,7 +158,7 @@ func TestHandleJoinChannelEnforcesSessionScope(t *testing.T) {
 func TestHandleUserState(t *testing.T) {
 	srv, st, handler := newTestServer(t)
 
-	session := srv.sessions.Create(1, "johndoe", model.RoleUser)
+	session := mustCreateSession(t, srv.sessions, 1, "johndoe", model.RoleUser)
 
 	srv.handleUserState(handler, session.ID, &pb.UserStateUpdate{Muted: true, Deafened: true}, st)
 
@@ -173,9 +173,9 @@ func TestHandleUserState(t *testing.T) {
 
 func TestHandleKickUserClosesEverySession(t *testing.T) {
 	srv, _, handler := newTestServer(t)
-	admin := srv.sessions.Create(1, "admin", model.RoleAdmin)
-	targetOne := srv.sessions.Create(2, "target", model.RoleUser)
-	targetTwo := srv.sessions.Create(2, "target", model.RoleUser)
+	admin := mustCreateSession(t, srv.sessions, 1, "admin", model.RoleAdmin)
+	targetOne := mustCreateSession(t, srv.sessions, 2, "target", model.RoleUser)
+	targetTwo := mustCreateSession(t, srv.sessions, 2, "target", model.RoleUser)
 	connOne := registerTestConn(handler, targetOne.ID)
 	connTwo := registerTestConn(handler, targetTwo.ID)
 
@@ -195,9 +195,9 @@ func TestHandleBanUserClosesEverySession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateUser(target): %v", err)
 	}
-	admin := srv.sessions.Create(adminUser.ID, adminUser.Username, adminUser.Role)
-	targetOne := srv.sessions.Create(targetUser.ID, targetUser.Username, targetUser.Role)
-	targetTwo := srv.sessions.Create(targetUser.ID, targetUser.Username, targetUser.Role)
+	admin := mustCreateSession(t, srv.sessions, adminUser.ID, adminUser.Username, adminUser.Role)
+	targetOne := mustCreateSession(t, srv.sessions, targetUser.ID, targetUser.Username, targetUser.Role)
+	targetTwo := mustCreateSession(t, srv.sessions, targetUser.ID, targetUser.Username, targetUser.Role)
 	connOne := registerTestConn(handler, targetOne.ID)
 	connTwo := registerTestConn(handler, targetTwo.ID)
 
@@ -217,9 +217,9 @@ func TestHandleSetUserRoleUpdatesEverySession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateUser(target): %v", err)
 	}
-	admin := srv.sessions.Create(adminUser.ID, adminUser.Username, adminUser.Role)
-	targetOne := srv.sessions.Create(targetUser.ID, targetUser.Username, targetUser.Role)
-	targetTwo := srv.sessions.Create(targetUser.ID, targetUser.Username, targetUser.Role)
+	admin := mustCreateSession(t, srv.sessions, adminUser.ID, adminUser.Username, adminUser.Role)
+	targetOne := mustCreateSession(t, srv.sessions, targetUser.ID, targetUser.Username, targetUser.Role)
+	targetTwo := mustCreateSession(t, srv.sessions, targetUser.ID, targetUser.Username, targetUser.Role)
 
 	srv.handleSetUserRole(handler, admin.ID, &pb.SetUserRoleRequest{TargetUserID: targetUser.ID, NewRole: model.RoleUser.String()}, st, &nopConn{})
 

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -4,6 +4,9 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
 	"net"
 	"sync"
 	"time"
@@ -14,9 +17,16 @@ import (
 
 // SessionManager manages active client sessions.
 type SessionManager struct {
-	mu       sync.RWMutex
-	sessions map[uint32]*model.Session // sessionID -> session
+	mu               sync.RWMutex
+	sessions         map[uint32]*model.Session // sessionID -> session
+	nextSessionID    uint32
+	issuedSessionIDs uint64
+	sessionIDSeeded  bool
 }
+
+var ErrSessionIDExhausted = errors.New("server: session ID space exhausted")
+
+const usableSessionIDs = uint64(math.MaxUint32) - 1 // zero and the registration magic are reserved
 
 // SessionSnapshot is an immutable view of a session.
 type SessionSnapshot struct {
@@ -40,30 +50,26 @@ func NewSessionManager() *SessionManager {
 }
 
 // Create creates a new session for an authenticated user.
-func (sm *SessionManager) Create(userID int64, username string, role model.Role) *model.Session {
+func (sm *SessionManager) Create(userID int64, username string, role model.Role) (*model.Session, error) {
 	return sm.CreateWithChannelScope(userID, username, role, 0)
 }
 
 // CreateWithChannelScope creates a session with a persistent invite restriction.
-func (sm *SessionManager) CreateWithChannelScope(userID int64, username string, role model.Role, channelScope int64) *model.Session {
+func (sm *SessionManager) CreateWithChannelScope(userID int64, username string, role model.Role, channelScope int64) (*model.Session, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	// Generate random session ID and its independent UDP registration secret.
-	var id uint32
-	var registrationKey []byte
-	for {
-		b := make([]byte, 4+protocol.VoiceRegistrationKeySize)
-		if _, err := rand.Read(b); err != nil {
-			panic("crypto/rand failure: " + err.Error())
-		}
-		id = binary.BigEndian.Uint32(b)
-		if id != 0 && id != protocol.VoiceRegistrationMagic {
-			if _, exists := sm.sessions[id]; !exists {
-				registrationKey = append([]byte(nil), b[4:]...)
-				break
-			}
-		}
+	id, err := sm.nextIDLocked()
+	if err != nil {
+		return nil, err
+	}
+	registrationKey := make([]byte, protocol.VoiceRegistrationKeySize)
+	if _, err := rand.Read(registrationKey); err != nil {
+		return nil, fmt.Errorf("server: generate voice registration key: %w", err)
+	}
+	screenAuthToken, err := newScreenAuthToken()
+	if err != nil {
+		return nil, err
 	}
 
 	sess := &model.Session{
@@ -72,11 +78,37 @@ func (sm *SessionManager) CreateWithChannelScope(userID int64, username string, 
 		Username:             username,
 		Role:                 role,
 		ChannelScope:         channelScope,
-		ScreenAuthToken:      newScreenAuthToken(),
+		ScreenAuthToken:      screenAuthToken,
 		VoiceRegistrationKey: registrationKey,
 	}
 	sm.sessions[id] = sess
-	return sess
+	return sess, nil
+}
+
+// nextIDLocked allocates each usable uint32 exactly once for this manager's
+// lifetime. The server voice key is scoped to the same server lifecycle, so a
+// reused (session ID, sequence number) GCM nonce is impossible.
+func (sm *SessionManager) nextIDLocked() (uint32, error) {
+	if sm.issuedSessionIDs >= usableSessionIDs {
+		return 0, ErrSessionIDExhausted
+	}
+	if !sm.sessionIDSeeded {
+		var seed [4]byte
+		if _, err := rand.Read(seed[:]); err != nil {
+			return 0, fmt.Errorf("server: seed session IDs: %w", err)
+		}
+		sm.nextSessionID = binary.BigEndian.Uint32(seed[:])
+		sm.sessionIDSeeded = true
+	}
+	for {
+		id := sm.nextSessionID
+		sm.nextSessionID++
+		if id == 0 || id == protocol.VoiceRegistrationMagic {
+			continue
+		}
+		sm.issuedSessionIDs++
+		return id, nil
+	}
 }
 
 // GetSnapshot returns an immutable snapshot of the session by session ID.
@@ -212,10 +244,10 @@ func udpAddrEqual(left, right *net.UDPAddr) bool {
 	return left != nil && right != nil && left.IP.Equal(right.IP) && left.Port == right.Port && left.Zone == right.Zone
 }
 
-func newScreenAuthToken() string {
+func newScreenAuthToken() (string, error) {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
-		panic("crypto/rand failure: " + err.Error())
+		return "", fmt.Errorf("server: generate screen auth token: %w", err)
 	}
-	return hex.EncodeToString(b)
+	return hex.EncodeToString(b), nil
 }

--- a/pkg/server/session_nonce_test.go
+++ b/pkg/server/session_nonce_test.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"github.com/NicolasHaas/gospeak/pkg/model"
+	"github.com/NicolasHaas/gospeak/pkg/protocol"
+)
+
+func mustCreateSession(t *testing.T, sessions *SessionManager, userID int64, username string, role model.Role) *model.Session {
+	t.Helper()
+	session, err := sessions.Create(userID, username, role)
+	if err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+	return session
+}
+
+func mustCreateScopedSession(t *testing.T, sessions *SessionManager, userID int64, username string, role model.Role, channelScope int64) *model.Session {
+	t.Helper()
+	session, err := sessions.CreateWithChannelScope(userID, username, role, channelScope)
+	if err != nil {
+		t.Fatalf("Create scoped session: %v", err)
+	}
+	return session
+}
+
+func TestSessionIDAllocatorSkipsReservedValues(t *testing.T) {
+	sessions := NewSessionManager()
+	sessions.sessionIDSeeded = true
+	sessions.nextSessionID = ^uint32(0)
+
+	last, err := sessions.nextIDLocked()
+	if err != nil {
+		t.Fatalf("allocate max session ID: %v", err)
+	}
+	first, err := sessions.nextIDLocked()
+	if err != nil {
+		t.Fatalf("allocate after wrap: %v", err)
+	}
+	if last != ^uint32(0) || first != 1 {
+		t.Fatalf("IDs across wrap = (%d, %d), want (%d, 1)", last, first, uint32(^uint32(0)))
+	}
+
+	sessions.nextSessionID = protocol.VoiceRegistrationMagic
+	next, err := sessions.nextIDLocked()
+	if err != nil {
+		t.Fatalf("allocate after registration magic: %v", err)
+	}
+	if next != protocol.VoiceRegistrationMagic+1 {
+		t.Fatalf("ID after registration magic = %d, want %d", next, protocol.VoiceRegistrationMagic+1)
+	}
+}
+
+func TestSessionIDExhaustionFailsClosed(t *testing.T) {
+	sessions := NewSessionManager()
+	sessions.sessionIDSeeded = true
+	sessions.issuedSessionIDs = usableSessionIDs
+
+	_, err := sessions.Create(1, "user", model.RoleUser)
+	if !errors.Is(err, ErrSessionIDExhausted) {
+		t.Fatalf("Create error = %v, want %v", err, ErrSessionIDExhausted)
+	}
+}
+
+func TestSessionIDsAreNotReusedAfterRemoval(t *testing.T) {
+	originalReader := rand.Reader
+	t.Cleanup(func() { rand.Reader = originalReader })
+
+	// The old allocator read 52 random bytes per session: four for the ID,
+	// 32 for voice registration, and 16 for screen authentication. Repeating
+	// that input reproduces a historical session-ID collision deterministically.
+	chunk := make([]byte, 52)
+	binary.BigEndian.PutUint32(chunk[:4], 42)
+	rand.Reader = bytes.NewReader(append(append([]byte(nil), chunk...), chunk...))
+
+	sessions := NewSessionManager()
+	first := mustCreateSession(t, sessions, 1, "first", model.RoleUser)
+	sessions.Remove(first.ID)
+	second := mustCreateSession(t, sessions, 2, "second", model.RoleUser)
+
+	if first.ID == second.ID {
+		t.Fatalf("session ID %d was reused while the voice key could still be active", first.ID)
+	}
+}

--- a/pkg/server/voice_test.go
+++ b/pkg/server/voice_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestVoiceEndpointRequiresAuthenticatedRegistration(t *testing.T) {
 	srv, _, _ := newTestServer(t)
-	session := srv.sessions.Create(1, "speaker", model.RoleUser)
+	session := mustCreateSession(t, srv.sessions, 1, "speaker", model.RoleUser)
 	legitimate := &net.UDPAddr{IP: net.ParseIP("192.0.2.10"), Port: 40000}
 	attacker := &net.UDPAddr{IP: net.ParseIP("198.51.100.20"), Port: 50000}
 
@@ -47,7 +47,7 @@ func TestVoiceEndpointRequiresAuthenticatedRegistration(t *testing.T) {
 
 func TestVoiceRegistrationRejectsReplayAndRateLimitsRebind(t *testing.T) {
 	srv, _, _ := newTestServer(t)
-	session := srv.sessions.Create(1, "speaker", model.RoleUser)
+	session := mustCreateSession(t, srv.sessions, 1, "speaker", model.RoleUser)
 	first := &net.UDPAddr{IP: net.ParseIP("192.0.2.10"), Port: 40000}
 	rebound := &net.UDPAddr{IP: net.ParseIP("192.0.2.10"), Port: 40001}
 	now := time.Now()


### PR DESCRIPTION
## Summary

Prevents AES-GCM voice nonce reuse across historical sessions and sequence-number exhaustion.

- allocates session IDs from a random starting point without reissuing them during the server lifecycle
- keeps removed session IDs reserved while the same voice key may remain active
- skips reserved session IDs and fails closed if the ID space is exhausted
- refuses to send voice packets before the uint32 sequence number can wrap
- propagates secure-random generation failures instead of panicking
- preserves the existing voice wire format
- updates the protocol and security documentation
- adds regression coverage for historical ID reuse, reserved IDs, allocator exhaustion and sequence wrap