### PR TITLE
fix: acknowledge channel joins before client state changes

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -17,6 +17,7 @@ Every control message is a `ControlMessage` struct with exactly one field set:
 - `ChannelListRequest`
 - `ChannelListResponse`
 - `JoinChannelRequest`
+- `ChannelJoinResponse`
 - `LeaveChannelRequest`
 - `ChannelJoinedEvent`
 - `ChannelLeftEvent`
@@ -86,7 +87,8 @@ sequenceDiagram
 
     Note over C,S: Join Channel
     C->>S: JoinChannelRequest{channelID}
-    S->>S: Check max_users, validate channel
+    S->>S: Validate and atomically reserve capacity
+    S->>C: ChannelJoinResponse{channelID, success, message}
     S->>Others: ChannelJoinedEvent{channelID, user}
     S->>C: ServerStateEvent{channels} (full refresh)
 
@@ -173,10 +175,10 @@ This field is required: clients and servers from before authenticated UDP regist
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│  Header (8 bytes, sent as plaintext additional data)    │
-│  ┌─────────────────┬───────────────────┐                │
-│  │ SessionID (4B)  │ SeqNum (4B)       │                │
-│  └─────────────────┴───────────────────┘                │
+│  Header (20 bytes, sent as plaintext additional data)   │
+│  ┌───────────────┬─────────────┬──────────────┬────────┐ │
+│  │SessionID (4B) │SeqNum (4B)  │Timestamp (4B)│Chan(8B)│ │
+│  └───────────────┴─────────────┴──────────────┴────────┘ │
 ├─────────────────────────────────────────────────────────┤
 │  Payload: AES-128-GCM(opus_frame)                       │
 │  ┌──────────────────────────────────────────────┐       │
@@ -184,6 +186,10 @@ This field is required: clients and servers from before authenticated UDP regist
 │  └──────────────────────────────────────────────┘       │
 └─────────────────────────────────────────────────────────┘
 ```
+
+The 64-bit unsigned channel field carries positive SQLite channel IDs without
+truncation. The 20-byte header is authenticated as AES-GCM additional data.
+Clients and servers using the former 14-byte voice header are not wire-compatible.
 
 ### Voice Pipeline
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -115,12 +115,12 @@ For each voice packet:
 2. **Authenticated encryption**:
    - **Algorithm**: AES-128-GCM
    - **Plaintext**: Opus-encoded audio frame
-   - **Additional Data (AD)**: 14-byte packet header (SessionID + SeqNum + Timestamp + ChannelID)
+   - **Additional Data (AD)**: 20-byte packet header (SessionID + SeqNum + Timestamp + ChannelID)
    - **Output**: Ciphertext + 16-byte authentication tag
 
 3. **Packet assembly**:
    ```
-   [SessionID:4B][SeqNum:4B][Timestamp:4B][ChannelID:2B][Ciphertext + AuthTag]
+   [SessionID:4B][SeqNum:4B][Timestamp:4B][ChannelID:8B][Ciphertext + AuthTag]
    ```
 
 ### Security Properties
@@ -129,7 +129,7 @@ For each voice packet:
 |----------|------------------|
 | **Confidentiality** | AES-128-GCM encryption of Opus frames |
 | **Integrity** | GCM authentication tag (16 bytes) |
-| **Authenticity** | The complete 14-byte voice header is authenticated as additional data |
+| **Authenticity** | The complete 20-byte voice header is authenticated as additional data |
 | **Nonce uniqueness** | Session IDs are not reissued under the same key, and sequence wrap fails closed |
 | **Forward secrecy** | New key generated on each server restart |
 

--- a/pkg/client/engine.go
+++ b/pkg/client/engine.go
@@ -90,6 +90,7 @@ type connectionGeneration struct {
 	cipher         *gospeakCrypto.VoiceCipher
 	audio          *audioResources
 	keepaliveNow   chan struct{}
+	pendingJoins   map[int64]uint32
 }
 
 func newConnectionGeneration() *connectionGeneration {
@@ -99,6 +100,7 @@ func newConnectionGeneration() *connectionGeneration {
 		cancel:       cancel,
 		done:         make(chan struct{}),
 		keepaliveNow: make(chan struct{}, 1),
+		pendingJoins: make(map[int64]uint32),
 	}
 }
 
@@ -519,10 +521,12 @@ func (e *Engine) publishConnectedGeneration(g *connectionGeneration, authResp *p
 
 func selectAutoJoinChannel(channels []pb.ChannelInfo, channelScope int64) (pb.ChannelInfo, bool) {
 	if channelScope == 0 {
-		if len(channels) == 0 {
-			return pb.ChannelInfo{}, false
+		for _, channel := range channels {
+			if channel.MaxUsers <= 0 || len(channel.Users) < int(channel.MaxUsers) {
+				return channel, true
+			}
 		}
-		return channels[0], true
+		return pb.ChannelInfo{}, false
 	}
 	for _, channel := range channels {
 		if channel.ID == channelScope {
@@ -961,6 +965,48 @@ func (e *Engine) handleEvent(g *connectionGeneration, msg *pb.ControlMessage) {
 			"channel", msg.ChannelJoinedEvent.ChannelID,
 		)
 
+	case msg.ChannelJoinResponse != nil:
+		response := msg.ChannelJoinResponse
+		g.mu.Lock()
+		pendingCount := g.pendingJoins[response.ChannelID]
+		pending := pendingCount > 0
+		if pendingCount <= 1 {
+			delete(g.pendingJoins, response.ChannelID)
+		} else {
+			g.pendingJoins[response.ChannelID] = pendingCount - 1
+		}
+		voice := g.voice
+		applied := false
+		if pending && response.Success && g.ctx.Err() == nil {
+			e.mu.Lock()
+			if e.generation == g && e.state == StateConnected {
+				e.channelID = response.ChannelID
+				if voice != nil {
+					voice.SetChannel(response.ChannelID)
+				}
+				applied = true
+			}
+			e.mu.Unlock()
+		}
+		g.mu.Unlock()
+		if !pending {
+			return
+		}
+		if !response.Success {
+			if callback := e.OnError; callback != nil {
+				err := fmt.Errorf("join channel: %s", response.Message)
+				e.enqueueGenerationCallbackLocked(g, func() { callback(err) })
+			}
+			return
+		}
+		if applied {
+			e.clearScreenShareStateGenerationLocked(g)
+			select {
+			case g.keepaliveNow <- struct{}{}:
+			default:
+			}
+		}
+
 	case msg.ChannelLeftEvent != nil:
 		slog.Info("user left channel",
 			"user", msg.ChannelLeftEvent.Username,
@@ -1034,39 +1080,30 @@ func (e *Engine) beginControlOperation() (*connectionGeneration, *ControlClient,
 	return g, ctrl, true
 }
 
-// JoinChannel sends a request to join a channel.
+// JoinChannel sends a request to join a channel. Local channel state changes
+// only after the server returns a successful ChannelJoinResponse.
 func (e *Engine) JoinChannel(channelID int64) error {
-	g, ctrl, voice, _ := e.connectionClients()
+	g, ctrl, _, _ := e.connectionClients()
 
 	if ctrl == nil || g == nil || !g.begin() {
 		return fmt.Errorf("not connected")
 	}
 	defer g.wg.Done()
 
+	g.mu.Lock()
+	g.pendingJoins[channelID]++
+	g.mu.Unlock()
 	if err := ctrl.Send(&pb.ControlMessage{
 		JoinChannelRequest: &pb.JoinChannelRequest{ChannelID: channelID},
 	}); err != nil {
+		g.mu.Lock()
+		if g.pendingJoins[channelID] <= 1 {
+			delete(g.pendingJoins, channelID)
+		} else {
+			g.pendingJoins[channelID]--
+		}
+		g.mu.Unlock()
 		return err
-	}
-
-	e.mu.Lock()
-	if e.generation != g || e.state != StateConnected || g.ctx.Err() != nil {
-		e.mu.Unlock()
-		return fmt.Errorf("not connected")
-	}
-	e.channelID = channelID
-	e.mu.Unlock()
-	e.clearScreenShareStateGeneration(g)
-
-	if voice != nil {
-		voice.SetChannel(channelID)
-	}
-
-	// Ask the keepalive loop to announce our UDP address immediately so the
-	// server can route voice without waiting for the next tick.
-	select {
-	case g.keepaliveNow <- struct{}{}:
-	default:
 	}
 
 	return nil
@@ -1087,13 +1124,21 @@ func (e *Engine) LeaveChannel() error {
 		return err
 	}
 
+	g.mu.Lock()
+	clear(g.pendingJoins)
+	voice := g.voice
 	e.mu.Lock()
 	if e.generation != g || e.state != StateConnected || g.ctx.Err() != nil {
 		e.mu.Unlock()
+		g.mu.Unlock()
 		return fmt.Errorf("not connected")
 	}
 	e.channelID = 0
+	if voice != nil {
+		voice.SetChannel(0)
+	}
 	e.mu.Unlock()
+	g.mu.Unlock()
 	e.clearScreenShareStateGeneration(g)
 
 	return nil

--- a/pkg/client/engine_test.go
+++ b/pkg/client/engine_test.go
@@ -1,16 +1,36 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"image"
 	"net"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	pb "github.com/NicolasHaas/gospeak/pkg/protocol/pb"
 )
+
+type recordingConn struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (*recordingConn) Read([]byte) (int, error) { return 0, errors.New("not implemented") }
+func (c *recordingConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.b.Write(p)
+}
+func (*recordingConn) Close() error                     { return nil }
+func (*recordingConn) LocalAddr() net.Addr              { return &net.IPAddr{} }
+func (*recordingConn) RemoteAddr() net.Addr             { return &net.IPAddr{} }
+func (*recordingConn) SetDeadline(time.Time) error      { return nil }
+func (*recordingConn) SetReadDeadline(time.Time) error  { return nil }
+func (*recordingConn) SetWriteDeadline(time.Time) error { return nil }
 
 type lifecycleCapturer struct {
 	closed atomic.Bool
@@ -45,6 +65,91 @@ func setTestGeneration(e *Engine) *connectionGeneration {
 	e.generation = g
 	e.state = StateConnected
 	return g
+}
+
+func TestJoinChannelWaitsForSuccessfulResponseBeforeChangingState(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	g.control = &ControlClient{conn: &recordingConn{}}
+	g.voice = &VoiceClient{channelID: 1}
+	e.mu.Lock()
+	e.generation = g
+	e.state = StateConnected
+	e.channelID = 1
+	e.mu.Unlock()
+
+	if err := e.JoinChannel(2); err != nil {
+		t.Fatalf("JoinChannel: %v", err)
+	}
+	if got := e.GetChannelID(); got != 1 {
+		t.Fatalf("channel before response = %d, want 1", got)
+	}
+	if got := g.voice.channelID; got != 1 {
+		t.Fatalf("voice channel before response = %d, want 1", got)
+	}
+
+	e.handleEventGeneration(g, &pb.ControlMessage{
+		ChannelJoinResponse: &pb.ChannelJoinResponse{ChannelID: 2, Success: true},
+	})
+	if got := e.GetChannelID(); got != 2 {
+		t.Fatalf("channel after response = %d, want 2", got)
+	}
+	if got := g.voice.channelID; got != 2 {
+		t.Fatalf("voice channel after response = %d, want 2", got)
+	}
+}
+
+func TestRejectedChannelJoinDoesNotChangeState(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	g.control = &ControlClient{conn: &recordingConn{}}
+	g.voice = &VoiceClient{channelID: 1}
+	e.mu.Lock()
+	e.generation = g
+	e.state = StateConnected
+	e.channelID = 1
+	e.mu.Unlock()
+
+	if err := e.JoinChannel(2); err != nil {
+		t.Fatalf("JoinChannel: %v", err)
+	}
+	e.handleEventGeneration(g, &pb.ControlMessage{
+		ChannelJoinResponse: &pb.ChannelJoinResponse{ChannelID: 2, Success: false, Message: "channel is full"},
+	})
+	if got := e.GetChannelID(); got != 1 {
+		t.Fatalf("channel after rejection = %d, want 1", got)
+	}
+	if got := g.voice.channelID; got != 1 {
+		t.Fatalf("voice channel after rejection = %d, want 1", got)
+	}
+}
+
+func TestLeaveChannelInvalidatesPendingJoinResponse(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	g.control = &ControlClient{conn: &recordingConn{}}
+	g.voice = &VoiceClient{channelID: 1}
+	e.mu.Lock()
+	e.generation = g
+	e.state = StateConnected
+	e.channelID = 1
+	e.mu.Unlock()
+
+	if err := e.JoinChannel(2); err != nil {
+		t.Fatalf("JoinChannel: %v", err)
+	}
+	if err := e.LeaveChannel(); err != nil {
+		t.Fatalf("LeaveChannel: %v", err)
+	}
+	e.handleEventGeneration(g, &pb.ControlMessage{
+		ChannelJoinResponse: &pb.ChannelJoinResponse{ChannelID: 2, Success: true},
+	})
+	if got := e.GetChannelID(); got != 0 {
+		t.Fatalf("channel after stale join response = %d, want 0", got)
+	}
+	if got := g.voice.channelID; got != 0 {
+		t.Fatalf("voice channel after leave = %d, want 0", got)
+	}
 }
 
 func TestStaleGenerationCannotDisconnectReplacement(t *testing.T) {
@@ -750,6 +855,13 @@ func TestSelectAutoJoinChannelHonorsScope(t *testing.T) {
 	got, ok = selectAutoJoinChannel(channels, 0)
 	if !ok || got.ID != 1 {
 		t.Fatalf("selectAutoJoinChannel(scope=0) = (%#v, %t), want first channel", got, ok)
+	}
+	got, ok = selectAutoJoinChannel([]pb.ChannelInfo{
+		{ID: 1, Name: "full", MaxUsers: 1, Users: []pb.UserInfo{{ID: 1}}},
+		{ID: 2, Name: "available", MaxUsers: 1},
+	}, 0)
+	if !ok || got.ID != 2 {
+		t.Fatalf("selectAutoJoinChannel(full first channel) = (%#v, %t), want channel 2", got, ok)
 	}
 	if _, ok := selectAutoJoinChannel(channels, 3); ok {
 		t.Fatal("selectAutoJoinChannel accepted a missing scoped channel")

--- a/pkg/client/voice.go
+++ b/pkg/client/voice.go
@@ -18,7 +18,7 @@ type VoiceClient struct {
 	conn                *net.UDPConn
 	serverAddr          *net.UDPAddr
 	sessionID           uint32
-	channelID           uint16
+	channelID           uint64
 	cipher              *gospeakCrypto.VoiceCipher
 	seqNum              uint32
 	registrationKey     []byte
@@ -86,7 +86,7 @@ func (v *VoiceClient) SendRegistration() error {
 func (v *VoiceClient) SetChannel(channelID int64) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
-	v.channelID = uint16(channelID) //nolint:gosec // channel IDs fit in uint16
+	v.channelID = uint64(channelID) //nolint:gosec // server-issued channel IDs are positive
 }
 
 // SendVoice encrypts and sends an Opus frame over UDP.

--- a/pkg/protocol/pb/messages.go
+++ b/pkg/protocol/pb/messages.go
@@ -10,6 +10,7 @@ type ControlMessage struct {
 	ChannelListRequest  *ChannelListRequest            `json:"channel_list_request,omitempty"`
 	ChannelListResponse *ChannelListResponse           `json:"channel_list_response,omitempty"`
 	JoinChannelRequest  *JoinChannelRequest            `json:"join_channel_request,omitempty"`
+	ChannelJoinResponse *ChannelJoinResponse           `json:"channel_join_response,omitempty"`
 	LeaveChannelRequest *LeaveChannelRequest           `json:"leave_channel_request,omitempty"`
 	ChannelJoinedEvent  *ChannelJoinedEvent            `json:"channel_joined_event,omitempty"`
 	ChannelLeftEvent    *ChannelLeftEvent              `json:"channel_left_event,omitempty"`
@@ -91,6 +92,12 @@ type ChannelListResponse struct {
 
 type JoinChannelRequest struct {
 	ChannelID int64 `json:"channel_id"`
+}
+
+type ChannelJoinResponse struct {
+	ChannelID int64  `json:"channel_id"`
+	Success   bool   `json:"success"`
+	Message   string `json:"message,omitempty"`
 }
 
 type LeaveChannelRequest struct{}

--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -13,8 +13,8 @@ import (
 
 const (
 	// VoiceHeaderSize is the byte size of the voice packet header.
-	// [sessionID(4) | seqNum(4) | timestamp(4) | channelID(2)] = 14 bytes
-	VoiceHeaderSize = 14
+	// [sessionID(4) | seqNum(4) | timestamp(4) | channelID(8)] = 20 bytes
+	VoiceHeaderSize = 20
 
 	// MaxVoicePayload is the maximum encrypted Opus payload size.
 	MaxVoicePayload = 1400
@@ -40,17 +40,17 @@ type VoicePacket struct {
 	SessionID uint32 // 4 bytes: identifies the sender session
 	SeqNum    uint32 // 4 bytes: sequence number for ordering (prevents AES-GCM nonce reuse)
 	Timestamp uint32 // 4 bytes: RTP-style timestamp
-	ChannelID uint16 // 2 bytes: target channel
+	ChannelID uint64 // 8 bytes: target channel
 	Payload   []byte // encrypted Opus frame + GCM auth tag
 }
 
-// MarshalHeader marshals only the header portion (14 bytes).
+// MarshalHeader marshals only the header portion (20 bytes).
 func (p *VoicePacket) MarshalHeader() []byte {
 	h := make([]byte, VoiceHeaderSize)
 	binary.BigEndian.PutUint32(h[0:4], p.SessionID)
 	binary.BigEndian.PutUint32(h[4:8], p.SeqNum)
 	binary.BigEndian.PutUint32(h[8:12], p.Timestamp)
-	binary.BigEndian.PutUint16(h[12:14], p.ChannelID)
+	binary.BigEndian.PutUint64(h[12:20], p.ChannelID)
 	return h
 }
 
@@ -72,7 +72,7 @@ func UnmarshalVoicePacket(data []byte) (*VoicePacket, error) {
 		SessionID: binary.BigEndian.Uint32(data[0:4]),
 		SeqNum:    binary.BigEndian.Uint32(data[4:8]),
 		Timestamp: binary.BigEndian.Uint32(data[8:12]),
-		ChannelID: binary.BigEndian.Uint16(data[12:14]),
+		ChannelID: binary.BigEndian.Uint64(data[12:20]),
 		Payload:   make([]byte, len(data)-VoiceHeaderSize),
 	}
 	copy(pkt.Payload, data[VoiceHeaderSize:])

--- a/pkg/protocol/protocol_test.go
+++ b/pkg/protocol/protocol_test.go
@@ -35,3 +35,21 @@ func TestWriteControlMessageHandlesShortWrites(t *testing.T) {
 		t.Fatalf("Ping mismatch: got %#v, want timestamp %d", got.Ping, want.Ping.Timestamp)
 	}
 }
+
+func TestVoicePacketRoundTripPreservesLargeChannelID(t *testing.T) {
+	want := &VoicePacket{
+		SessionID: 1,
+		SeqNum:    2,
+		Timestamp: 3,
+		ChannelID: 1 << 32,
+		Payload:   []byte("encrypted"),
+	}
+
+	got, err := UnmarshalVoicePacket(want.Marshal())
+	if err != nil {
+		t.Fatalf("UnmarshalVoicePacket: %v", err)
+	}
+	if got.ChannelID != want.ChannelID {
+		t.Fatalf("ChannelID = %d, want %d", got.ChannelID, want.ChannelID)
+	}
+}

--- a/pkg/server/channels.go
+++ b/pkg/server/channels.go
@@ -44,6 +44,36 @@ func (cm *ChannelManager) Join(sessionID uint32, channelID int64) (prevChannelID
 	return prevChannelID
 }
 
+// TryJoin adds a session only when the destination has capacity. The capacity
+// check and move happen under the same lock.
+func (cm *ChannelManager) TryJoin(sessionID uint32, channelID int64, maxUsers int) (prevChannelID int64, joined bool) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	current := cm.sessionToChannel[sessionID]
+	if current == channelID {
+		return current, true
+	}
+	if maxUsers > 0 && len(cm.members[channelID]) >= maxUsers {
+		return current, false
+	}
+
+	if current != 0 {
+		if sessions := cm.members[current]; sessions != nil {
+			delete(sessions, sessionID)
+			if len(sessions) == 0 {
+				delete(cm.members, current)
+			}
+		}
+	}
+	if cm.members[channelID] == nil {
+		cm.members[channelID] = make(map[uint32]bool)
+	}
+	cm.members[channelID][sessionID] = true
+	cm.sessionToChannel[sessionID] = channelID
+	return current, true
+}
+
 // Leave removes a session from its current channel.
 func (cm *ChannelManager) Leave(sessionID uint32) (channelID int64) {
 	cm.mu.Lock()

--- a/pkg/server/channels_test.go
+++ b/pkg/server/channels_test.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestChannelManagerTryJoinEnforcesCapacityAtomically(t *testing.T) {
+	channels := NewChannelManager()
+	start := make(chan struct{})
+	results := make(chan bool, 2)
+	var wg sync.WaitGroup
+
+	for _, sessionID := range []uint32{1, 2} {
+		wg.Add(1)
+		go func(sessionID uint32) {
+			defer wg.Done()
+			<-start
+			_, joined := channels.TryJoin(sessionID, 10, 1)
+			results <- joined
+		}(sessionID)
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	joined := 0
+	for result := range results {
+		if result {
+			joined++
+		}
+	}
+	if joined != 1 {
+		t.Fatalf("successful joins = %d, want 1", joined)
+	}
+	if got := len(channels.Members(10)); got != 1 {
+		t.Fatalf("channel members = %d, want 1", got)
+	}
+}

--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -713,29 +713,42 @@ func (s *Server) handleMessage(handler *ControlHandler, sessionID uint32, msg *p
 }
 
 func (s *Server) handleJoinChannel(handler *ControlHandler, sessionID uint32, req *pb.JoinChannelRequest, st datastore.DataProviderFactory, conn net.Conn) {
+	respond := func(success bool, message string) {
+		if err := writeControlMessage(conn, &pb.ControlMessage{
+			ChannelJoinResponse: &pb.ChannelJoinResponse{
+				ChannelID: req.ChannelID,
+				Success:   success,
+				Message:   message,
+			},
+		}); err != nil {
+			slog.Warn("send channel join response", "session", sessionID, "err", err)
+		}
+	}
 	session, ok := s.sessions.GetSnapshot(sessionID)
 	if !ok {
-		sendError(conn, 3, "session not found")
+		respond(false, "session not found")
 		return
 	}
 	if session.ChannelScope != 0 && req.ChannelID != session.ChannelScope {
-		sendError(conn, 12, "channel is outside your invite scope")
+		respond(false, "channel is outside your invite scope")
 		return
 	}
 	// Verify channel exists
 	ch, err := st.NonTx().GetChannel(req.ChannelID)
 	if err != nil || ch == nil {
-		sendError(conn, 10, "channel not found")
+		respond(false, "channel not found")
 		return
 	}
 
-	// Check max users
-	if ch.MaxUsers > 0 && s.channels.MembersCount(ch.ID) >= ch.MaxUsers {
-		sendError(conn, 11, "channel is full")
+	prevCh, joined := s.channels.TryJoin(session.ID, ch.ID, ch.MaxUsers)
+	if !joined {
+		respond(false, "channel is full")
 		return
 	}
-
-	prevCh := s.channels.Join(session.ID, ch.ID)
+	if prevCh == ch.ID {
+		respond(true, "")
+		return
+	}
 	if prevCh > 0 {
 		if stopEvent, stopped := s.screenShare.StopBySession(session.ID); stopped && stopEvent != nil {
 			handler.broadcastToChannel(prevCh, &pb.ControlMessage{ScreenShareEvent: stopEvent}, session.ID)
@@ -743,6 +756,7 @@ func (s *Server) handleJoinChannel(handler *ControlHandler, sessionID uint32, re
 	}
 	s.sessions.SetChannel(session.ID, ch.ID)
 	s.screenShare.Unsubscribe(session.ID)
+	respond(true, "")
 
 	// Notify old channel
 	if prevCh > 0 {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -84,7 +84,7 @@ func requireClosed(t *testing.T, conn *closeTrackingConn) {
 
 func TestHandleJoinLeaveChannel(t *testing.T) {
 	srv, st, handler := newTestServer(t)
-	conn := &nopConn{}
+	conn := &bufferConn{}
 
 	ch := model.NewChannel()
 	if err := st.NonTx().CreateChannel(ch); err != nil {
@@ -94,6 +94,13 @@ func TestHandleJoinLeaveChannel(t *testing.T) {
 	session := mustCreateSession(t, srv.sessions, 1, "johndoe", model.RoleUser)
 
 	srv.handleJoinChannel(handler, session.ID, &pb.JoinChannelRequest{ChannelID: ch.ID}, st, conn)
+	response, err := protocol.ReadControlMessage(conn)
+	if err != nil {
+		t.Fatalf("ReadControlMessage: %v", err)
+	}
+	if response.ChannelJoinResponse == nil || !response.ChannelJoinResponse.Success || response.ChannelJoinResponse.ChannelID != ch.ID {
+		t.Fatalf("join response = %#v, want successful response for channel %d", response, ch.ID)
+	}
 	joinedChannel := srv.channels.ChannelOf(session.ID)
 	if joinedChannel != ch.ID {
 		t.Fatalf("JoinChannel: expected channel %d got %d", ch.ID, joinedChannel)
@@ -142,8 +149,8 @@ func TestHandleJoinChannelEnforcesSessionScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadControlMessage: %v", err)
 	}
-	if response.ErrorResponse == nil || response.ErrorResponse.Code != 12 {
-		t.Fatalf("out-of-scope join returned %#v, want error code 12", response)
+	if response.ChannelJoinResponse == nil || response.ChannelJoinResponse.Success {
+		t.Fatalf("out-of-scope join returned %#v, want rejection", response)
 	}
 	if got := srv.channels.ChannelOf(session.ID); got != 0 {
 		t.Fatalf("out-of-scope join moved session to channel %d", got)

--- a/pkg/server/voice.go
+++ b/pkg/server/voice.go
@@ -103,9 +103,14 @@ func (s *Server) voiceLoop() {
 
 		// Verify the sender is actually in the claimed channel (prevent channel spoofing)
 		actualChannel := s.channels.ChannelOf(pkt.SessionID)
-		if actualChannel == 0 || actualChannel != int64(pkt.ChannelID) {
+		if actualChannel <= 0 {
 			s.metrics.VoicePacketsDropped.Add(1)
-			continue // not in this channel, discard
+			continue // not in a channel, discard
+		}
+		packetChannel := uint64(actualChannel) //nolint:gosec // positivity is checked immediately above
+		if packetChannel != pkt.ChannelID {
+			s.metrics.VoicePacketsDropped.Add(1)
+			continue // claimed channel does not match membership
 		}
 
 		// Track per-session voice debug stats


### PR DESCRIPTION
## Summary

Prevents rejected channel joins from leaving client and server state inconsistent.

- adds an explicit channel-join response and updates client state only after a successful acknowledgement
- ignores stale join responses and clears pending joins when leaving a channel
- makes channel capacity checks and session moves atomic under concurrent joins
- widens voice channel IDs from 16 to 64 bits to prevent truncation
- updates the voice wire format and related protocol/security documentation
- adds regression coverage for rejected and stale joins, concurrent capacity limits and large channel IDs

## Breaking Change
This changes the voice header from 14 to 20 bytes.