### PR TITLE
fix: add timed playout to voice jitter buffer

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -118,9 +118,11 @@ sequenceDiagram
     NET->>CRY: Encrypted packet
     CRY->>CRY: Decrypt + verify authenticity
     CRY->>JIT: (SessionID, SeqNum, Opus frame)
-    JIT->>JIT: Reorder by SeqNum
+    JIT->>JIT: Buffer and reorder by SeqNum
     JIT->>JIT: Drop duplicates & late packets
-    JIT->>DEC: Ordered Opus frames
+    loop Fixed 20ms playout clock
+        JIT->>DEC: Due Opus frame or loss signal
+    end
     DEC->>SPK: PCM samples → PortAudio playback
 ```
 
@@ -155,7 +157,17 @@ Each remote speaker gets a dedicated jitter buffer that:
 1. **Reorders** packets by sequence number (handles out-of-order UDP delivery)
 2. **Drops duplicates** (same SeqNum received twice)
 3. **Drops late packets** (SeqNum too far behind the playback cursor)
-4. **Provides smooth playback** by buffering a small number of frames
+4. **Waits for a 20 ms playout window** before releasing the first frame, so
+   ordinary UDP reordering does not immediately trigger packet-loss concealment
+5. **Runs on a fixed 20 ms playout clock** and emits packet-loss concealment only
+   after the missing frame's deadline has elapsed
+6. **Stays bounded to 15 frames** and resynchronizes after larger sequence jumps
+   instead of accumulating packets or producing a long PLC burst
+
+Sequence comparisons use modular `uint32` ordering, including wrap from
+`4294967295` to `0`. Duplicate and already-played packets are discarded. When a
+speaker becomes idle, playout also becomes idle rather than generating PLC
+forever; the next talk spurt starts a fresh jitter window.
 
 ## PortAudio Initialization
 

--- a/pkg/client/engine.go
+++ b/pkg/client/engine.go
@@ -684,13 +684,10 @@ func (e *Engine) captureLoop(g *connectionGeneration) {
 
 // playbackLoop receives voice packets, decodes, and plays them.
 func (e *Engine) playbackLoop(g *connectionGeneration) {
-	for {
-		select {
-		case <-g.ctx.Done():
-			return
-		default:
-		}
+	ticker := time.NewTicker(voiceFrameDuration)
+	defer ticker.Stop()
 
+	for {
 		g.mu.Lock()
 		voice := g.voice
 		resources := g.audio
@@ -708,15 +705,21 @@ func (e *Engine) playbackLoop(g *connectionGeneration) {
 			if deafened {
 				continue
 			}
-			e.processIncomingVoice(g, pkt, resources.playback)
+			e.processIncomingVoice(g, pkt)
+		case <-ticker.C:
+			if deafened {
+				continue
+			}
+			e.playJitterFrames(resources.playback)
 		case <-g.ctx.Done():
 			return
 		}
 	}
 }
 
-// processIncomingVoice decrypts and plays a received voice packet.
-func (e *Engine) processIncomingVoice(g *connectionGeneration, pkt *protocol.VoicePacket, playback audio.Player) {
+// processIncomingVoice decrypts and queues a received voice packet. Decoding
+// and playback happen independently on the fixed playout clock.
+func (e *Engine) processIncomingVoice(g *connectionGeneration, pkt *protocol.VoicePacket) {
 	g.mu.Lock()
 	cipher := g.cipher
 	g.mu.Unlock()
@@ -726,10 +729,9 @@ func (e *Engine) processIncomingVoice(g *connectionGeneration, pkt *protocol.Voi
 
 	// Get or create decoder for this speaker
 	e.decoderMu.Lock()
-	dec, ok := e.decoders[pkt.SessionID]
+	_, ok := e.decoders[pkt.SessionID]
 	if !ok {
-		var err error
-		dec, err = e.decoderFactory.NewDecoder()
+		dec, err := e.decoderFactory.NewDecoder()
 		if err != nil {
 			e.decoderMu.Unlock()
 			slog.Error("create decoder failed", "err", err)
@@ -759,27 +761,43 @@ func (e *Engine) processIncomingVoice(g *connectionGeneration, pkt *protocol.Voi
 
 	// Push to jitter buffer
 	jb.Push(pkt.SeqNum, opusData)
+}
 
-	// Pop and play
-	for {
-		data, _, ok := jb.Pop()
+type speakerPlayout struct {
+	decoder audio.AudioDecoder
+	buffer  *JitterBuffer
+}
+
+func (e *Engine) playJitterFrames(playback audio.Player) {
+	e.decoderMu.Lock()
+	speakers := make([]speakerPlayout, 0, len(e.jitterBufs))
+	for sessionID, jb := range e.jitterBufs {
+		if dec := e.decoders[sessionID]; dec != nil {
+			speakers = append(speakers, speakerPlayout{decoder: dec, buffer: jb})
+		}
+	}
+	e.decoderMu.Unlock()
+
+	for _, speaker := range speakers {
+		data, _, ok := speaker.buffer.Pop()
 		if !ok {
-			break
+			continue
 		}
 
-		var pcm []int16
+		var (
+			pcm []int16
+			err error
+		)
 		if data == nil {
-			// Packet lost — use PLC
-			pcm, err = dec.DecodePLC()
+			pcm, err = speaker.decoder.DecodePLC()
 		} else {
-			pcm, err = dec.Decode(data)
+			pcm, err = speaker.decoder.Decode(data)
 		}
 		if err != nil {
 			slog.Debug("decode error", "err", err)
 			continue
 		}
-
-		if err := playback.WriteFrame(pcm); err != nil {
+		if err = playback.WriteFrame(pcm); err != nil {
 			slog.Debug("playback error", "err", err)
 		}
 	}

--- a/pkg/client/jitter.go
+++ b/pkg/client/jitter.go
@@ -2,80 +2,116 @@ package client
 
 import (
 	"sync"
+	"time"
 )
 
 const (
-	jitterBufSize  = 5  // frames (~100ms at 20ms/frame)
-	maxJitterDelay = 10 // max frames to wait before considering packet lost
+	voiceFrameDuration = 20 * time.Millisecond
+	defaultJitterDelay = voiceFrameDuration
+	maxJitterFrames    = 15
 )
 
-// JitterBuffer orders incoming voice packets and handles packet loss.
-type JitterBuffer struct {
-	mu      sync.Mutex
-	frames  map[uint32][]byte // seqNum -> encrypted payload
-	nextSeq uint32
-	ready   bool
+type jitterClock interface {
+	Now() time.Time
 }
 
-// NewJitterBuffer creates a new jitter buffer.
+type realJitterClock struct{}
+
+func (realJitterClock) Now() time.Time { return time.Now() }
+
+// JitterBuffer orders incoming voice packets and releases at most one frame on
+// each 20 ms playout deadline. A nil payload indicates packet loss and asks the
+// decoder to perform packet-loss concealment.
+type JitterBuffer struct {
+	mu sync.Mutex
+
+	clock         jitterClock
+	playoutDelay  time.Duration
+	frameDuration time.Duration
+	maxFrames     uint32
+	frames        map[uint32][]byte
+	nextSeq       uint32
+	nextPlayout   time.Time
+	ready         bool
+	playing       bool
+	started       bool
+}
+
+// NewJitterBuffer creates a bounded jitter buffer with a 20 ms playout delay.
 func NewJitterBuffer() *JitterBuffer {
+	return newJitterBuffer(realJitterClock{}, defaultJitterDelay, voiceFrameDuration, maxJitterFrames)
+}
+
+func newJitterBuffer(clock jitterClock, playoutDelay, frameDuration time.Duration, maxFrames uint32) *JitterBuffer {
 	return &JitterBuffer{
-		frames: make(map[uint32][]byte),
+		clock:         clock,
+		playoutDelay:  playoutDelay,
+		frameDuration: frameDuration,
+		maxFrames:     maxFrames,
+		frames:        make(map[uint32][]byte),
 	}
 }
 
-// Push adds a packet to the jitter buffer.
+// Push adds a packet. Duplicate and already-played packets are ignored. A jump
+// beyond the bounded reordering window starts a fresh playout window instead
+// of growing the buffer or emitting a long run of PLC frames.
 func (jb *JitterBuffer) Push(seqNum uint32, payload []byte) {
 	jb.mu.Lock()
 	defer jb.mu.Unlock()
 
+	now := jb.clock.Now()
 	if !jb.ready {
+		jb.startAt(seqNum, now)
+	} else if len(jb.frames) == 0 && !jb.playing {
+		jb.nextPlayout = now.Add(jb.playoutDelay)
+	}
+
+	distance := seqNum - jb.nextSeq
+	switch {
+	case sequenceBefore(seqNum, jb.nextSeq):
+		if jb.started || uint32(jb.nextSeq-seqNum) >= jb.maxFrames {
+			return
+		}
+		// Before playout starts, permit a bounded packet to move the initial
+		// cursor backwards. This is the normal N+1-before-N reorder case.
 		jb.nextSeq = seqNum
-		jb.ready = true
+	case distance >= jb.maxFrames:
+		jb.startAt(seqNum, now)
 	}
 
-	// Store the frame
-	data := make([]byte, len(payload))
-	copy(data, payload)
-	jb.frames[seqNum] = data
-
-	// Limit buffer size to prevent memory growth
-	if len(jb.frames) > jitterBufSize*3 {
-		jb.cleanup()
+	if _, duplicate := jb.frames[seqNum]; duplicate {
+		return
 	}
+	jb.frames[seqNum] = append([]byte(nil), payload...)
 }
 
-// Pop returns the next frame in sequence order.
-// Returns (payload, seqNum, ok). If the next frame isn't available,
-// checks if we should skip it (lost packet).
+// Pop returns the frame due at the current playout deadline. It never advances
+// merely because a later packet arrived; loss is declared only when the fixed
+// deadline for the missing sequence has elapsed.
 func (jb *JitterBuffer) Pop() ([]byte, uint32, bool) {
 	jb.mu.Lock()
 	defer jb.mu.Unlock()
 
-	if !jb.ready {
+	if !jb.ready || jb.clock.Now().Before(jb.nextPlayout) {
 		return nil, 0, false
 	}
 
-	// Check if we have the next expected frame
-	if frame, ok := jb.frames[jb.nextSeq]; ok {
-		seq := jb.nextSeq
-		delete(jb.frames, jb.nextSeq)
-		jb.nextSeq++
+	seq := jb.nextSeq
+	if frame, ok := jb.frames[seq]; ok {
+		delete(jb.frames, seq)
+		jb.advance()
 		return frame, seq, true
 	}
 
-	// Check if we've waited too long (packet lost)
-	// Look ahead to see if later packets exist
-	for i := uint32(1); i <= maxJitterDelay; i++ {
-		if _, ok := jb.frames[jb.nextSeq+i]; ok {
-			// Later packet exists, the current one is likely lost
-			seq := jb.nextSeq
-			jb.nextSeq++
-			return nil, seq, true // nil payload = packet lost, use PLC
-		}
+	if !jb.hasFutureFrame() {
+		// The speaker may have stopped due to VAD. Do not synthesize silence
+		// forever; the next packet starts a fresh jitter window.
+		jb.playing = false
+		return nil, 0, false
 	}
 
-	return nil, 0, false // not enough data yet
+	jb.advance()
+	return nil, seq, true
 }
 
 // Reset clears the jitter buffer.
@@ -84,22 +120,46 @@ func (jb *JitterBuffer) Reset() {
 	defer jb.mu.Unlock()
 	jb.frames = make(map[uint32][]byte)
 	jb.ready = false
+	jb.playing = false
+	jb.started = false
+	jb.nextPlayout = time.Time{}
 }
 
-func (jb *JitterBuffer) cleanup() {
-	// Remove frames that are too old
+func (jb *JitterBuffer) startAt(seqNum uint32, now time.Time) {
+	clear(jb.frames)
+	jb.nextSeq = seqNum
+	jb.nextPlayout = now.Add(jb.playoutDelay)
+	jb.ready = true
+	jb.playing = false
+	jb.started = false
+}
+
+func (jb *JitterBuffer) advance() {
+	jb.nextSeq++
+	jb.nextPlayout = jb.nextPlayout.Add(jb.frameDuration)
+	jb.playing = true
+	jb.started = true
+}
+
+func (jb *JitterBuffer) hasFutureFrame() bool {
 	for seq := range jb.frames {
-		if seqDiff(seq, jb.nextSeq) > jitterBufSize*3 {
-			delete(jb.frames, seq)
+		if sequenceBefore(jb.nextSeq, seq) {
+			return true
 		}
 	}
+	return false
 }
 
-// seqDiff computes the distance between two sequence numbers,
-// handling uint32 wraparound.
-func seqDiff(a, b uint32) uint32 {
-	if a >= b {
-		return a - b
-	}
-	return b - a
+// sequenceBefore compares uint32 sequence numbers within the bounded jitter
+// window. A distance of exactly half the sequence space is intentionally not
+// ordered; valid buffered distances are far smaller.
+func sequenceBefore(a, b uint32) bool {
+	distance := b - a
+	return distance != 0 && distance < uint32(1)<<31
+}
+
+func (jb *JitterBuffer) buffered() int {
+	jb.mu.Lock()
+	defer jb.mu.Unlock()
+	return len(jb.frames)
 }

--- a/pkg/client/jitter_test.go
+++ b/pkg/client/jitter_test.go
@@ -1,0 +1,109 @@
+package client
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+type fakeJitterClock struct {
+	now time.Time
+}
+
+func (c *fakeJitterClock) Now() time.Time { return c.now }
+
+func (c *fakeJitterClock) Advance(d time.Duration) { c.now = c.now.Add(d) }
+
+func newTestJitterBuffer(clock *fakeJitterClock) *JitterBuffer {
+	return newJitterBuffer(clock, defaultJitterDelay, voiceFrameDuration, maxJitterFrames)
+}
+
+func TestJitterBufferWaitsForReorderedPacket(t *testing.T) {
+	clock := &fakeJitterClock{now: time.Unix(0, 0)}
+	jb := newTestJitterBuffer(clock)
+
+	jb.Push(11, []byte("eleven"))
+	jb.Push(10, []byte("ten"))
+	if _, _, ok := jb.Pop(); ok {
+		t.Fatal("Pop() before playout deadline succeeded")
+	}
+
+	clock.Advance(defaultJitterDelay)
+	assertJitterFrame(t, jb, 10, []byte("ten"))
+	clock.Advance(voiceFrameDuration)
+	assertJitterFrame(t, jb, 11, []byte("eleven"))
+}
+
+func TestJitterBufferEmitsPLCAfterLossDeadline(t *testing.T) {
+	clock := &fakeJitterClock{now: time.Unix(0, 0)}
+	jb := newTestJitterBuffer(clock)
+
+	jb.Push(20, []byte("twenty"))
+	jb.Push(22, []byte("twenty-two"))
+	clock.Advance(defaultJitterDelay)
+	assertJitterFrame(t, jb, 20, []byte("twenty"))
+
+	clock.Advance(voiceFrameDuration)
+	assertJitterFrame(t, jb, 21, nil)
+	clock.Advance(voiceFrameDuration)
+	assertJitterFrame(t, jb, 22, []byte("twenty-two"))
+}
+
+func TestJitterBufferDropsDuplicateAndLatePackets(t *testing.T) {
+	clock := &fakeJitterClock{now: time.Unix(0, 0)}
+	jb := newTestJitterBuffer(clock)
+
+	jb.Push(30, []byte("first"))
+	jb.Push(30, []byte("duplicate"))
+	clock.Advance(defaultJitterDelay)
+	assertJitterFrame(t, jb, 30, []byte("first"))
+
+	clock.Advance(voiceFrameDuration)
+	if _, _, ok := jb.Pop(); ok {
+		t.Fatal("idle buffer unexpectedly emitted PLC")
+	}
+	jb.Push(30, []byte("late"))
+	if got := jb.buffered(); got != 0 {
+		t.Fatalf("buffered frames after late packet = %d, want 0", got)
+	}
+}
+
+func TestJitterBufferHandlesSequenceWrap(t *testing.T) {
+	clock := &fakeJitterClock{now: time.Unix(0, 0)}
+	jb := newTestJitterBuffer(clock)
+
+	jb.Push(^uint32(0), []byte("max"))
+	jb.Push(0, []byte("zero"))
+	clock.Advance(defaultJitterDelay)
+	assertJitterFrame(t, jb, ^uint32(0), []byte("max"))
+	clock.Advance(voiceFrameDuration)
+	assertJitterFrame(t, jb, 0, []byte("zero"))
+}
+
+func TestJitterBufferBoundsAndResyncsLargeJump(t *testing.T) {
+	clock := &fakeJitterClock{now: time.Unix(0, 0)}
+	jb := newTestJitterBuffer(clock)
+
+	jb.Push(1, []byte("old"))
+	jb.Push(1000, []byte("new"))
+	if got := jb.buffered(); got > maxJitterFrames {
+		t.Fatalf("buffered frames = %d, want at most %d", got, maxJitterFrames)
+	}
+
+	clock.Advance(defaultJitterDelay)
+	assertJitterFrame(t, jb, 1000, []byte("new"))
+}
+
+func assertJitterFrame(t *testing.T, jb *JitterBuffer, wantSeq uint32, wantPayload []byte) {
+	t.Helper()
+	payload, seq, ok := jb.Pop()
+	if !ok {
+		t.Fatalf("Pop() for sequence %d was not ready", wantSeq)
+	}
+	if seq != wantSeq {
+		t.Fatalf("Pop() sequence = %d, want %d", seq, wantSeq)
+	}
+	if !bytes.Equal(payload, wantPayload) {
+		t.Fatalf("Pop() payload = %q, want %q", payload, wantPayload)
+	}
+}


### PR DESCRIPTION
## Summary

Adds time-based jitter buffer that handles UDP reordering and packet loss while prioritizing minimal latency.

- uses a fixed 20 ms playout delay instead of treating reordered packets as immediate loss
- decouples packet reception from decoding and playback with a 20 ms playout clock
- emits packet-loss concealment only after a missing frame's deadline
- drops duplicate and late packets and handles uint32 sequence wrap
- bounds each speaker buffer to 15 frames and resynchronizes after large sequence jumps
- stops producing concealment frames when a speaker becomes idle
- adds deterministic "fake clock" regression coverage and updates the audio documentation
