### PR TITLE
fix: mix concurrent voice streams at playout

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -206,10 +206,15 @@ graph TB
         JB3[Jitter Buffer 3] --> D3[Opus Decoder 3]
     end
 
-    D1 --> MIX[Hardware Mixer<br/>PortAudio handles<br/>concurrent writes]
+    D1 --> MIX[Saturating PCM mixer<br/>one frame per 20 ms tick]
     D2 --> MIX
     D3 --> MIX
     MIX --> SPK[Speaker]
 ```
 
-Decoder and jitter buffer instances are created lazily when the first packet from a new `SessionID` is received, and are cleaned up when the speaker disconnects.
+On every 20 ms playout tick, at most one due frame is decoded per active
+speaker. Those PCM frames are summed with `int16` saturation and sent to
+PortAudio as exactly one frame, so concurrent speakers do not multiply the
+playout duration. A speaker without a due frame contributes silence. Decoder
+and jitter-buffer state is created lazily and removed after 30 seconds without
+a packet.

--- a/pkg/audio/playback_test.go
+++ b/pkg/audio/playback_test.go
@@ -1,0 +1,19 @@
+package audio
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMixFramesSaturatesAndTreatsMissingSamplesAsSilence(t *testing.T) {
+	frames := [][]int16{
+		{20000, -20000, 1000},
+		{20000, -20000},
+	}
+
+	got := MixFrames(frames, 3)
+	want := []int16{32767, -32768, 1000}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("MixFrames() = %v, want %v", got, want)
+	}
+}

--- a/pkg/client/engine.go
+++ b/pkg/client/engine.go
@@ -31,6 +31,8 @@ const (
 	defaultScreenShareCaptureTimeout = 15 * time.Second
 	defaultScreenShareStartTimeout   = 10 * time.Second
 	keepAliveInterval                = 5 * time.Second
+	voiceFrameSamples                = 960
+	speakerStateTTL                  = 30 * time.Second
 	maxCallbackQueue                 = 256
 	maxReliableCallbackQueue         = 1024
 )
@@ -192,10 +194,12 @@ type Engine struct {
 	vad           audio.VoiceDetector
 
 	// Per-speaker decoders and jitter buffers
-	decoders       map[uint32]audio.AudioDecoder
-	jitterBufs     map[uint32]*JitterBuffer
-	decoderMu      sync.Mutex
-	decoderFactory audio.DecoderFactory
+	decoders        map[uint32]audio.AudioDecoder
+	jitterBufs      map[uint32]*JitterBuffer
+	speakerLastSeen map[uint32]time.Time
+	decoderMu       sync.Mutex
+	decoderFactory  audio.DecoderFactory
+	now             func() time.Time
 
 	channels []pb.ChannelInfo
 
@@ -255,9 +259,11 @@ func NewEngine() *Engine {
 		state:              StateDisconnected,
 		decoders:           make(map[uint32]audio.AudioDecoder),
 		jitterBufs:         make(map[uint32]*JitterBuffer),
+		speakerLastSeen:    make(map[uint32]time.Time),
 		voiceDebugSpeakers: make(map[uint32]struct{}),
 		vad:                audio.NewVAD(200, 15, 3), // threshold=200, hold=300ms, prebuf=60ms
 		decoderFactory:     &defaultDecoderFactory{},
+		now:                time.Now,
 		encodeScreenFn:     screenshare.EncodeJPEG,
 		screenCaptureWait:  defaultScreenShareCaptureTimeout,
 		screenStartWait:    defaultScreenShareStartTimeout,
@@ -741,6 +747,7 @@ func (e *Engine) processIncomingVoice(g *connectionGeneration, pkt *protocol.Voi
 		e.jitterBufs[pkt.SessionID] = NewJitterBuffer()
 	}
 	jb := e.jitterBufs[pkt.SessionID]
+	e.speakerLastSeen[pkt.SessionID] = e.now()
 	e.decoderMu.Unlock()
 
 	// Decrypt the voice data
@@ -769,15 +776,23 @@ type speakerPlayout struct {
 }
 
 func (e *Engine) playJitterFrames(playback audio.Player) {
+	now := e.now()
 	e.decoderMu.Lock()
 	speakers := make([]speakerPlayout, 0, len(e.jitterBufs))
 	for sessionID, jb := range e.jitterBufs {
+		if lastSeen, ok := e.speakerLastSeen[sessionID]; ok && now.Sub(lastSeen) >= speakerStateTTL {
+			delete(e.decoders, sessionID)
+			delete(e.jitterBufs, sessionID)
+			delete(e.speakerLastSeen, sessionID)
+			continue
+		}
 		if dec := e.decoders[sessionID]; dec != nil {
 			speakers = append(speakers, speakerPlayout{decoder: dec, buffer: jb})
 		}
 	}
 	e.decoderMu.Unlock()
 
+	frames := make([][]int16, 0, len(speakers))
 	for _, speaker := range speakers {
 		data, _, ok := speaker.buffer.Pop()
 		if !ok {
@@ -797,9 +812,14 @@ func (e *Engine) playJitterFrames(playback audio.Player) {
 			slog.Debug("decode error", "err", err)
 			continue
 		}
-		if err = playback.WriteFrame(pcm); err != nil {
-			slog.Debug("playback error", "err", err)
-		}
+		frames = append(frames, pcm)
+	}
+	if len(frames) == 0 {
+		return
+	}
+
+	if err := playback.WriteFrame(audio.MixFrames(frames, voiceFrameSamples)); err != nil {
+		slog.Debug("playback error", "err", err)
 	}
 }
 
@@ -1629,6 +1649,7 @@ func (e *Engine) resetReceiveState() {
 	e.decoderMu.Lock()
 	e.decoders = make(map[uint32]audio.AudioDecoder)
 	e.jitterBufs = make(map[uint32]*JitterBuffer)
+	e.speakerLastSeen = make(map[uint32]time.Time)
 	e.decoderMu.Unlock()
 }
 

--- a/pkg/client/engine_test.go
+++ b/pkg/client/engine_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NicolasHaas/gospeak/pkg/audio"
 	pb "github.com/NicolasHaas/gospeak/pkg/protocol/pb"
 )
 
@@ -59,12 +60,88 @@ type lifecycleEncoder struct{}
 
 func (*lifecycleEncoder) Encode([]int16) ([]byte, error) { return nil, nil }
 
+type recordingPlayer struct {
+	frames [][]int16
+}
+
+func (*recordingPlayer) Start() error { return nil }
+func (p *recordingPlayer) WriteFrame(frame []int16) error {
+	p.frames = append(p.frames, append([]int16(nil), frame...))
+	return nil
+}
+func (*recordingPlayer) Stop() error { return nil }
+
+type fixedDecoder struct {
+	frame []int16
+}
+
+func (d *fixedDecoder) Decode([]byte) ([]int16, error) {
+	return append([]int16(nil), d.frame...), nil
+}
+func (d *fixedDecoder) DecodePLC() ([]int16, error) {
+	return append([]int16(nil), d.frame...), nil
+}
+
+var _ audio.Player = (*recordingPlayer)(nil)
+
 func setTestGeneration(e *Engine) *connectionGeneration {
 	g := newConnectionGeneration()
 	g.control = &ControlClient{}
 	e.generation = g
 	e.state = StateConnected
 	return g
+}
+
+func TestPlayoutMixesConcurrentSpeakersIntoOneFrame(t *testing.T) {
+	clock := &fakeJitterClock{now: time.Unix(0, 0)}
+	first := newTestJitterBuffer(clock)
+	second := newTestJitterBuffer(clock)
+	first.Push(1, []byte("first"))
+	second.Push(1, []byte("second"))
+	clock.Advance(defaultJitterDelay)
+
+	e := NewEngine()
+	e.now = clock.Now
+	e.decoders[1] = &fixedDecoder{frame: []int16{20000, -20000}}
+	e.decoders[2] = &fixedDecoder{frame: []int16{20000, -20000}}
+	e.jitterBufs[1] = first
+	e.jitterBufs[2] = second
+	e.speakerLastSeen[1] = clock.Now()
+	e.speakerLastSeen[2] = clock.Now()
+	player := &recordingPlayer{}
+
+	e.playJitterFrames(player)
+
+	if got := len(player.frames); got != 1 {
+		t.Fatalf("playback writes = %d, want 1 mixed frame", got)
+	}
+	if got, want := player.frames[0][0], int16(32767); got != want {
+		t.Fatalf("mixed positive sample = %d, want %d", got, want)
+	}
+	if got, want := player.frames[0][1], int16(-32768); got != want {
+		t.Fatalf("mixed negative sample = %d, want %d", got, want)
+	}
+}
+
+func TestPlayoutRemovesInactiveSpeakerState(t *testing.T) {
+	now := time.Unix(100, 0)
+	e := NewEngine()
+	e.now = func() time.Time { return now }
+	e.decoders[1] = &fixedDecoder{}
+	e.jitterBufs[1] = newTestJitterBuffer(&fakeJitterClock{now: now})
+	e.speakerLastSeen[1] = now.Add(-speakerStateTTL)
+
+	e.playJitterFrames(&recordingPlayer{})
+
+	if _, ok := e.decoders[1]; ok {
+		t.Fatal("inactive decoder was not removed")
+	}
+	if _, ok := e.jitterBufs[1]; ok {
+		t.Fatal("inactive jitter buffer was not removed")
+	}
+	if _, ok := e.speakerLastSeen[1]; ok {
+		t.Fatal("inactive last-seen timestamp was not removed")
+	}
 }
 
 func TestJoinChannelWaitsForSuccessfulResponseBeforeChangingState(t *testing.T) {


### PR DESCRIPTION
## Summary

Mixes concurrent speakers into one PCM frame per playout tick.

- collects at most one due frame from each active speaker every 20 ms
- mixes concurrent PCM streams before writing to PortAudio
- produces exactly one playback write per tick regardless of speaker count
- saturates positive and negative sample overflow to the int16 range
- handles missing or shorter speaker frames without extending playout duration
- removes inactive decoder and jitter buffer state after 30 seconds
- adds regression coverage for concurrent speakers, clipping, missing samples and inactive-state cleanup
- updates the audio documentation to describe the software mixer