### PR TITLE
fix: apply audio settings and use user config paths

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -148,7 +148,7 @@ stateDiagram-v2
 | Hold Frames | 15 | Number of frames to keep transmitting after voice stops (15 × 20ms = 300ms) |
 | Pre-buffer | 3 | Frames buffered before voice onset for smooth start (3 × 20ms = 60ms) |
 
-The VAD threshold is user-configurable via the settings dialog and persisted in `settings.yaml`.
+The VAD threshold and selected input/output devices are user-configurable via the settings dialog. They are persisted in `settings.yaml` under the operating system's user config directory (`gospeak/`), and device changes apply on the next connection. If a selected device is no longer available, the client shows a warning and uses the system default. The 60 ms VAD pre-buffer is transmitted when speech starts so word beginnings are not clipped.
 
 ## Jitter Buffer
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -162,6 +162,7 @@ graph TB
 
 - Tokens are 256-bit random values (64 hex characters)
 - Only the SHA-256 hash is stored in the database (invite + personal tokens). Personal tokens are stored on the user record and are shown only once.
+- Saved client bookmarks contain personal tokens in plaintext so the client can reconnect. The bookmark file is atomically written with mode `0600` under the operating system's user config directory (`gospeak/`). On upgrade, legacy bookmark and settings files beside the executable are migrated there and removed only after the protected replacement is written successfully. Protect the user account and its config directory accordingly.
 - Invite tokens can have: role assignment, channel scope, max uses, expiration. A non-zero channel scope is enforced by the server: the client auto-joins that channel and cannot join another channel. The generated personal token retains this restriction on later logins. Existing users and unscoped tokens remain server-wide. Older clients remain wire-compatible but must be upgraded to select the scoped channel automatically.
 - On first server run, an admin token is automatically generated and logged
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hraban/opus v0.0.0-20251117090126-c76ea7e21bf3
 	github.com/kbinani/screenshot v0.0.0-20250624051815-089614a94018
 	golang.org/x/crypto v0.48.0
+	golang.org/x/sys v0.41.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.45.0
 )
@@ -52,7 +53,7 @@ require (
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/image v0.24.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
-	golang.org/x/sys v0.41.0 // indirect
+
 	golang.org/x/text v0.34.0 // indirect
 	modernc.org/libc v1.67.6 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/pkg/audio/capture.go
+++ b/pkg/audio/capture.go
@@ -48,6 +48,9 @@ func (c *CaptureDevice) Start() error {
 	var defaultInput *portaudio.DeviceInfo
 	if c.deviceName != "" {
 		defaultInput = FindDevice(c.deviceName)
+		if defaultInput == nil {
+			return fmt.Errorf("audio: configured input device %q not found", c.deviceName)
+		}
 	}
 	if defaultInput == nil {
 		var err error

--- a/pkg/audio/playback.go
+++ b/pkg/audio/playback.go
@@ -44,6 +44,9 @@ func (p *PlaybackDevice) Start() error {
 	var defaultOutput *portaudio.DeviceInfo
 	if p.deviceName != "" {
 		defaultOutput = FindDevice(p.deviceName)
+		if defaultOutput == nil {
+			return fmt.Errorf("audio: configured output device %q not found", p.deviceName)
+		}
 	}
 	if defaultOutput == nil {
 		var err error

--- a/pkg/client/bookmarks.go
+++ b/pkg/client/bookmarks.go
@@ -1,8 +1,8 @@
 package client
 
 import (
+	"log/slog"
 	"os"
-	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 )
@@ -17,22 +17,25 @@ type Bookmark struct {
 	LastUsed    int64  `yaml:"last_used,omitempty"`
 }
 
-// BookmarkStore manages server bookmarks stored next to the binary.
+// BookmarkStore manages server bookmarks stored in the user config directory.
 type BookmarkStore struct {
 	path              string
+	legacyPath        string
 	Bookmarks         []Bookmark        `yaml:"bookmarks"`
 	TrustedServerPins map[string]string `yaml:"trusted_server_pins,omitempty"`
 }
 
-// NewBookmarkStore creates a bookmark store using a file next to the executable.
+// NewBookmarkStore creates a bookmark store in the user config directory.
 func NewBookmarkStore() *BookmarkStore {
-	exePath, err := os.Executable()
+	legacyPath := legacyFilePath("servers.yaml")
+	path, err := configFilePath("servers.yaml")
 	if err != nil {
-		exePath = "."
+		slog.Error("resolve bookmark path", "err", err)
+		path = legacyPath
 	}
-	dir := filepath.Dir(exePath)
 	return &BookmarkStore{
-		path: filepath.Join(dir, "servers.yaml"),
+		path:       path,
+		legacyPath: legacyPath,
 	}
 }
 
@@ -40,11 +43,31 @@ func NewBookmarkStore() *BookmarkStore {
 func (bs *BookmarkStore) Load() error {
 	data, err := os.ReadFile(bs.path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			bs.Bookmarks = nil
-			return nil
+		if !os.IsNotExist(err) || bs.legacyPath == "" || bs.legacyPath == bs.path {
+			if os.IsNotExist(err) {
+				bs.Bookmarks = nil
+				return nil
+			}
+			return err
 		}
-		return err
+		data, err = os.ReadFile(bs.legacyPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				bs.Bookmarks = nil
+				return nil
+			}
+			return err
+		}
+		if err := yaml.Unmarshal(data, bs); err != nil {
+			return err
+		}
+		if err := bs.Save(); err != nil {
+			return err
+		}
+		if err := os.Remove(bs.legacyPath); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
 	}
 	return yaml.Unmarshal(data, bs)
 }
@@ -55,10 +78,7 @@ func (bs *BookmarkStore) Save() error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(bs.path, data, 0600); err != nil {
-		return err
-	}
-	return os.Chmod(bs.path, 0600)
+	return writePrivateFile(bs.path, data)
 }
 
 // PinForAddr returns the saved TOFU identity for a control address.

--- a/pkg/client/bookmarks_test.go
+++ b/pkg/client/bookmarks_test.go
@@ -43,3 +43,27 @@ func TestBookmarkStoreLoadsFileWithoutTrustPins(t *testing.T) {
 		t.Fatalf("PinForAddr() = %q, want empty", got)
 	}
 }
+
+func TestBookmarkStoreMigratesLegacyFileToUserConfig(t *testing.T) {
+	dir := t.TempDir()
+	legacyPath := filepath.Join(dir, "legacy", "servers.yaml")
+	configPath := filepath.Join(dir, "config", "servers.yaml")
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("bookmarks:\n  - name: old\n    control_addr: old.test:9600\n    token: secret\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	store := &BookmarkStore{path: configPath, legacyPath: legacyPath}
+	if err := store.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.Bookmarks) != 1 || store.Bookmarks[0].Token != "secret" {
+		t.Fatalf("migrated bookmarks = %#v", store.Bookmarks)
+	}
+	assertPrivateFile(t, configPath)
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy bookmarks still exist: %v", err)
+	}
+}

--- a/pkg/client/configfiles.go
+++ b/pkg/client/configfiles.go
@@ -1,0 +1,65 @@
+package client
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const configDirName = "gospeak"
+
+func configFilePath(name string) (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("user config directory: %w", err)
+	}
+	return filepath.Join(dir, configDirName, name), nil
+}
+
+func legacyFilePath(name string) string {
+	executable, err := os.Executable()
+	if err != nil {
+		return name
+	}
+	return filepath.Join(filepath.Dir(executable), name)
+}
+
+func writePrivateFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("create config directory: %w", err)
+	}
+	if err := os.Chmod(dir, 0700); err != nil { //nolint:gosec // private directories require owner execute permission
+		return fmt.Errorf("secure config directory: %w", err)
+	}
+
+	temporary, err := os.CreateTemp(dir, ".gospeak-*")
+	if err != nil {
+		return fmt.Errorf("create temporary config: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer func() { _ = os.Remove(temporaryPath) }()
+
+	if err := temporary.Chmod(0600); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("secure temporary config: %w", err)
+	}
+	if _, err := temporary.Write(data); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("write temporary config: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("sync temporary config: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary config: %w", err)
+	}
+	if err := replaceFile(temporaryPath, path); err != nil {
+		return fmt.Errorf("replace config: %w", err)
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		return fmt.Errorf("secure config: %w", err)
+	}
+	return nil
+}

--- a/pkg/client/engine.go
+++ b/pkg/client/engine.go
@@ -63,6 +63,7 @@ type audioResources struct {
 	capture  audio.Capturer
 	playback audio.Player
 	encoder  audio.AudioEncoder
+	warnings []error
 }
 
 func (r *audioResources) close() {
@@ -218,8 +219,13 @@ type Engine struct {
 	screenCaptureWait  time.Duration
 	screenStartWait    time.Duration
 
-	// Audio initialization function (allows platform-specific audio backends)
-	initAudioFn func() (*audioResources, error)
+	// Audio initialization functions allow platform-specific audio backends.
+	initAudioFn   func() (*audioResources, error)
+	newCaptureFn  func(deviceName string) (audio.Capturer, error)
+	newPlaybackFn func(deviceName string) (audio.Player, error)
+	newEncoderFn  func() (audio.AudioEncoder, error)
+	audioInput    string
+	audioOutput   string
 
 	// Voice debug counters (reset each log interval; only used when debug is enabled)
 	voiceDebugEnabled   bool
@@ -271,6 +277,13 @@ func NewEngine() *Engine {
 	e.captureScreenFn = func(displayIndex int) (image.Image, error) {
 		return screenshare.CaptureDisplay(displayIndex)
 	}
+	e.newCaptureFn = func(deviceName string) (audio.Capturer, error) {
+		return audio.NewCaptureDevice(48000, 960, deviceName)
+	}
+	e.newPlaybackFn = func(deviceName string) (audio.Player, error) {
+		return audio.NewPlaybackDevice(48000, 960, deviceName)
+	}
+	e.newEncoderFn = func() (audio.AudioEncoder, error) { return audio.NewEncoder() }
 	e.initAudioFn = e.initAudioDefault
 	return e
 }
@@ -556,32 +569,66 @@ func (e *Engine) connectionClients() (*connectionGeneration, *ControlClient, *Vo
 
 // initAudioDefault initializes PortAudio devices and Opus codec (the default backend).
 func (e *Engine) initAudioDefault() (*audioResources, error) {
-	capture, err := audio.NewCaptureDevice(48000, 960)
-	if err != nil {
-		return nil, fmt.Errorf("capture device: %w", err)
+	e.mu.RLock()
+	inputName := e.audioInput
+	outputName := e.audioOutput
+	e.mu.RUnlock()
+
+	resources := &audioResources{}
+	capture, err := e.newCaptureFn(inputName)
+	if err == nil {
+		err = capture.Start()
 	}
-	if err := capture.Start(); err != nil {
-		_ = capture.Close()
+	if err != nil && inputName != "" {
+		if capture != nil {
+			_ = capture.Close()
+		}
+		resources.warnings = append(resources.warnings,
+			fmt.Errorf("configured audio input %q is unavailable; using the system default", inputName))
+		capture, err = e.newCaptureFn("")
+		if err == nil {
+			err = capture.Start()
+		}
+	}
+	if err != nil {
+		if capture != nil {
+			_ = capture.Close()
+		}
 		return nil, fmt.Errorf("start capture: %w", err)
 	}
+	resources.capture = capture
 
-	playback, err := audio.NewPlaybackDevice(48000, 960)
-	if err != nil {
-		_ = capture.Close()
-		return nil, fmt.Errorf("playback device: %w", err)
+	playback, err := e.newPlaybackFn(outputName)
+	if err == nil {
+		err = playback.Start()
 	}
-	if err := playback.Start(); err != nil {
-		_ = capture.Close()
+	if err != nil && outputName != "" {
+		if playback != nil {
+			_ = playback.Stop()
+		}
+		resources.warnings = append(resources.warnings,
+			fmt.Errorf("configured audio output %q is unavailable; using the system default", outputName))
+		playback, err = e.newPlaybackFn("")
+		if err == nil {
+			err = playback.Start()
+		}
+	}
+	if err != nil {
+		if playback != nil {
+			_ = playback.Stop()
+		}
+		resources.close()
 		return nil, fmt.Errorf("start playback: %w", err)
 	}
+	resources.playback = playback
 
-	encoder, err := audio.NewEncoder()
+	encoder, err := e.newEncoderFn()
 	if err != nil {
-		_ = playback.Stop()
-		_ = capture.Close()
+		resources.close()
 		return nil, fmt.Errorf("encoder: %w", err)
 	}
-	return &audioResources{capture: capture, playback: playback, encoder: encoder}, nil
+	resources.encoder = encoder
+	return resources, nil
 }
 
 func (e *Engine) startAudio(g *connectionGeneration) {
@@ -591,6 +638,12 @@ func (e *Engine) startAudio(g *connectionGeneration) {
 			slog.Error("audio init failed (continuing without audio)", "err", err)
 			resources.close()
 			return
+		}
+		for _, warning := range resources.warnings {
+			slog.Warn("audio device fallback", "err", warning)
+			if callback := e.OnError; callback != nil {
+				e.invokeGenerationCallback(g, func() { callback(warning) })
+			}
 		}
 
 		g.mu.Lock()
@@ -655,7 +708,7 @@ func (e *Engine) captureLoop(g *connectionGeneration) {
 		}
 
 		// VAD
-		active := e.vad.Process(pcm)
+		active, frames := e.captureFrames(pcm)
 		if callback := e.OnVoiceActivity; callback != nil {
 			e.invokeLatestGenerationCallback(g, callbackVoiceActivity, func() { callback(active) })
 		}
@@ -666,26 +719,46 @@ func (e *Engine) captureLoop(g *connectionGeneration) {
 			continue
 		}
 
-		opusData, err := resources.encoder.Encode(pcm)
-		if err != nil {
-			slog.Debug("encode error", "err", err)
-			timestamp += 960
-			continue
+		frameTimestamp := timestamp
+		offset := uint32((len(frames) - 1) * 960) //nolint:gosec // VAD pre-buffer size is bounded
+		if offset <= timestamp {
+			frameTimestamp -= offset
 		}
+		for _, frame := range frames {
+			opusData, err := resources.encoder.Encode(frame)
+			if err != nil {
+				slog.Debug("encode error", "err", err)
+				frameTimestamp += 960
+				continue
+			}
 
-		if err := voice.SendVoice(opusData, timestamp); err != nil {
-			slog.Debug("voice send error", "err", err)
-		} else if e.voiceDebugEnabled {
-			e.voiceDebugMu.Lock()
-			e.voiceDebugSent++
-			e.voiceDebugMu.Unlock()
+			if err := voice.SendVoice(opusData, frameTimestamp); err != nil {
+				slog.Debug("voice send error", "err", err)
+			} else if e.voiceDebugEnabled {
+				e.voiceDebugMu.Lock()
+				e.voiceDebugSent++
+				e.voiceDebugMu.Unlock()
+			}
+			e.mu.Lock()
+			e.lastSendTime = time.Now()
+			e.mu.Unlock()
+			frameTimestamp += 960
 		}
-		e.mu.Lock()
-		e.lastSendTime = time.Now()
-		e.mu.Unlock()
 
 		timestamp += 960
 	}
+}
+
+func (e *Engine) captureFrames(pcm []int16) (bool, [][]int16) {
+	wasActive := e.vad.IsActive()
+	active := e.vad.Process(pcm)
+	if !active {
+		return false, nil
+	}
+	if !wasActive {
+		return true, e.vad.PreBufferedFrames()
+	}
+	return true, [][]int16{pcm}
 }
 
 // playbackLoop receives voice packets, decodes, and plays them.
@@ -1247,6 +1320,15 @@ func (e *Engine) updateDeafenedGeneration(g *connectionGeneration, deafened bool
 // SetVADThreshold updates the VAD sensitivity.
 func (e *Engine) SetVADThreshold(threshold float64) {
 	e.vad.SetThreshold(threshold)
+}
+
+// SetAudioDevices selects the devices to open on the next connection. Empty
+// names select the operating system defaults.
+func (e *Engine) SetAudioDevices(inputName, outputName string) {
+	e.mu.Lock()
+	e.audioInput = inputName
+	e.audioOutput = outputName
+	e.mu.Unlock()
 }
 
 // CreateChannel sends a create channel request (admin only).

--- a/pkg/client/engine_test.go
+++ b/pkg/client/engine_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"image"
 	"net"
+	"reflect"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -60,6 +62,23 @@ type lifecycleEncoder struct{}
 
 func (*lifecycleEncoder) Encode([]int16) ([]byte, error) { return nil, nil }
 
+type configuredCapturer struct {
+	startErr error
+}
+
+func (c *configuredCapturer) Start() error              { return c.startErr }
+func (*configuredCapturer) ReadFrame() ([]int16, error) { return nil, errors.New("stopped") }
+func (*configuredCapturer) Stop() error                 { return nil }
+func (*configuredCapturer) Close() error                { return nil }
+
+type configuredPlayer struct {
+	startErr error
+}
+
+func (p *configuredPlayer) Start() error           { return p.startErr }
+func (*configuredPlayer) WriteFrame([]int16) error { return nil }
+func (*configuredPlayer) Stop() error              { return nil }
+
 type recordingPlayer struct {
 	frames [][]int16
 }
@@ -90,6 +109,81 @@ func setTestGeneration(e *Engine) *connectionGeneration {
 	e.generation = g
 	e.state = StateConnected
 	return g
+}
+
+func TestAudioInitializationUsesConfiguredDevices(t *testing.T) {
+	e := NewEngine()
+	var captureNames, playbackNames []string
+	e.newCaptureFn = func(name string) (audio.Capturer, error) {
+		captureNames = append(captureNames, name)
+		return &configuredCapturer{}, nil
+	}
+	e.newPlaybackFn = func(name string) (audio.Player, error) {
+		playbackNames = append(playbackNames, name)
+		return &configuredPlayer{}, nil
+	}
+	e.newEncoderFn = func() (audio.AudioEncoder, error) { return &lifecycleEncoder{}, nil }
+	e.SetAudioDevices("Studio Mic", "USB Headset")
+
+	resources, err := e.initAudioDefault()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resources.close()
+	if got, want := captureNames, []string{"Studio Mic"}; !slices.Equal(got, want) {
+		t.Fatalf("capture device names = %q, want %q", got, want)
+	}
+	if got, want := playbackNames, []string{"USB Headset"}; !slices.Equal(got, want) {
+		t.Fatalf("playback device names = %q, want %q", got, want)
+	}
+}
+
+func TestAudioInitializationWarnsAndFallsBackForUnavailableDevice(t *testing.T) {
+	e := NewEngine()
+	var captureNames []string
+	e.newCaptureFn = func(name string) (audio.Capturer, error) {
+		captureNames = append(captureNames, name)
+		if name != "" {
+			return &configuredCapturer{startErr: errors.New("device unavailable")}, nil
+		}
+		return &configuredCapturer{}, nil
+	}
+	e.newPlaybackFn = func(string) (audio.Player, error) { return &configuredPlayer{}, nil }
+	e.newEncoderFn = func() (audio.AudioEncoder, error) { return &lifecycleEncoder{}, nil }
+	e.SetAudioDevices("Missing Mic", "")
+
+	resources, err := e.initAudioDefault()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resources.close()
+	if got, want := captureNames, []string{"Missing Mic", ""}; !slices.Equal(got, want) {
+		t.Fatalf("capture device attempts = %q, want %q", got, want)
+	}
+	if len(resources.warnings) != 1 {
+		t.Fatalf("audio warnings = %d, want 1", len(resources.warnings))
+	}
+}
+
+func TestVADPrependsBufferedFramesWhenSpeechStarts(t *testing.T) {
+	e := NewEngine()
+	quietOne := []int16{10}
+	quietTwo := []int16{20}
+	voice := []int16{400}
+
+	if active, frames := e.captureFrames(quietOne); active || len(frames) != 0 {
+		t.Fatalf("first quiet frame: active=%v frames=%v", active, frames)
+	}
+	if active, frames := e.captureFrames(quietTwo); active || len(frames) != 0 {
+		t.Fatalf("second quiet frame: active=%v frames=%v", active, frames)
+	}
+	active, frames := e.captureFrames(voice)
+	if !active {
+		t.Fatal("voice frame did not activate VAD")
+	}
+	if got, want := frames, [][]int16{quietOne, quietTwo, voice}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("frames on VAD activation = %v, want %v", got, want)
+	}
 }
 
 func TestPlayoutMixesConcurrentSpeakersIntoOneFrame(t *testing.T) {

--- a/pkg/client/replacefile_unix.go
+++ b/pkg/client/replacefile_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package client
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+func replaceFile(source, destination string) error {
+	if err := os.Rename(source, destination); err != nil {
+		return err
+	}
+	directory, err := os.Open(filepath.Dir(destination))
+	if err != nil {
+		return err
+	}
+	syncErr := directory.Sync()
+	closeErr := directory.Close()
+	return errors.Join(syncErr, closeErr)
+}

--- a/pkg/client/replacefile_windows.go
+++ b/pkg/client/replacefile_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package client
+
+import "golang.org/x/sys/windows"
+
+func replaceFile(source, destination string) error {
+	sourcePointer, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	destinationPointer, err := windows.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(
+		sourcePointer,
+		destinationPointer,
+		windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH,
+	)
+}

--- a/pkg/client/settings.go
+++ b/pkg/client/settings.go
@@ -3,12 +3,11 @@ package client
 import (
 	"log/slog"
 	"os"
-	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 )
 
-// Settings stores user preferences persisted as YAML next to the binary.
+// Settings stores user preferences persisted as YAML in the user config directory.
 type Settings struct {
 	MuteKey      string  `yaml:"mute_key"`
 	DeafenKey    string  `yaml:"deafen_key"`
@@ -26,33 +25,63 @@ func DefaultSettings() *Settings {
 	}
 }
 
-func settingsPath() string {
-	exe, err := os.Executable()
-	if err != nil {
-		return "settings.yaml"
-	}
-	return filepath.Join(filepath.Dir(exe), "settings.yaml")
-}
-
 // LoadSettings loads settings from YAML or returns defaults.
 func LoadSettings() *Settings {
-	s := DefaultSettings()
-	data, err := os.ReadFile(settingsPath())
+	path, err := configFilePath("settings.yaml")
 	if err != nil {
+		slog.Error("resolve settings path", "err", err)
+		path = legacyFilePath("settings.yaml")
+	}
+	return loadSettings(path, legacyFilePath("settings.yaml"))
+}
+
+func loadSettings(path, legacyPath string) *Settings {
+	s := DefaultSettings()
+	data, err := os.ReadFile(path) //nolint:gosec // path is resolved from the OS user config directory
+	if err == nil {
+		if err := yaml.Unmarshal(data, s); err != nil {
+			slog.Error("parse settings", "err", err)
+			return DefaultSettings()
+		}
+		return s
+	}
+	if !os.IsNotExist(err) || legacyPath == path {
+		if !os.IsNotExist(err) {
+			slog.Error("read settings", "err", err)
+		}
+		return s
+	}
+
+	data, err = os.ReadFile(legacyPath) //nolint:gosec // legacy path is derived from the current executable
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Error("read legacy settings", "err", err)
+		}
 		return s
 	}
 	if err := yaml.Unmarshal(data, s); err != nil {
-		slog.Error("parse settings", "err", err)
+		slog.Error("parse legacy settings", "err", err)
 		return DefaultSettings()
+	}
+	if err := writePrivateFile(path, data); err != nil {
+		slog.Error("migrate settings", "err", err)
+		return s
+	}
+	if err := os.Remove(legacyPath); err != nil && !os.IsNotExist(err) {
+		slog.Warn("remove migrated legacy settings", "err", err)
 	}
 	return s
 }
 
-// Save writes settings to YAML.
+// Save writes settings atomically to the user config directory.
 func (s *Settings) Save() error {
 	data, err := yaml.Marshal(s)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(settingsPath(), data, 0600)
+	path, err := configFilePath("settings.yaml")
+	if err != nil {
+		return err
+	}
+	return writePrivateFile(path, data)
 }

--- a/pkg/client/settings_test.go
+++ b/pkg/client/settings_test.go
@@ -1,0 +1,77 @@
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadSettingsMigratesLegacyFileToUserConfig(t *testing.T) {
+	dir := t.TempDir()
+	legacyPath := filepath.Join(dir, "legacy", "settings.yaml")
+	configPath := filepath.Join(dir, "config", "settings.yaml")
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("audio_input: Studio Mic\naudio_output: USB Headset\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	settings := loadSettings(configPath, legacyPath)
+	if settings.AudioInput != "Studio Mic" || settings.AudioOutput != "USB Headset" {
+		t.Fatalf("migrated settings = %#v", settings)
+	}
+	assertPrivateFile(t, configPath)
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy settings still exist: %v", err)
+	}
+}
+
+func TestConfigFilePathUsesUserConfigDirectory(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	got, err := configFilePath("settings.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(configHome, "gospeak", "settings.yaml")
+	if got != want {
+		t.Fatalf("config path = %q, want %q", got, want)
+	}
+}
+
+func TestWritePrivateFileReplacesExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gospeak", "settings.yaml")
+	if err := writePrivateFile(path, []byte("old")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writePrivateFile(path, []byte("new")); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path is inside the test's temporary directory
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "new" {
+		t.Fatalf("settings contents = %q, want new", data)
+	}
+	assertPrivateFile(t, path)
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "settings.yaml" {
+		t.Fatalf("config directory entries = %v", entries)
+	}
+}
+
+func assertPrivateFile(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("%s mode = %o, want 600", path, info.Mode().Perm())
+	}
+}

--- a/ui/app.go
+++ b/ui/app.go
@@ -95,6 +95,7 @@ func NewApp() *App {
 	}
 	a.bookmarks.Load() //nolint:errcheck,gosec // best-effort load
 	a.engine.SetVADThreshold(a.settings.VADThreshold)
+	a.engine.SetAudioDevices(a.settings.AudioInput, a.settings.AudioOutput)
 	a.window = a.fyneApp.NewWindow("GoSpeak")
 	a.window.Resize(fyne.NewSize(800, 600))
 	a.window.SetMaster()
@@ -1200,6 +1201,8 @@ func (a *App) showSettingsDialog() {
 			if err := a.settings.Save(); err != nil {
 				slog.Error("save settings", "err", err)
 			}
+			a.engine.SetVADThreshold(a.settings.VADThreshold)
+			a.engine.SetAudioDevices(a.settings.AudioInput, a.settings.AudioOutput)
 
 			// Update global hotkeys live
 			a.hotkeys.SetKeys(a.settings.MuteKey, a.settings.DeafenKey)


### PR DESCRIPTION
## Summary

Applies persisted audio settings and moves client configuration to platform-appropriate user directories.

- opens the selected input and output devices on the next connection
- shows a warning and falls back to the system default when a configured device is unavailable
- sends the 60 ms VAD pre-buffer in chronological order to preserve the beginning of speech
- stores `settings.yaml` and `servers.yaml` under `os.UserConfigDir()/gospeak`
- safely migrates existing configuration files located beside the executable
- writes configuration atomically with restrictive permissions
- uses replace and write-through semantics for atomic configuration updates on Windows
- documents configuration paths, migration behavior and plaintext personal-token storage
- adds regression coverage for device selection, fallback behavior, VAD pre-buffering and because I felt fancy also configuration migration