### PR TITLE
fix: isolate screen viewers and authorization state

### DIFF
--- a/pkg/client/screen.go
+++ b/pkg/client/screen.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/NicolasHaas/gospeak/pkg/protocol"
 )
@@ -33,15 +34,25 @@ func NewScreenClientContext(ctx context.Context, addr string, sessionID uint32, 
 	}
 
 	dialer := &tls.Dialer{Config: tlsCfg}
-	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	dialCtx, cancel := context.WithTimeout(ctx, connectTimeout)
+	defer cancel()
+	conn, err := dialer.DialContext(dialCtx, "tcp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("client: connect screen: %w", err)
 	}
 	stopCancel := context.AfterFunc(ctx, func() { _ = conn.Close() })
 	defer stopCancel()
+	if err := conn.SetWriteDeadline(time.Now().Add(connectTimeout)); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("client: set screen auth deadline: %w", err)
+	}
 	if err := protocol.WriteScreenAuth(conn, &protocol.ScreenAuth{SessionID: sessionID, Token: authToken}); err != nil {
 		_ = conn.Close()
 		return nil, fmt.Errorf("client: authenticate screen: %w", err)
+	}
+	if err := conn.SetWriteDeadline(time.Time{}); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("client: clear screen auth deadline: %w", err)
 	}
 
 	return &ScreenClient{conn: conn, done: make(chan struct{})}, nil

--- a/pkg/protocol/screen.go
+++ b/pkg/protocol/screen.go
@@ -63,21 +63,46 @@ func UnmarshalScreenPacket(data []byte) (*ScreenPacket, error) {
 }
 
 func WriteScreenPacket(w io.Writer, pkt *ScreenPacket) error {
+	frame, err := MarshalScreenPacketFrame(pkt)
+	if err != nil {
+		return err
+	}
+	return WriteScreenPacketFrame(w, frame)
+}
+
+// MarshalScreenPacketFrame returns one immutable length-prefixed wire frame.
+func MarshalScreenPacketFrame(pkt *ScreenPacket) ([]byte, error) {
+	if pkt == nil {
+		return nil, errors.New("protocol: nil screen packet")
+	}
 	data := pkt.Marshal()
 	if len(data) > MaxScreenPacket {
-		return fmt.Errorf("protocol: screen packet too large: %d bytes", len(data))
+		return nil, fmt.Errorf("protocol: screen packet too large: %d bytes", len(data))
 	}
 	n, err := checkUint32(len(data))
 	if err != nil {
-		return fmt.Errorf("protocol: write screen length: %w", err)
+		return nil, fmt.Errorf("protocol: write screen length: %w", err)
 	}
-	lenBuf := make([]byte, 4)
-	binary.BigEndian.PutUint32(lenBuf, n)
-	if _, err := w.Write(lenBuf); err != nil {
-		return fmt.Errorf("protocol: write screen length: %w", err)
-	}
-	if _, err := w.Write(data); err != nil {
-		return fmt.Errorf("protocol: write screen payload: %w", err)
+	frame := make([]byte, 4+len(data))
+	binary.BigEndian.PutUint32(frame[:4], n)
+	copy(frame[4:], data)
+	return frame, nil
+}
+
+// WriteScreenPacketFrame writes a frame returned by MarshalScreenPacketFrame.
+func WriteScreenPacketFrame(w io.Writer, frame []byte) error {
+	for len(frame) > 0 {
+		n, err := w.Write(frame)
+		if n < 0 || n > len(frame) {
+			return fmt.Errorf("protocol: invalid screen write count: %d", n)
+		}
+		frame = frame[n:]
+		if err != nil {
+			return fmt.Errorf("protocol: write screen frame: %w", err)
+		}
+		if n == 0 {
+			return fmt.Errorf("protocol: write screen frame: %w", io.ErrShortWrite)
+		}
 	}
 	return nil
 }

--- a/pkg/protocol/screen_test.go
+++ b/pkg/protocol/screen_test.go
@@ -5,6 +5,20 @@ import (
 	"testing"
 )
 
+type shortScreenWriter struct {
+	buf      bytes.Buffer
+	maxWrite int
+	writes   int
+}
+
+func (w *shortScreenWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if len(p) > w.maxWrite {
+		p = p[:w.maxWrite]
+	}
+	return w.buf.Write(p)
+}
+
 func TestScreenPacketRoundTrip(t *testing.T) {
 	original := &ScreenPacket{
 		SessionID: 42,
@@ -88,5 +102,23 @@ func TestMarshalScreenFrame_RejectsInvalidFormat(t *testing.T) {
 	_, err := MarshalScreenFrame(&ScreenFrame{Format: "", Data: []byte{1}})
 	if err == nil {
 		t.Fatalf("MarshalScreenFrame() error = nil, want non-nil")
+	}
+}
+
+func TestWriteScreenPacketHandlesShortWrites(t *testing.T) {
+	pkt := &ScreenPacket{SessionID: 42, SeqNum: 7, Payload: []byte("ciphertext")}
+	w := &shortScreenWriter{maxWrite: 3}
+	if err := WriteScreenPacket(w, pkt); err != nil {
+		t.Fatalf("WriteScreenPacket: %v", err)
+	}
+	if w.writes < 2 {
+		t.Fatalf("Write calls = %d, want multiple short writes", w.writes)
+	}
+	got, err := ReadScreenPacket(&w.buf)
+	if err != nil {
+		t.Fatalf("ReadScreenPacket: %v", err)
+	}
+	if got.SessionID != pkt.SessionID || got.SeqNum != pkt.SeqNum || !bytes.Equal(got.Payload, pkt.Payload) {
+		t.Fatalf("round trip = %#v, want %#v", got, pkt)
 	}
 }

--- a/pkg/server/screen.go
+++ b/pkg/server/screen.go
@@ -80,8 +80,8 @@ func (s *Server) handleScreenConn(conn net.Conn) {
 	}
 	s.finishPreAuth(conn)
 
-	s.setScreenConn(auth.SessionID, conn)
-	defer s.removeScreenConn(auth.SessionID, conn)
+	client := s.setScreenConn(auth.SessionID, conn)
+	defer s.removeScreenConn(auth.SessionID, client)
 
 	for {
 		pkt, err := protocol.ReadScreenPacket(conn)
@@ -112,13 +112,18 @@ func (s *Server) handleScreenPacket(sessionID uint32, pkt *protocol.ScreenPacket
 	}
 
 	pkt.SessionID = sessionID
+	frame, err := protocol.MarshalScreenPacketFrame(pkt)
+	if err != nil {
+		slog.Error("marshal screen packet", "session", sessionID, "err", err)
+		return
+	}
 	s.metrics.ScreenShareFramesIn.Add(1)
 	s.metrics.ScreenShareBytesIn.Add(int64(len(pkt.Payload)))
 
 	viewers := s.screenShare.SubscribersForSharer(sessionID)
 	forwarded := 0
 	for _, viewerSessionID := range viewers {
-		if s.sendScreenPacketToSession(viewerSessionID, pkt) {
+		if s.sendScreenFrameToSession(viewerSessionID, frame) {
 			forwarded++
 		}
 	}

--- a/pkg/server/screenshare.go
+++ b/pkg/server/screenshare.go
@@ -116,10 +116,14 @@ func (m *ScreenShareManager) stopBySessionLocked(sessionID uint32) (*pb.ScreenSh
 	delete(m.channelBySession, sessionID)
 	delete(m.lastFrameAt, sessionID)
 	for viewer := range m.authorizedByShare[sessionID] {
-		delete(m.authorizedTarget, viewer)
+		if m.authorizedTarget[viewer] == sessionID {
+			delete(m.authorizedTarget, viewer)
+		}
 	}
 	for viewer := range m.subscribersByShare[sessionID] {
-		delete(m.viewerTarget, viewer)
+		if m.viewerTarget[viewer] == sessionID {
+			delete(m.viewerTarget, viewer)
+		}
 	}
 	delete(m.authorizedByShare, sessionID)
 	delete(m.subscribersByShare, sessionID)
@@ -185,6 +189,7 @@ func (m *ScreenShareManager) ShareWithViewers(sharerSessionID uint32, viewerSess
 		if m.authorizedTarget[viewerSessionID] == sharerSessionID {
 			continue
 		}
+		m.removeViewerLocked(viewerSessionID)
 		m.authorizedByShare[sharerSessionID][viewerSessionID] = true
 		m.authorizedTarget[viewerSessionID] = sharerSessionID
 		shared = append(shared, viewerSessionID)

--- a/pkg/server/screenshare_test.go
+++ b/pkg/server/screenshare_test.go
@@ -1,9 +1,37 @@
 package server
 
 import (
+	"net"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/NicolasHaas/gospeak/pkg/protocol"
 )
+
+type blockingScreenConn struct {
+	nopConn
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (c *blockingScreenConn) Write(p []byte) (int, error) {
+	c.once.Do(func() { close(c.started) })
+	<-c.release
+	return len(p), nil
+}
+
+type signalingScreenConn struct {
+	nopConn
+	wrote chan struct{}
+	once  sync.Once
+}
+
+func (c *signalingScreenConn) Write(p []byte) (int, error) {
+	c.once.Do(func() { close(c.wrote) })
+	return len(p), nil
+}
 
 func TestScreenShareManager_PublicEventHidesEncryptionKey(t *testing.T) {
 	mgr := NewScreenShareManager()
@@ -133,3 +161,78 @@ func TestSessionManager_ValidateScreenAuth(t *testing.T) {
 		t.Fatalf("ValidateScreenAuth(wrong) = true, want false")
 	}
 }
+
+func TestScreenShareManager_ReassigningViewerRemovesOldAuthorization(t *testing.T) {
+	mgr := NewScreenShareManager()
+	if _, err := mgr.Start(1, 10, 20, "alice", 800, 600); err != nil {
+		t.Fatalf("Start share A: %v", err)
+	}
+	if _, err := mgr.Start(2, 11, 21, "bob", 800, 600); err != nil {
+		t.Fatalf("Start share B: %v", err)
+	}
+	if _, _, err := mgr.ShareWithViewers(10, []uint32{30}); err != nil {
+		t.Fatalf("share A: %v", err)
+	}
+	if _, err := mgr.Subscribe(1, 30); err != nil {
+		t.Fatalf("Subscribe(A): %v", err)
+	}
+	if _, _, err := mgr.ShareWithViewers(11, []uint32{30}); err != nil {
+		t.Fatalf("share B: %v", err)
+	}
+
+	if mgr.authorizedByShare[10][30] {
+		t.Fatalf("viewer remains authorized for old share")
+	}
+	if mgr.subscribersByShare[10][30] {
+		t.Fatalf("viewer remains subscribed to old share")
+	}
+	if !mgr.authorizedByShare[11][30] || mgr.authorizedTarget[30] != 11 {
+		t.Fatalf("viewer authorization does not point only to new share")
+	}
+
+	if _, ok := mgr.StopBySession(10); !ok {
+		t.Fatalf("StopBySession(A): ok = false, want true")
+	}
+	if _, err := mgr.Subscribe(2, 30); err != nil {
+		t.Fatalf("Subscribe(B) after stopping A: %v", err)
+	}
+}
+
+func TestScreenRelay_SlowViewerDoesNotBlockOtherViewer(t *testing.T) {
+	s := New(DefaultConfig(), Dependencies{})
+	slow := &blockingScreenConn{started: make(chan struct{}), release: make(chan struct{})}
+	fast := &signalingScreenConn{wrote: make(chan struct{})}
+	s.setScreenConn(1, slow)
+	s.setScreenConn(2, fast)
+	t.Cleanup(func() {
+		close(slow.release)
+		s.closeScreenConns()
+	})
+
+	pkt := &protocol.ScreenPacket{SessionID: 9, SeqNum: 1, Payload: []byte("frame")}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.sendScreenPacketToSession(1, pkt)
+		s.sendScreenPacketToSession(2, pkt)
+	}()
+
+	select {
+	case <-slow.started:
+	case <-time.After(time.Second):
+		t.Fatal("slow viewer write did not start")
+	}
+	select {
+	case <-fast.wrote:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("fast viewer was blocked by slow viewer")
+	}
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("screen relay remained blocked on slow viewer")
+	}
+}
+
+var _ net.Conn = (*blockingScreenConn)(nil)
+var _ net.Conn = (*signalingScreenConn)(nil)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -65,7 +65,7 @@ type Server struct {
 	voiceConn     *net.UDPConn
 	screenConn    net.Listener
 	screenMu      sync.RWMutex
-	screenConns   map[uint32]net.Conn
+	screenConns   map[uint32]*screenClientConn
 	voiceKey      []byte // shared AES-128 key for all voice encryption
 	authLimiter   *authRateLimiter
 	preAuthMu     sync.Mutex
@@ -96,7 +96,7 @@ func New(cfg Config, deps Dependencies) *Server {
 		channels:      NewChannelManager(),
 		screenShare:   NewScreenShareManager(),
 		metrics:       NewMetrics(),
-		screenConns:   make(map[uint32]net.Conn),
+		screenConns:   make(map[uint32]*screenClientConn),
 		voiceStats:    make(map[uint32]*perSessionVoiceStat),
 		store:         deps.Store,
 		authLimiter:   newAuthRateLimiter(authRateLimitAttempts, authRateLimitWindow),
@@ -168,45 +168,123 @@ func (s *Server) closeAcceptedConns() {
 	}
 }
 
-func (s *Server) setScreenConn(sessionID uint32, conn net.Conn) {
-	s.screenMu.Lock()
-	old := s.screenConns[sessionID]
-	s.screenConns[sessionID] = conn
-	s.screenMu.Unlock()
-	if old != nil && old != conn {
-		_ = old.Close()
+const screenWriteTimeout = 2 * time.Second
+
+type screenClientConn struct {
+	conn      net.Conn
+	outbound  chan []byte
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+func (c *screenClientConn) close() {
+	c.closeOnce.Do(func() {
+		close(c.done)
+		_ = c.conn.Close()
+	})
+}
+
+func (c *screenClientConn) enqueue(frame []byte) bool {
+	select {
+	case <-c.done:
+		return false
+	default:
+	}
+	select {
+	case c.outbound <- frame:
+		return true
+	default:
+	}
+	select {
+	case <-c.outbound:
+	default:
+	}
+	select {
+	case c.outbound <- frame:
+		return true
+	case <-c.done:
+		return false
+	default:
+		return false
 	}
 }
 
-func (s *Server) removeScreenConn(sessionID uint32, conn net.Conn) {
+func (s *Server) setScreenConn(sessionID uint32, conn net.Conn) *screenClientConn {
+	client := &screenClientConn{
+		conn:     conn,
+		outbound: make(chan []byte, 1),
+		done:     make(chan struct{}),
+	}
+	s.screenMu.Lock()
+	old := s.screenConns[sessionID]
+	s.screenConns[sessionID] = client
+	s.screenMu.Unlock()
+	if old != nil {
+		old.close()
+	}
+	go s.writeScreenPackets(sessionID, client)
+	return client
+}
+
+func (s *Server) writeScreenPackets(sessionID uint32, client *screenClientConn) {
+	for {
+		select {
+		case frame := <-client.outbound:
+			if err := client.conn.SetWriteDeadline(time.Now().Add(screenWriteTimeout)); err != nil {
+				slog.Error("set screen write deadline", "session", sessionID, "err", err)
+				s.removeScreenConn(sessionID, client)
+				return
+			}
+			if err := protocol.WriteScreenPacketFrame(client.conn, frame); err != nil {
+				slog.Warn("screen write failed", "session", sessionID, "err", err)
+				s.removeScreenConn(sessionID, client)
+				return
+			}
+		case <-client.done:
+			return
+		}
+	}
+}
+
+func (s *Server) removeScreenConn(sessionID uint32, client *screenClientConn) {
 	s.screenMu.Lock()
 	current := s.screenConns[sessionID]
-	if current == conn {
+	if current == client {
 		delete(s.screenConns, sessionID)
 	}
 	s.screenMu.Unlock()
+	client.close()
 }
 
 func (s *Server) sendScreenPacketToSession(sessionID uint32, pkt *protocol.ScreenPacket) bool {
+	frame, err := protocol.MarshalScreenPacketFrame(pkt)
+	if err != nil {
+		slog.Error("marshal screen packet", "session", sessionID, "err", err)
+		return false
+	}
+	return s.sendScreenFrameToSession(sessionID, frame)
+}
+
+func (s *Server) sendScreenFrameToSession(sessionID uint32, frame []byte) bool {
 	s.screenMu.RLock()
-	conn, ok := s.screenConns[sessionID]
+	client, ok := s.screenConns[sessionID]
 	s.screenMu.RUnlock()
 	if !ok {
 		return false
 	}
-	if err := protocol.WriteScreenPacket(conn, pkt); err != nil {
-		slog.Error("screen write failed", "session", sessionID, "err", err)
-		return false
-	}
-	return true
+	return client.enqueue(frame)
 }
 
 func (s *Server) closeScreenConns() {
 	s.screenMu.Lock()
-	defer s.screenMu.Unlock()
-	for sessionID, conn := range s.screenConns {
-		_ = conn.Close()
-		delete(s.screenConns, sessionID)
+	clients := make([]*screenClientConn, 0, len(s.screenConns))
+	for _, client := range s.screenConns {
+		clients = append(clients, client)
+	}
+	s.screenConns = make(map[uint32]*screenClientConn)
+	s.screenMu.Unlock()
+	for _, client := range clients {
+		client.close()
 	}
 }
 


### PR DESCRIPTION
## Summary

Prevents slow screen viewers from blocking the sharer or other viewers and keeps screen-share authorization state consistent.

- gives each viewer an isolated writer goroutine with a bounded latest-frame queue
- applies write deadlines so stalled viewers cannot block relay progress indefinitely
- serializes each screen packet once and distributes the immutable wire frame
- handles short writes when framing screen packets
- removes the previous subscription and authorization when a viewer switches shares
- prevents stopping an old share from clearing authorization for the viewer's current share
- adds bounded client dial, TLS-handshake and authentication-write timeouts
- adds regression coverage for slow-viewer isolation, short writes and share-switch authorization cleanup