### PR TITLE
fix(server): clean up lifecycle resources

### DIFF
--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -63,14 +63,12 @@ type controlClient struct {
 }
 
 func newControlClient(sessionID uint32, conn net.Conn) *controlClient {
-	client := &controlClient{
+	return &controlClient{
 		Conn:      conn,
 		sessionID: sessionID,
 		sendQueue: make(chan queuedControlMessage, controlSendQueueSize),
 		done:      make(chan struct{}),
 	}
-	go client.writeLoop()
-	return client
 }
 
 func (c *controlClient) send(msg *pb.ControlMessage) error {
@@ -250,6 +248,10 @@ func newControlHandler(srv *Server, st datastore.DataProviderFactory) *ControlHa
 // setConn registers a connection with a dedicated serialized writer.
 func (ch *ControlHandler) setConn(sessionID uint32, conn net.Conn) *controlClient {
 	client := newControlClient(sessionID, conn)
+	if !ch.server.startWorker(client.writeLoop) {
+		_ = client.Close()
+		return client
+	}
 	ch.mu.Lock()
 	previous := ch.connMap[sessionID]
 	ch.connMap[sessionID] = client
@@ -323,6 +325,24 @@ func (ch *ControlHandler) broadcastToChannel(channelID int64, msg *pb.ControlMes
 
 // StartControl starts the TCP/TLS control listener.
 func (s *Server) StartControl(st datastore.DataProviderFactory) error {
+	if !s.beginTask() {
+		return fmt.Errorf("server: start control: %w", s.ctx.Err())
+	}
+	defer s.endTask()
+
+	s.listenerMu.Lock()
+	if s.controlStarting || s.controlConn != nil {
+		s.listenerMu.Unlock()
+		return fmt.Errorf("server: control already started")
+	}
+	s.controlStarting = true
+	s.listenerMu.Unlock()
+	defer func() {
+		s.listenerMu.Lock()
+		s.controlStarting = false
+		s.listenerMu.Unlock()
+	}()
+
 	cert, err := loadOrGenerateTLS(s.cfg)
 	if err != nil {
 		return fmt.Errorf("server: tls: %w", err)
@@ -337,15 +357,20 @@ func (s *Server) StartControl(st datastore.DataProviderFactory) error {
 	if err != nil {
 		return fmt.Errorf("server: listen control: %w", err)
 	}
+	s.listenerMu.Lock()
 	s.controlConn = ln
+	s.listenerMu.Unlock()
 
 	handler := newControlHandler(s, st)
 	slog.Info("control plane listening", "addr", s.cfg.ControlAddr)
 	if s.cfg.EnableScreenShare {
-		go s.runScreenShareJanitor(handler)
+		if !s.startWorker(func() { s.runScreenShareJanitor(handler) }) {
+			_ = ln.Close()
+			return fmt.Errorf("server: start screen-share janitor: %w", s.ctx.Err())
+		}
 	}
 
-	go func() {
+	if !s.startWorker(func() {
 		for {
 			conn, err := ln.Accept()
 			if err != nil {
@@ -362,9 +387,16 @@ func (s *Server) StartControl(st datastore.DataProviderFactory) error {
 				_ = conn.Close()
 				continue
 			}
-			go s.handleControlConn(handler, conn, st)
+			acceptedConn := conn
+			if !s.startWorker(func() { s.handleControlConn(handler, acceptedConn, st) }) {
+				s.forgetAcceptedConn(conn)
+				_ = conn.Close()
+			}
 		}
-	}()
+	}) {
+		_ = ln.Close()
+		return fmt.Errorf("server: start control worker: %w", s.ctx.Err())
+	}
 
 	return nil
 }
@@ -413,6 +445,7 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 	rateLimitKey := authRateLimitKey(conn.RemoteAddr())
 	s.metrics.TotalConnections.Add(1)
 	s.metrics.ActiveConnections.Add(1)
+	defer s.metrics.ActiveConnections.Add(-1)
 	slog.Debug("new control connection", "remote", remoteAddr)
 
 	// Rate limit failed authentication attempts per remote IP.
@@ -574,7 +607,6 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 		handler.removeConn(sessionID)
 		s.sessions.Remove(sessionID)
 		s.removeVoiceStat(sessionID)
-		s.metrics.ActiveConnections.Add(-1)
 		s.metrics.TotalDisconnects.Add(1)
 		slog.Info("client disconnected", "user", user.Username, "session", sessionID)
 
@@ -1195,8 +1227,14 @@ func (s *Server) cleanupTempChannel(channelID int64, st datastore.DataProviderFa
 		return
 	}
 
-	go func() {
-		time.Sleep(5 * time.Minute)
+	s.startWorker(func() {
+		timer := time.NewTimer(5 * time.Minute)
+		defer timer.Stop()
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-timer.C:
+		}
 		// Re-check after grace period
 		if s.channels.MembersCount(channelID) > 0 {
 			return
@@ -1206,7 +1244,7 @@ func (s *Server) cleanupTempChannel(channelID int64, st datastore.DataProviderFa
 			return
 		}
 		slog.Debug("auto-deleted empty temp channel after 5m", "name", ch.Name, "id", channelID)
-	}()
+	})
 }
 
 func sendError(conn net.Conn, code int32, message string) {

--- a/pkg/server/lifecycle_test.go
+++ b/pkg/server/lifecycle_test.go
@@ -1,0 +1,629 @@
+package server
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/NicolasHaas/gospeak/pkg/datastore"
+	"github.com/NicolasHaas/gospeak/pkg/protocol"
+	"github.com/NicolasHaas/gospeak/pkg/protocol/pb"
+)
+
+func listenTCP(t *testing.T, addr string) net.Listener {
+	t.Helper()
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(context.Background(), "tcp", addr)
+	if err != nil {
+		t.Fatalf("Listen on %s: %v", addr, err)
+	}
+	return listener
+}
+
+func dialTCP(addr string, timeout time.Duration) (net.Conn, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	var dialer net.Dialer
+	return dialer.DialContext(ctx, "tcp", addr)
+}
+
+func waitForStopping(t *testing.T, srv *Server) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		srv.workerMu.Lock()
+		stopping := srv.stopping
+		srv.workerMu.Unlock()
+		if stopping {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("Shutdown did not enter stopping state")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func concurrentStartResults(start func() error) [2]error {
+	gate := make(chan struct{})
+	var wg sync.WaitGroup
+	var results [2]error
+	for i := range results {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-gate
+			results[i] = start()
+		}()
+	}
+	close(gate)
+	wg.Wait()
+	return results
+}
+
+func requireSingleSuccessfulStart(t *testing.T, plane string, results [2]error) {
+	t.Helper()
+	successes := 0
+	rejections := 0
+	for _, err := range results {
+		if err == nil {
+			successes++
+		} else if strings.Contains(err.Error(), "already started") {
+			rejections++
+		}
+	}
+	if successes != 1 || rejections != 1 {
+		t.Fatalf("concurrent %s starts returned %v; want one success and one already-started error", plane, results)
+	}
+}
+
+func TestRejectedControlConnectionDoesNotLeakActiveMetric(t *testing.T) {
+	srv, st, _ := newTestServer(t)
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+
+	go func() {
+		srv.handleControlConn(newControlHandler(srv, st), serverConn, st)
+		close(done)
+	}()
+
+	if err := clientConn.Close(); err != nil {
+		t.Fatalf("Close client connection: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("control handler did not return")
+	}
+
+	if got := srv.metrics.ActiveConnections.Load(); got != 0 {
+		t.Fatalf("ActiveConnections = %d after rejected connection, want 0", got)
+	}
+	if got := srv.metrics.TotalConnections.Load(); got != 1 {
+		t.Fatalf("TotalConnections = %d, want 1", got)
+	}
+}
+
+func TestRunCleansUpControlListenerWhenVoiceStartFails(t *testing.T) {
+	voiceBlocker, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1")})
+	if err != nil {
+		t.Fatalf("Reserve voice address: %v", err)
+	}
+	defer func() { _ = voiceBlocker.Close() }()
+
+	cfg := DefaultConfig()
+	cfg.ControlAddr = "127.0.0.1:0"
+	cfg.VoiceAddr = voiceBlocker.LocalAddr().String()
+	cfg.MetricsAddr = ""
+	cfg.DataDir = t.TempDir()
+	cfg.DBPath = cfg.DataDir + "/gospeak.db"
+
+	st, err := datastore.NewProviderFactory(cfg.DBPath)
+	if err != nil {
+		t.Fatalf("Create datastore: %v", err)
+	}
+	defer func() {
+		if err := st.Close(); err != nil {
+			t.Errorf("Close datastore: %v", err)
+		}
+	}()
+
+	srv := New(cfg, Dependencies{Store: st})
+	defer srv.Shutdown()
+
+	err = srv.Run()
+	if err == nil || !strings.Contains(err.Error(), "listen voice") {
+		t.Fatalf("Run error = %v, want voice listener failure", err)
+	}
+	if srv.ctx.Err() == nil {
+		t.Fatal("server context remains active after partial startup failure")
+	}
+	if srv.controlConn == nil {
+		t.Fatal("control listener was not started before voice failure")
+	}
+
+	controlListener := listenTCP(t, srv.controlConn.Addr().String())
+	_ = controlListener.Close()
+}
+
+func TestStartMetricsHTTPReportsBindFailure(t *testing.T) {
+	blocker := listenTCP(t, "127.0.0.1:0")
+	defer func() { _ = blocker.Close() }()
+
+	cfg := DefaultConfig()
+	cfg.MetricsAddr = blocker.Addr().String()
+	srv := New(cfg, Dependencies{})
+	defer srv.Shutdown()
+
+	if err := srv.startMetricsHTTP(); err == nil {
+		t.Fatal("StartMetricsHTTP succeeded with an occupied address")
+	}
+}
+
+func TestShutdownClosesMetricsListenerAndIsIdempotent(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MetricsAddr = "127.0.0.1:0"
+	srv := New(cfg, Dependencies{})
+
+	if err := srv.startMetricsHTTP(); err != nil {
+		t.Fatalf("StartMetricsHTTP: %v", err)
+	}
+	srv.metricsMu.Lock()
+	addr := srv.metricsConn.Addr().String()
+	srv.metricsMu.Unlock()
+
+	conn, err := dialTCP(addr, time.Second)
+	if err != nil {
+		t.Fatalf("Dial metrics listener: %v", err)
+	}
+	_ = conn.Close()
+
+	srv.Shutdown()
+	srv.Shutdown()
+	metricsListener := listenTCP(t, addr)
+	_ = metricsListener.Close()
+}
+
+func TestRunReportsMetricsFailureAndCleansUpListeners(t *testing.T) {
+	metricsBlocker := listenTCP(t, "127.0.0.1:0")
+	defer func() { _ = metricsBlocker.Close() }()
+
+	cfg := DefaultConfig()
+	cfg.ControlAddr = "127.0.0.1:0"
+	cfg.VoiceAddr = "127.0.0.1:0"
+	cfg.ScreenAddr = "127.0.0.1:0"
+	cfg.MetricsAddr = metricsBlocker.Addr().String()
+	cfg.EnableScreenShare = true
+	cfg.DataDir = t.TempDir()
+	cfg.DBPath = cfg.DataDir + "/gospeak.db"
+
+	st, err := datastore.NewProviderFactory(cfg.DBPath)
+	if err != nil {
+		t.Fatalf("Create datastore: %v", err)
+	}
+	defer func() {
+		if err := st.Close(); err != nil {
+			t.Errorf("Close datastore: %v", err)
+		}
+	}()
+
+	srv := New(cfg, Dependencies{Store: st})
+	err = srv.Run()
+	if err == nil || !strings.Contains(err.Error(), "listen metrics") {
+		t.Fatalf("Run error = %v, want metrics listener failure", err)
+	}
+	if srv.ctx.Err() == nil {
+		t.Fatal("server context remains active after metrics startup failure")
+	}
+	if srv.controlConn == nil || srv.voiceConn == nil || srv.screenConn == nil {
+		t.Fatal("control, voice, and screen listeners must start before the metrics failure")
+	}
+
+	controlListener := listenTCP(t, srv.controlConn.Addr().String())
+	_ = controlListener.Close()
+	voiceAddr, ok := srv.voiceConn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		t.Fatalf("voice listener address has type %T", srv.voiceConn.LocalAddr())
+	}
+	voiceListener, err := net.ListenUDP("udp", voiceAddr)
+	if err != nil {
+		t.Fatalf("Voice address remains occupied after metrics startup failure: %v", err)
+	}
+	_ = voiceListener.Close()
+	screenListener := listenTCP(t, srv.screenConn.Addr().String())
+	_ = screenListener.Close()
+}
+
+func TestShutdownStopsRunAndReleasesListeners(t *testing.T) {
+	controlProbe := listenTCP(t, "127.0.0.1:0")
+	controlAddr := controlProbe.Addr().String()
+	_ = controlProbe.Close()
+	screenProbe := listenTCP(t, "127.0.0.1:0")
+	screenAddr := screenProbe.Addr().String()
+	_ = screenProbe.Close()
+	metricsProbe := listenTCP(t, "127.0.0.1:0")
+	metricsAddr := metricsProbe.Addr().String()
+	_ = metricsProbe.Close()
+
+	voiceProbe, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1")})
+	if err != nil {
+		t.Fatalf("Reserve voice address: %v", err)
+	}
+	voiceAddr := voiceProbe.LocalAddr().(*net.UDPAddr)
+	_ = voiceProbe.Close()
+
+	cfg := DefaultConfig()
+	cfg.ControlAddr = controlAddr
+	cfg.VoiceAddr = voiceAddr.String()
+	cfg.ScreenAddr = screenAddr
+	cfg.MetricsAddr = metricsAddr
+	cfg.EnableScreenShare = true
+	cfg.DataDir = t.TempDir()
+	cfg.DBPath = cfg.DataDir + "/gospeak.db"
+
+	st, err := datastore.NewProviderFactory(cfg.DBPath)
+	if err != nil {
+		t.Fatalf("Create datastore: %v", err)
+	}
+	defer func() {
+		if err := st.Close(); err != nil {
+			t.Errorf("Close datastore: %v", err)
+		}
+	}()
+
+	srv := New(cfg, Dependencies{Store: st})
+	runDone := make(chan error, 1)
+	go func() { runDone <- srv.Run() }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		controlConn, controlErr := dialTCP(controlAddr, 20*time.Millisecond)
+		if controlErr == nil {
+			_ = controlConn.Close()
+		}
+		screenConn, screenErr := dialTCP(screenAddr, 20*time.Millisecond)
+		if screenErr == nil {
+			_ = screenConn.Close()
+		}
+		metricsConn, metricsErr := dialTCP(metricsAddr, 20*time.Millisecond)
+		if metricsErr == nil {
+			_ = metricsConn.Close()
+		}
+		voiceListener, voiceErr := net.ListenUDP("udp", voiceAddr)
+		if voiceErr == nil {
+			_ = voiceListener.Close()
+		}
+		if controlErr == nil && screenErr == nil && metricsErr == nil && voiceErr != nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			srv.Shutdown()
+			t.Fatal("server listeners did not become ready")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	srv.Shutdown()
+	select {
+	case err := <-runDone:
+		if err != nil {
+			t.Fatalf("Run returned after Shutdown with error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after Shutdown")
+	}
+
+	for name, addr := range map[string]string{
+		"control": controlAddr,
+		"screen":  screenAddr,
+		"metrics": metricsAddr,
+	} {
+		listener := listenTCP(t, addr)
+		if err := listener.Close(); err != nil {
+			t.Errorf("Close rebound %s listener: %v", name, err)
+		}
+	}
+	voiceListener, err := net.ListenUDP("udp", voiceAddr)
+	if err != nil {
+		t.Fatalf("Voice address remains occupied after Shutdown: %v", err)
+	}
+	_ = voiceListener.Close()
+}
+
+func TestAuthenticatedControlConnectionBalancesMetrics(t *testing.T) {
+	srv, st, handler := newTestServer(t)
+	srv.cfg.AllowNoToken = true
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+
+	go func() {
+		srv.handleControlConn(handler, serverConn, st)
+		close(done)
+	}()
+	if err := protocol.WriteControlMessage(clientConn, &pb.ControlMessage{
+		AuthRequest: &pb.AuthRequest{Username: "lifecycle-user"},
+	}); err != nil {
+		t.Fatalf("Write AuthRequest: %v", err)
+	}
+	response, err := protocol.ReadControlMessage(clientConn)
+	if err != nil {
+		t.Fatalf("Read AuthResponse: %v", err)
+	}
+	if response.AuthResponse == nil || response.AuthResponse.SessionID == 0 {
+		t.Fatalf("AuthResponse = %#v, want assigned session", response.AuthResponse)
+	}
+	if err := clientConn.Close(); err != nil {
+		t.Fatalf("Close client connection: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("authenticated control handler did not return")
+	}
+	srv.Shutdown()
+
+	if got := srv.metrics.TotalConnections.Load(); got != 1 {
+		t.Fatalf("TotalConnections = %d, want 1", got)
+	}
+	if got := srv.metrics.ActiveConnections.Load(); got != 0 {
+		t.Fatalf("ActiveConnections = %d, want 0", got)
+	}
+	if got := srv.metrics.TotalDisconnects.Load(); got != 1 {
+		t.Fatalf("TotalDisconnects = %d, want 1", got)
+	}
+}
+
+func TestRunCleansUpControlAndVoiceWhenScreenStartFails(t *testing.T) {
+	screenBlocker := listenTCP(t, "127.0.0.1:0")
+	defer func() { _ = screenBlocker.Close() }()
+
+	cfg := DefaultConfig()
+	cfg.ControlAddr = "127.0.0.1:0"
+	cfg.VoiceAddr = "127.0.0.1:0"
+	cfg.ScreenAddr = screenBlocker.Addr().String()
+	cfg.MetricsAddr = ""
+	cfg.EnableScreenShare = true
+	cfg.DataDir = t.TempDir()
+	cfg.DBPath = cfg.DataDir + "/gospeak.db"
+
+	st, err := datastore.NewProviderFactory(cfg.DBPath)
+	if err != nil {
+		t.Fatalf("Create datastore: %v", err)
+	}
+	defer func() {
+		if err := st.Close(); err != nil {
+			t.Errorf("Close datastore: %v", err)
+		}
+	}()
+
+	srv := New(cfg, Dependencies{Store: st})
+	err = srv.Run()
+	if err == nil || !strings.Contains(err.Error(), "listen screen") {
+		t.Fatalf("Run error = %v, want screen listener failure", err)
+	}
+	if srv.ctx.Err() == nil {
+		t.Fatal("server context remains active after screen startup failure")
+	}
+	if srv.controlConn == nil || srv.voiceConn == nil {
+		t.Fatal("control and voice listeners must start before the screen failure")
+	}
+
+	controlListener := listenTCP(t, srv.controlConn.Addr().String())
+	_ = controlListener.Close()
+	voiceAddr, ok := srv.voiceConn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		t.Fatalf("voice listener address has type %T", srv.voiceConn.LocalAddr())
+	}
+	voiceListener, err := net.ListenUDP("udp", voiceAddr)
+	if err != nil {
+		t.Fatalf("Voice address remains occupied after screen startup failure: %v", err)
+	}
+	_ = voiceListener.Close()
+}
+
+func TestShutdownWaitsForServerWorkers(t *testing.T) {
+	srv := New(DefaultConfig(), Dependencies{})
+	started := make(chan struct{})
+	release := make(chan struct{})
+	if !srv.startWorker(func() {
+		close(started)
+		<-release
+	}) {
+		t.Fatal("startWorker rejected worker before shutdown")
+	}
+	<-started
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		srv.Shutdown()
+		close(shutdownDone)
+	}()
+	waitForStopping(t, srv)
+	select {
+	case <-shutdownDone:
+		t.Fatal("Shutdown returned before server worker stopped")
+	default:
+	}
+
+	close(release)
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("Shutdown did not return after server worker stopped")
+	}
+	if srv.startWorker(func() {}) {
+		t.Fatal("startWorker accepted worker after shutdown")
+	}
+}
+
+func TestShutdownWaitsForInFlightStartupTask(t *testing.T) {
+	probe := listenTCP(t, "127.0.0.1:0")
+	addr := probe.Addr().String()
+	_ = probe.Close()
+
+	srv := New(DefaultConfig(), Dependencies{})
+	if !srv.beginTask() {
+		t.Fatal("beginTask rejected startup task before shutdown")
+	}
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		srv.Shutdown()
+		close(shutdownDone)
+	}()
+	waitForStopping(t, srv)
+
+	listener := listenTCP(t, addr)
+	select {
+	case <-shutdownDone:
+		_ = listener.Close()
+		srv.endTask()
+		t.Fatal("Shutdown returned while an admitted startup task owned a listener")
+	default:
+	}
+	_ = listener.Close()
+	srv.endTask()
+
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("Shutdown did not return after startup task released its listener")
+	}
+	rebound := listenTCP(t, addr)
+	_ = rebound.Close()
+}
+
+func TestShutdownWaitsForMetricsHandler(t *testing.T) {
+	srv := New(DefaultConfig(), Dependencies{})
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	handlerDone := make(chan struct{})
+	handler := srv.trackHTTPHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		close(entered)
+		<-release
+	}))
+	go func() {
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", nil))
+		close(handlerDone)
+	}()
+	<-entered
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		srv.Shutdown()
+		close(shutdownDone)
+	}()
+	waitForStopping(t, srv)
+	select {
+	case <-shutdownDone:
+		t.Fatal("Shutdown returned before metrics handler stopped")
+	default:
+	}
+
+	close(release)
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("metrics handler did not return")
+	}
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("Shutdown did not return after metrics handler stopped")
+	}
+}
+
+func TestConcurrentDuplicatePlaneStartsDoNotLeak(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.ControlAddr = "127.0.0.1:0"
+	cfg.VoiceAddr = "127.0.0.1:0"
+	cfg.ScreenAddr = "127.0.0.1:0"
+	cfg.DataDir = t.TempDir()
+	cfg.DBPath = cfg.DataDir + "/gospeak.db"
+
+	st, err := datastore.NewProviderFactory(cfg.DBPath)
+	if err != nil {
+		t.Fatalf("Create datastore: %v", err)
+	}
+	defer func() {
+		if err := st.Close(); err != nil {
+			t.Errorf("Close datastore: %v", err)
+		}
+	}()
+
+	srv := New(cfg, Dependencies{Store: st})
+	defer srv.Shutdown()
+	requireSingleSuccessfulStart(t, "control", concurrentStartResults(func() error {
+		return srv.StartControl(st)
+	}))
+	requireSingleSuccessfulStart(t, "voice", concurrentStartResults(srv.StartVoice))
+	requireSingleSuccessfulStart(t, "screen", concurrentStartResults(srv.StartScreen))
+
+	srv.listenerMu.Lock()
+	controlAddr := srv.controlConn.Addr().String()
+	voiceAddr, ok := srv.voiceConn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		srv.listenerMu.Unlock()
+		t.Fatalf("voice listener address has type %T", srv.voiceConn.LocalAddr())
+	}
+	screenAddr := srv.screenConn.Addr().String()
+	srv.listenerMu.Unlock()
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		srv.Shutdown()
+		close(shutdownDone)
+	}()
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("Shutdown blocked after concurrent duplicate starts")
+	}
+
+	controlListener := listenTCP(t, controlAddr)
+	_ = controlListener.Close()
+	voiceListener, err := net.ListenUDP("udp", voiceAddr)
+	if err != nil {
+		t.Fatalf("Voice address remains occupied after duplicate starts: %v", err)
+	}
+	_ = voiceListener.Close()
+	screenListener := listenTCP(t, screenAddr)
+	_ = screenListener.Close()
+}
+
+func TestShutdownBeforeRunDoesNotLeakControlListener(t *testing.T) {
+	controlProbe := listenTCP(t, "127.0.0.1:0")
+	controlAddr := controlProbe.Addr().String()
+	_ = controlProbe.Close()
+
+	cfg := DefaultConfig()
+	cfg.ControlAddr = controlAddr
+	cfg.VoiceAddr = "127.0.0.1:0"
+	cfg.MetricsAddr = ""
+	cfg.DataDir = t.TempDir()
+	cfg.DBPath = cfg.DataDir + "/gospeak.db"
+
+	st, err := datastore.NewProviderFactory(cfg.DBPath)
+	if err != nil {
+		t.Fatalf("Create datastore: %v", err)
+	}
+	defer func() {
+		if err := st.Close(); err != nil {
+			t.Errorf("Close datastore: %v", err)
+		}
+	}()
+
+	srv := New(cfg, Dependencies{Store: st})
+	srv.Shutdown()
+	if err := srv.Run(); err == nil || !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("Run error after prior Shutdown = %v, want context cancellation", err)
+	}
+
+	controlListener := listenTCP(t, controlAddr)
+	_ = controlListener.Close()
+}

--- a/pkg/server/metrics_http.go
+++ b/pkg/server/metrics_http.go
@@ -3,19 +3,28 @@ package server
 import (
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 )
 
-// StartMetricsHTTP starts a lightweight HTTP server that exposes /metrics
-// in Prometheus text exposition format. It runs in the background and
-// shuts down when the server context is cancelled.
-//
-// Bind address is :9602 by default — configurable via Config.MetricsAddr.
+// StartMetricsHTTP starts the metrics endpoint and logs startup failures.
+// Run uses startMetricsHTTP directly so startup failures can be returned.
 func (s *Server) StartMetricsHTTP() {
+	if err := s.startMetricsHTTP(); err != nil {
+		slog.Error("start metrics HTTP", "err", err)
+	}
+}
+
+func (s *Server) startMetricsHTTP() error {
+	if !s.beginTask() {
+		return fmt.Errorf("server: start metrics: %w", s.ctx.Err())
+	}
+	defer s.endTask()
+
 	addr := s.cfg.MetricsAddr
 	if addr == "" {
-		return // metrics endpoint disabled
+		return nil // metrics endpoint disabled
 	}
 
 	mux := http.NewServeMux()
@@ -27,21 +36,44 @@ func (s *Server) StartMetricsHTTP() {
 
 	srv := &http.Server{
 		Addr:              addr,
-		Handler:           mux,
+		Handler:           s.trackHTTPHandler(mux),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
+	var listenConfig net.ListenConfig
+	ln, err := listenConfig.Listen(s.ctx, "tcp", addr)
+	if err != nil {
+		return fmt.Errorf("server: listen metrics: %w", err)
+	}
 
-	go func() {
-		slog.Info("metrics HTTP listening", "addr", addr)
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	s.metricsMu.Lock()
+	if err := s.ctx.Err(); err != nil {
+		s.metricsMu.Unlock()
+		_ = ln.Close()
+		return fmt.Errorf("server: start metrics: %w", err)
+	}
+	if s.metricsHTTP != nil {
+		s.metricsMu.Unlock()
+		_ = ln.Close()
+		return fmt.Errorf("server: metrics already started")
+	}
+	s.metricsHTTP = srv
+	s.metricsConn = ln
+	s.metricsMu.Unlock()
+
+	if !s.startWorker(func() {
+		slog.Info("metrics HTTP listening", "addr", ln.Addr().String())
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
 			slog.Error("metrics HTTP error", "err", err)
 		}
-	}()
-
-	go func() {
-		<-s.ctx.Done()
-		_ = srv.Close()
-	}()
+	}) {
+		s.metricsMu.Lock()
+		s.metricsHTTP = nil
+		s.metricsConn = nil
+		s.metricsMu.Unlock()
+		_ = ln.Close()
+		return fmt.Errorf("server: start metrics worker: %w", s.ctx.Err())
+	}
+	return nil
 }
 
 // handleMetrics writes all metrics in Prometheus text exposition format.

--- a/pkg/server/run.go
+++ b/pkg/server/run.go
@@ -14,11 +14,14 @@ import (
 	"github.com/NicolasHaas/gospeak/pkg/model"
 )
 
+const metricsShutdownTimeout = 5 * time.Second
+
 // Run starts the server and blocks until shutdown signal.
 func (s *Server) Run() error {
 	if s.store == nil {
 		return fmt.Errorf("server: missing store dependency")
 	}
+	defer s.Shutdown()
 	st := s.store
 
 	// Generate shared voice encryption key
@@ -66,16 +69,18 @@ func (s *Server) Run() error {
 		}
 	}
 
+	if s.cfg.MetricsAddr != "" {
+		// Start Prometheus metrics HTTP endpoint
+		if err := s.startMetricsHTTP(); err != nil {
+			return err
+		}
+	}
+
 	slog.Info("GoSpeak server running",
 		"control", s.cfg.ControlAddr,
 		"voice", s.cfg.VoiceAddr,
 		"screen", s.cfg.ScreenAddr,
 	)
-
-	if s.cfg.MetricsAddr != "" {
-		// Start Prometheus metrics HTTP endpoint
-		s.StartMetricsHTTP()
-	}
 
 	// Start periodic voice debug logging (only when log level is debug)
 	if s.voiceDebugEnabled {
@@ -85,27 +90,58 @@ func (s *Server) Run() error {
 	// Wait for shutdown signal
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	<-sigCh
-
-	slog.Info("shutting down...")
-	s.Shutdown()
+	defer signal.Stop(sigCh)
+	select {
+	case <-sigCh:
+		slog.Info("shutting down...")
+	case <-s.ctx.Done():
+	}
 	return nil
 }
 
 // Shutdown gracefully stops the server.
 func (s *Server) Shutdown() {
-	s.cancel()
-	if s.controlConn != nil {
-		_ = s.controlConn.Close()
-	}
-	if s.voiceConn != nil {
-		_ = s.voiceConn.Close()
-	}
-	if s.screenConn != nil {
-		_ = s.screenConn.Close()
-	}
-	s.closeAcceptedConns()
-	s.closeScreenConns()
+	s.shutdownOnce.Do(func() {
+		s.workerMu.Lock()
+		s.stopping = true
+		s.cancel()
+		s.workerMu.Unlock()
+
+		s.metricsMu.Lock()
+		metricsHTTP := s.metricsHTTP
+		metricsConn := s.metricsConn
+		s.metricsHTTP = nil
+		s.metricsConn = nil
+		s.metricsMu.Unlock()
+		if metricsHTTP != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), metricsShutdownTimeout)
+			if err := metricsHTTP.Shutdown(ctx); err != nil {
+				_ = metricsHTTP.Close()
+			}
+			cancel()
+		}
+		if metricsConn != nil {
+			_ = metricsConn.Close()
+		}
+
+		s.listenerMu.Lock()
+		screenConn := s.screenConn
+		voiceConn := s.voiceConn
+		controlConn := s.controlConn
+		s.listenerMu.Unlock()
+		if screenConn != nil {
+			_ = screenConn.Close()
+		}
+		if voiceConn != nil {
+			_ = voiceConn.Close()
+		}
+		if controlConn != nil {
+			_ = controlConn.Close()
+		}
+		s.closeAcceptedConns()
+		s.closeScreenConns()
+		s.workers.Wait()
+	})
 }
 
 // ensureAdminToken creates an admin token only on first run (no tokens exist).

--- a/pkg/server/screen.go
+++ b/pkg/server/screen.go
@@ -13,6 +13,24 @@ import (
 
 // StartScreen starts the TCP/TLS screen-share relay listener.
 func (s *Server) StartScreen() error {
+	if !s.beginTask() {
+		return fmt.Errorf("server: start screen: %w", s.ctx.Err())
+	}
+	defer s.endTask()
+
+	s.listenerMu.Lock()
+	if s.screenStarting || s.screenConn != nil {
+		s.listenerMu.Unlock()
+		return fmt.Errorf("server: screen already started")
+	}
+	s.screenStarting = true
+	s.listenerMu.Unlock()
+	defer func() {
+		s.listenerMu.Lock()
+		s.screenStarting = false
+		s.listenerMu.Unlock()
+	}()
+
 	cert, err := loadOrGenerateTLS(s.cfg)
 	if err != nil {
 		return fmt.Errorf("server: screen tls: %w", err)
@@ -27,10 +45,12 @@ func (s *Server) StartScreen() error {
 	if err != nil {
 		return fmt.Errorf("server: listen screen: %w", err)
 	}
+	s.listenerMu.Lock()
 	s.screenConn = ln
+	s.listenerMu.Unlock()
 	slog.Info("screen plane listening", "addr", s.cfg.ScreenAddr)
 
-	go func() {
+	if !s.startWorker(func() {
 		for {
 			conn, err := ln.Accept()
 			if err != nil {
@@ -47,9 +67,16 @@ func (s *Server) StartScreen() error {
 				_ = conn.Close()
 				continue
 			}
-			go s.handleScreenConn(conn)
+			acceptedConn := conn
+			if !s.startWorker(func() { s.handleScreenConn(acceptedConn) }) {
+				s.forgetAcceptedConn(conn)
+				_ = conn.Close()
+			}
 		}
-	}()
+	}) {
+		_ = ln.Close()
+		return fmt.Errorf("server: start screen worker: %w", s.ctx.Err())
+	}
 
 	return nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"log/slog"
 	"net"
+	"net/http"
 	"sync"
 	"time"
 
@@ -55,22 +56,33 @@ func DefaultConfig() Config {
 
 // Server is the main GoSpeak server.
 type Server struct {
-	cfg           Config
-	sessions      *SessionManager
-	channels      *ChannelManager
-	screenShare   *ScreenShareManager
-	metrics       *Metrics
-	store         datastore.DataProviderFactory
-	controlConn   net.Listener
-	voiceConn     *net.UDPConn
-	screenConn    net.Listener
-	screenMu      sync.RWMutex
-	screenConns   map[uint32]*screenClientConn
-	voiceKey      []byte // shared AES-128 key for all voice encryption
-	authLimiter   *authRateLimiter
-	preAuthMu     sync.Mutex
-	acceptedConns map[net.Conn]trackedConn
-	preAuthCount  map[preAuthPlane]int
+	cfg             Config
+	sessions        *SessionManager
+	channels        *ChannelManager
+	screenShare     *ScreenShareManager
+	metrics         *Metrics
+	store           datastore.DataProviderFactory
+	listenerMu      sync.Mutex
+	controlConn     net.Listener
+	voiceConn       *net.UDPConn
+	screenConn      net.Listener
+	controlStarting bool
+	voiceStarting   bool
+	screenStarting  bool
+	metricsMu       sync.Mutex
+	metricsHTTP     *http.Server
+	metricsConn     net.Listener
+	shutdownOnce    sync.Once
+	workerMu        sync.Mutex
+	workers         sync.WaitGroup
+	stopping        bool
+	screenMu        sync.RWMutex
+	screenConns     map[uint32]*screenClientConn
+	voiceKey        []byte // shared AES-128 key for all voice encryption
+	authLimiter     *authRateLimiter
+	preAuthMu       sync.Mutex
+	acceptedConns   map[net.Conn]trackedConn
+	preAuthCount    map[preAuthPlane]int
 
 	// Per-session voice debug counters (reset each debug interval; only used when debug is enabled)
 	voiceDebugEnabled bool
@@ -105,6 +117,45 @@ func New(cfg Config, deps Dependencies) *Server {
 		ctx:           ctx,
 		cancel:        cancel,
 	}
+}
+
+// beginTask registers server-owned work unless shutdown has begun.
+func (s *Server) beginTask() bool {
+	s.workerMu.Lock()
+	if s.stopping {
+		s.workerMu.Unlock()
+		return false
+	}
+	s.workers.Add(1)
+	s.workerMu.Unlock()
+	return true
+}
+
+func (s *Server) endTask() {
+	s.workers.Done()
+}
+
+// startWorker starts and tracks a server-owned goroutine.
+func (s *Server) startWorker(worker func()) bool {
+	if !s.beginTask() {
+		return false
+	}
+	go func() {
+		defer s.endTask()
+		worker()
+	}()
+	return true
+}
+
+func (s *Server) trackHTTPHandler(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.beginTask() {
+			http.Error(w, "server is shutting down", http.StatusServiceUnavailable)
+			return
+		}
+		defer s.endTask()
+		handler.ServeHTTP(w, r)
+	})
 }
 
 type preAuthPlane string
@@ -222,7 +273,9 @@ func (s *Server) setScreenConn(sessionID uint32, conn net.Conn) *screenClientCon
 	if old != nil {
 		old.close()
 	}
-	go s.writeScreenPackets(sessionID, client)
+	if !s.startWorker(func() { s.writeScreenPackets(sessionID, client) }) {
+		s.removeScreenConn(sessionID, client)
+	}
 	return client
 }
 

--- a/pkg/server/voice.go
+++ b/pkg/server/voice.go
@@ -13,6 +13,24 @@ const voiceRebindInterval = 5 * time.Second
 
 // StartVoice starts the UDP voice forwarder.
 func (s *Server) StartVoice() error {
+	if !s.beginTask() {
+		return fmt.Errorf("server: start voice: %w", s.ctx.Err())
+	}
+	defer s.endTask()
+
+	s.listenerMu.Lock()
+	if s.voiceStarting || s.voiceConn != nil {
+		s.listenerMu.Unlock()
+		return fmt.Errorf("server: voice already started")
+	}
+	s.voiceStarting = true
+	s.listenerMu.Unlock()
+	defer func() {
+		s.listenerMu.Lock()
+		s.voiceStarting = false
+		s.listenerMu.Unlock()
+	}()
+
 	addr, err := net.ResolveUDPAddr("udp", s.cfg.VoiceAddr)
 	if err != nil {
 		return fmt.Errorf("server: resolve voice addr: %w", err)
@@ -22,7 +40,9 @@ func (s *Server) StartVoice() error {
 	if err != nil {
 		return fmt.Errorf("server: listen voice: %w", err)
 	}
+	s.listenerMu.Lock()
 	s.voiceConn = conn
+	s.listenerMu.Unlock()
 
 	// Increase UDP buffer size for better performance
 	if err := conn.SetReadBuffer(1024 * 1024); err != nil {
@@ -34,13 +54,16 @@ func (s *Server) StartVoice() error {
 
 	slog.Info("voice plane listening", "addr", s.cfg.VoiceAddr)
 
-	go s.voiceLoop()
+	if !s.startWorker(func() { s.voiceLoop(conn) }) {
+		_ = conn.Close()
+		return fmt.Errorf("server: start voice worker: %w", s.ctx.Err())
+	}
 	return nil
 }
 
 // voiceLoop reads UDP voice packets and forwards them to channel members.
 // This is an SFU (Selective Forwarding Unit) - no decryption, no mixing.
-func (s *Server) voiceLoop() {
+func (s *Server) voiceLoop(conn *net.UDPConn) {
 	buf := make([]byte, protocol.VoiceHeaderSize+protocol.MaxVoicePayload)
 
 	for {
@@ -50,7 +73,7 @@ func (s *Server) voiceLoop() {
 		default:
 		}
 
-		n, remoteAddr, err := s.voiceConn.ReadFromUDP(buf)
+		n, remoteAddr, err := conn.ReadFromUDP(buf)
 		if err != nil {
 			select {
 			case <-s.ctx.Done():
@@ -139,7 +162,7 @@ func (s *Server) voiceLoop() {
 				continue // don't send to deafened users
 			}
 
-			_, err := s.voiceConn.WriteToUDP(rawPacket, memberSession.UDPAddr)
+			_, err := conn.WriteToUDP(rawPacket, memberSession.UDPAddr)
 			if err != nil {
 				slog.Debug("voice forward error", "target", memberSID, "err", err)
 			} else {

--- a/pkg/server/voicestats.go
+++ b/pkg/server/voicestats.go
@@ -122,7 +122,7 @@ func (s *Server) LogVoiceDebug() {
 // startVoiceDebugLogging runs LogVoiceDebug every interval until the
 // server context is cancelled.
 func (s *Server) startVoiceDebugLogging(interval time.Duration) {
-	go func() {
+	s.startWorker(func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
@@ -133,5 +133,5 @@ func (s *Server) startVoiceDebugLogging(interval time.Duration) {
 				s.LogVoiceDebug()
 			}
 		}
-	}()
+	})
 }


### PR DESCRIPTION
## Context

Server startup did not fully clean up resources when a later listener failed. Shutdown could also return while server-owned goroutines were still running, which meant the caller could close the datastore while handlers were finishing their cleanup.

Rejected control connections could also leave ActiveConnections above zero.

## Summary

- clean up control, voice, screen, and metrics resources after partial startup failures
- return metrics bind failures from `Run()` while keeping the existing public `StartMetricsHTTP()` API
- wait for server-owned workers and active metrics handlers before `Run()` returns
- cancel delayed temporary-channel cleanup during shutdown
- reject repeated or concurrent starts of the same network plane
- balance `ActiveConnections` for rejected and pre-auth control connections