### PR TITLE
server: disable metrics by default

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -165,7 +165,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=builder /out/gospeak-server /gospeak-server
 
-EXPOSE 9600/tcp 9601/udp 9602/tcp
+EXPOSE 9600/tcp 9601/udp
 
 VOLUME ["/data"]
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,18 @@ The server listens on:
 - **TCP :9600**: TLS control plane
 - **UDP :9601**: Encrypted voice
 - **TCP :9603**: Encrypted screen-share relay
-- **TCP :9602**: Prometheus metrics HTTP
+- **Metrics**: disabled by default; enable with `-metrics :9602` and keep the plaintext endpoint on a trusted network
+
+The bundled monitoring overlay enables metrics only on the Compose network and does not publish port 9602 on the host:
+
+```bash
+GOSPEAK_METRICS_ADDR=:9602 \
+GRAFANA_ADMIN_PASSWORD='<choose-password>' \
+docker compose -f compose.yaml -f compose.monitoring.yaml up -d
+```
+
+Grafana is then available only on `127.0.0.1:3000`. Prometheus is not published
+on the host.
 
 On first run, an **admin token** is printed to stdout — save it to create more tokens and manage the server.
 
@@ -115,7 +126,7 @@ Existing bookmark files remain compatible. They gain a `trusted_server_pins` sec
 | `-screen-share` | `false` | Enable per-channel screen sharing |
 | `-channels-file` | | YAML file for initial channel setup |
 | `-cert` / `-key` | *(empty)* | Custom matching TLS pair, including self-signed certificates; provide both. When both are empty, GoSpeak loads or creates `server.crt` and `server.key` in `-data` |
-| `-metrics` | `:9602` | Prometheus /metrics HTTP endpoint (empty to disable) |
+| `-metrics` | *(empty)* | Prometheus `/metrics` and `/healthz` HTTP bind address; opt in with a trusted bind such as `127.0.0.1:9602` |
 | `-export-users` | `false` | Export all users as YAML and exit |
 | `-export-channels` | `false` | Export all channels as YAML and exit |
 | `-log-level` | `info` | Log level |

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -25,7 +25,7 @@ func main() {
 	flag.BoolVar(&cfg.AllowNoToken, "open", false, "Allow users to join without a token (open server)")
 	flag.BoolVar(&cfg.EnableScreenShare, "screen-share", false, "Enable basic per-channel screen sharing")
 	flag.StringVar(&cfg.ChannelsFile, "channels-file", "", "YAML file defining channels to create on startup")
-	flag.StringVar(&cfg.MetricsAddr, "metrics", cfg.MetricsAddr, "HTTP bind address for Prometheus /metrics (empty to disable)")
+	flag.StringVar(&cfg.MetricsAddr, "metrics", cfg.MetricsAddr, "HTTP bind address for plaintext /metrics and /healthz (empty to disable)")
 	flag.BoolVar(&cfg.ExportUsers, "export-users", false, "Export all users as YAML and exit")
 	flag.BoolVar(&cfg.ExportChannels, "export-channels", false, "Export all channels as YAML and exit")
 

--- a/compose.monitoring.yaml
+++ b/compose.monitoring.yaml
@@ -1,0 +1,35 @@
+# Opt-in monitoring stack for GoSpeak.
+#
+# Usage:
+#   GOSPEAK_METRICS_ADDR=:9602 \
+#   GRAFANA_ADMIN_PASSWORD='<choose-password>' \
+#   docker compose -f compose.yaml -f compose.monitoring.yaml up -d
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: gospeak-prometheus
+    volumes:
+      - ./deploy/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: gospeak-grafana
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD}"
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /var/lib/grafana/dashboards/gospeak.json
+    volumes:
+      - ./deploy/grafana-datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
+      - ./deploy/grafana-dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+      - ./docs/grafana-dashboard.json:/var/lib/grafana/dashboards/gospeak.json:ro
+      - grafana-data:/var/lib/grafana
+    restart: unless-stopped
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,7 @@
 #   podman compose --profile build-lin run --build builder-lin  — Linux only   → ./bin/
 #   podman compose --profile dev       run --build lint         — golangci-lint
 #   podman compose --profile dev       run --build test         — go test -race
-#   podman compose --profile monitor   up -d                   — Prometheus + Grafana
+#   See compose.monitoring.yaml for the opt-in Prometheus + Grafana stack.
 #
 # NOTE: always use --build on "run" to ensure the latest source is compiled.
 #
@@ -26,7 +26,7 @@ services:
       - "9600:9600"      # TCP/TLS control plane
       - "9601:9601/udp"  # UDP voice plane
       - "9603:9603"      # TCP/TLS screen-share plane (used when -screen-share is enabled)
-      - "9602:9602"      # Prometheus /metrics HTTP
+    command: ["-metrics", "${GOSPEAK_METRICS_ADDR:-}"]
     volumes:
       - ./data:/data
     restart: unless-stopped
@@ -119,39 +119,3 @@ services:
       - |
         gofmt -w . && \
         go test -v -tags nolibopusfile -race -timeout=5m ./...
-
-  # --- Monitoring stack (activate with --profile monitor) ---
-
-  prometheus:
-    image: prom/prometheus:latest
-    container_name: gospeak-prometheus
-    profiles:
-      - monitor
-    ports:
-      - "9090:9090"
-    volumes:
-      - ./deploy/prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - prometheus-data:/prometheus
-    restart: unless-stopped
-
-  grafana:
-    image: grafana/grafana:latest
-    container_name: gospeak-grafana
-    profiles:
-      - monitor
-    ports:
-      - "3000:3000"
-    environment:
-      GF_SECURITY_ADMIN_USER: admin
-      GF_SECURITY_ADMIN_PASSWORD: gospeak
-      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /var/lib/grafana/dashboards/gospeak.json
-    volumes:
-      - ./deploy/grafana-datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
-      - ./deploy/grafana-dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
-      - ./docs/grafana-dashboard.json:/var/lib/grafana/dashboards/gospeak.json:ro
-      - grafana-data:/var/lib/grafana
-    restart: unless-stopped
-
-volumes:
-  prometheus-data:
-  grafana-data:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -67,7 +67,7 @@ These flags map directly to `gospeak-server` and are all supported options.
 | `-screen` | `:9603` | TCP/TLS screen-share relay bind address |
 | `-screen-share` | `false` | Enable per-channel screen sharing |
 | `-channels-file` | *(empty)* | YAML file defining channels created on startup |
-| `-metrics` | `:9602` | Prometheus /metrics bind address (empty to disable) |
+| `-metrics` | *(empty)* | Prometheus `/metrics` and `/healthz` bind address; disabled by default |
 | `-export-users` | `false` | Export all users as YAML and exit |
 | `-export-channels` | `false` | Export all channels as YAML and exit |
 | `-log-level` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
@@ -78,4 +78,4 @@ These flags map directly to `gospeak-server` and are all supported options.
 - `9600/tcp`: TLS control plane
 - `9601/udp`: encrypted voice
 - `9603/tcp`: encrypted screen-share relay (required when `-screen-share` is enabled)
-- `9602/tcp`: metrics (optional; not exposed by default)
+- `9602/tcp`: optional plaintext metrics and health HTTP. It is disabled and not published by default; if enabled, bind it to a trusted interface or protect it with a firewall or reverse proxy.

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -12,7 +12,6 @@ services:
       - "9600:9600"       # TCP/TLS control plane
       - "9601:9601/udp"   # UDP encrypted voice
       - "9603:9603"       # TCP/TLS screen-share plane (used when -screen-share is enabled)
-      - "9602:9602"       # Prometheus /metrics (optional, remove if not needed)
     volumes:
       - gospeak-data:/data
     restart: unless-stopped

--- a/docs/building.md
+++ b/docs/building.md
@@ -115,7 +115,7 @@ docker run -p 9600:9600 -p 9601:9601/udp \
 | `-screen` | `:9603` | TCP/TLS screen-share relay bind address |
 | `-screen-share` | `false` | Enable per-channel screen sharing |
 | `-channels-file` | *(none)* | YAML file defining channels to create on startup |
-| `-metrics` | `:9602` | HTTP bind address for Prometheus /metrics (empty to disable) |
+| `-metrics` | *(empty)* | HTTP bind address for Prometheus `/metrics` and `/healthz`; disabled by default |
 | `-export-users` | `false` | Export all users as YAML and exit |
 | `-export-channels` | `false` | Export all channels as YAML and exit |
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,6 +1,8 @@
 # GoSpeak Security & Encryption
 
-GoSpeak is designed with security as a core principle. All communication is encrypted and the server operates as a relay for voice and screen-sharing media.
+GoSpeak encrypts the control, voice, and screen planes. The optional metrics and
+health endpoint is plaintext, unauthenticated HTTP, so it is disabled by default
+and must be restricted separately when enabled.
 
 > **Note on the shared key model:** Voice uses a single server-wide AES-128 key distributed to all clients. Screen sharing uses a separate AES-128 key per active share, distributed to the sharer and to channel members who have been included in that share. In both cases the server generates the key material, so a compromised server _could_ theoretically decrypt media. This is a known trade-off for simplicity.
 

--- a/pkg/server/metrics_defaults_test.go
+++ b/pkg/server/metrics_defaults_test.go
@@ -1,0 +1,11 @@
+package server
+
+import "testing"
+
+func TestDefaultConfigDisablesMetrics(t *testing.T) {
+	t.Parallel()
+
+	if got := DefaultConfig().MetricsAddr; got != "" {
+		t.Fatalf("DefaultConfig().MetricsAddr = %q, want disabled", got)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -46,7 +46,7 @@ func DefaultConfig() Config {
 		ControlAddr:           ":9600",
 		VoiceAddr:             ":9601",
 		ScreenAddr:            ":9603",
-		MetricsAddr:           ":9602",
+		MetricsAddr:           "",
 		DBPath:                "gospeak.db",
 		DataDir:               ".",
 		PreAuthTimeout:        10 * time.Second,


### PR DESCRIPTION
## Summary

- disable the plaintext /metrics and /healthz endpoints unless the server is started with `-metrics <address>`
- stop publishing port 9602 in the bundled container and deployment configurations
- move Prometheus and Grafana into an opt-in Compose overlay; keep Prometheus internal, bind Grafana to loopback, and require an administrator password
- document the new default and the network protections required when metrics are enabled
