### PR TITLE
fix(server): hide disabled screen service

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ docker compose up --build
 The server listens on:
 - **TCP :9600**: TLS control plane
 - **UDP :9601**: Encrypted voice
-- **TCP :9603**: Encrypted screen-share relay
+- **Screen sharing**: disabled by default; `-screen-share` enables the encrypted TCP relay on `:9603`
 - **Metrics**: disabled by default; enable with `-metrics :9602` and keep the plaintext endpoint on a trusted network
 
 The bundled monitoring overlay enables metrics only on the Compose network and does not publish port 9602 on the host:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,12 +125,16 @@ sequenceDiagram
     Srv->>Store: Ensure admin token exists (first run only)
     Srv->>TLS: StartControl(:9600)
     Srv->>UDP: StartVoice(:9601)
-    Srv->>SCR: StartScreen(:9603)
+    opt screen sharing enabled
+        Srv->>SCR: StartScreen(:9603)
+    end
     Note over Srv: Server running — accepting connections
     Srv-->>Main: Block until SIGINT/SIGTERM
     Srv->>TLS: Close
     Srv->>UDP: Close
-    Srv->>SCR: Close
+    opt screen sharing enabled
+        Srv->>SCR: Close
+    end
     Srv->>Store: Close
 ```
 
@@ -149,11 +153,13 @@ sequenceDiagram
     Eng->>TLS: Dial TCP/TLS (skip verify for self-signed)
     TLS->>Srv: TLS 1.3 Handshake
     Eng->>Srv: AuthRequest{token?, username}
-    Srv->>Eng: AuthResponse{sessionID, role, encryptionKey, screenAddr, screenAuthToken, channels, autoToken?}
+    Srv->>Eng: AuthResponse{sessionID, role, encryptionKey, screenShareEnabled?, screenAddr?, screenAuthToken?, channels, autoToken?}
     Note over Eng: Store autoToken for future logins
     Eng->>Eng: Create VoiceCipher from encryptionKey
     Eng->>UDP: Dial UDP to server:9601
-    Eng->>SCR: Dial TCP/TLS to server:9603
+    opt screenShareEnabled
+        Eng->>SCR: Dial TCP/TLS to screenAddr and authenticate with screenAuthToken
+    end
     Eng->>Eng: Start audio capture + playback
     Eng->>UI: OnStateChange(Connected)
     Eng->>UI: OnChannelsUpdate(channels)

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -64,13 +64,13 @@ sequenceDiagram
         S->>S: Create user + personal token
         S->>S: Check bans
         S->>S: Generate session
-        S->>C: AuthResponse{sessionID, role, encryptionKey, voiceRegistrationKey, screenAddr, screenAuthToken, channels, autoToken}
+        S->>C: AuthResponse{sessionID, role, encryptionKey, voiceRegistrationKey, screenShareEnabled?, screenAddr?, screenAuthToken?, channels, autoToken}
         Note over C: Store personal token for reconnect
     else Existing user
         S->>S: Require personal token
         S->>S: Check bans
         S->>S: Generate session
-        S->>C: AuthResponse{sessionID, role, encryptionKey, voiceRegistrationKey, screenAddr, screenAuthToken, channels}
+        S->>C: AuthResponse{sessionID, role, encryptionKey, voiceRegistrationKey, screenShareEnabled?, screenAddr?, screenAuthToken?, channels}
     else Invalid token / banned
         S->>C: ErrorResponse{code, message}
         S->>S: Close connection
@@ -255,8 +255,8 @@ Nonce = [SessionID (4B)] [SeqNum (4B)] [0x00 0x00 0x00 0x00 (4B)]
 ### Connection Flow
 
 1. Client authenticates on the control plane.
-2. Server returns `screen_addr` and a session-scoped `screen_auth_token`.
-3. Client opens the screen-plane TLS connection and authenticates with that token.
+2. When screen sharing is enabled, the server sets `screen_share_enabled` and returns `screen_addr` plus a session-scoped `screen_auth_token`. These optional fields are omitted when the feature is disabled.
+3. The client opens the screen-plane TLS connection only when `screen_share_enabled` is true, then authenticates with the token.
 4. Screen-share start/stop/subscribe still happen on the control plane.
 5. Actual encrypted frame packets flow over the screen plane.
 

--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -630,6 +630,12 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 	// Build channel list
 	channels, _ := st.NonTx().ListChannels()
 	channelInfos := s.buildChannelInfos(channels)
+	screenAddr := ""
+	screenAuthToken := ""
+	if s.cfg.EnableScreenShare {
+		screenAddr = s.cfg.ScreenAddr
+		screenAuthToken = session.ScreenAuthToken
+	}
 
 	// Send auth response
 	authResp := &pb.ControlMessage{
@@ -641,8 +647,8 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 			EncryptionKey:        s.voiceKey,
 			VoiceRegistrationKey: append([]byte(nil), session.VoiceRegistrationKey...),
 			Channels:             channelInfos,
-			ScreenAddr:           s.cfg.ScreenAddr,
-			ScreenAuthToken:      session.ScreenAuthToken,
+			ScreenAddr:           screenAddr,
+			ScreenAuthToken:      screenAuthToken,
 			ScreenShareEnabled:   s.cfg.EnableScreenShare,
 			AutoToken:            autoToken,
 		},

--- a/pkg/server/lifecycle_test.go
+++ b/pkg/server/lifecycle_test.go
@@ -1,7 +1,11 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
+	"encoding/json"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -333,6 +337,79 @@ func TestShutdownStopsRunAndReleasesListeners(t *testing.T) {
 		t.Fatalf("Voice address remains occupied after Shutdown: %v", err)
 	}
 	_ = voiceListener.Close()
+}
+
+func TestAuthResponseGatesScreenCredentials(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		enabled bool
+	}{
+		{name: "disabled"},
+		{name: "enabled", enabled: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, st, handler := newTestServer(t)
+			srv.cfg.AllowNoToken = true
+			srv.cfg.EnableScreenShare = tc.enabled
+			srv.cfg.ScreenAddr = "screen.example:9603"
+			serverConn, clientConn := net.Pipe()
+			done := make(chan struct{})
+
+			go func() {
+				srv.handleControlConn(handler, serverConn, st)
+				close(done)
+			}()
+			if err := protocol.WriteControlMessage(clientConn, &pb.ControlMessage{
+				AuthRequest: &pb.AuthRequest{Username: "screen-gating-" + tc.name},
+			}); err != nil {
+				t.Fatalf("Write AuthRequest: %v", err)
+			}
+			var lengthBuf [4]byte
+			if _, err := io.ReadFull(clientConn, lengthBuf[:]); err != nil {
+				t.Fatalf("Read AuthResponse length: %v", err)
+			}
+			payload := make([]byte, binary.BigEndian.Uint32(lengthBuf[:]))
+			if _, err := io.ReadFull(clientConn, payload); err != nil {
+				t.Fatalf("Read AuthResponse payload: %v", err)
+			}
+			response := new(pb.ControlMessage)
+			if err := json.Unmarshal(payload, response); err != nil {
+				t.Fatalf("Decode AuthResponse: %v", err)
+			}
+			auth := response.AuthResponse
+			if auth == nil {
+				t.Fatal("AuthResponse is nil")
+			}
+			if tc.enabled {
+				for _, key := range [][]byte{[]byte(`"screen_share_enabled"`), []byte(`"screen_addr"`), []byte(`"screen_auth_token"`)} {
+					if !bytes.Contains(payload, key) {
+						t.Fatalf("enabled AuthResponse payload %s omits %s", payload, key)
+					}
+				}
+				if !auth.ScreenShareEnabled || auth.ScreenAddr != srv.cfg.ScreenAddr || auth.ScreenAuthToken == "" {
+					t.Fatalf("enabled screen fields = %#v, want enabled address and token", auth)
+				}
+			} else {
+				for _, key := range [][]byte{[]byte(`"screen_share_enabled"`), []byte(`"screen_addr"`), []byte(`"screen_auth_token"`)} {
+					if bytes.Contains(payload, key) {
+						t.Fatalf("disabled AuthResponse payload %s contains %s", payload, key)
+					}
+				}
+				if auth.ScreenShareEnabled || auth.ScreenAddr != "" || auth.ScreenAuthToken != "" {
+					t.Fatalf("disabled screen fields = %#v, want omitted credentials", auth)
+				}
+			}
+			if err := clientConn.Close(); err != nil {
+				t.Fatalf("Close client connection: %v", err)
+			}
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("authenticated control handler did not return")
+			}
+			srv.Shutdown()
+		})
+	}
 }
 
 func TestAuthenticatedControlConnectionBalancesMetrics(t *testing.T) {

--- a/pkg/server/run.go
+++ b/pkg/server/run.go
@@ -76,11 +76,7 @@ func (s *Server) Run() error {
 		}
 	}
 
-	slog.Info("GoSpeak server running",
-		"control", s.cfg.ControlAddr,
-		"voice", s.cfg.VoiceAddr,
-		"screen", s.cfg.ScreenAddr,
-	)
+	slog.Info("GoSpeak server running", s.runningLogArgs()...)
 
 	// Start periodic voice debug logging (only when log level is debug)
 	if s.voiceDebugEnabled {
@@ -97,6 +93,17 @@ func (s *Server) Run() error {
 	case <-s.ctx.Done():
 	}
 	return nil
+}
+
+func (s *Server) runningLogArgs() []any {
+	args := []any{
+		"control", s.cfg.ControlAddr,
+		"voice", s.cfg.VoiceAddr,
+	}
+	if s.cfg.EnableScreenShare {
+		args = append(args, "screen", s.cfg.ScreenAddr)
+	}
+	return args
 }
 
 // Shutdown gracefully stops the server.

--- a/pkg/server/screen_gating_test.go
+++ b/pkg/server/screen_gating_test.go
@@ -1,0 +1,24 @@
+package server
+
+import "testing"
+
+func TestRunningLogGatesScreenAddress(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		cfg := DefaultConfig()
+		cfg.EnableScreenShare = enabled
+		args := New(cfg, Dependencies{}).runningLogArgs()
+
+		found := false
+		for i := 0; i+1 < len(args); i += 2 {
+			if args[i] == "screen" {
+				found = true
+				if args[i+1] != cfg.ScreenAddr {
+					t.Fatalf("screen log address = %v, want %q", args[i+1], cfg.ScreenAddr)
+				}
+			}
+		}
+		if found != enabled {
+			t.Fatalf("screen log field present = %t with screen sharing enabled = %t", found, enabled)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- omit screen address, authentication token, and enable flag from authentication responses when screen sharing is disabled
- keep the screen endpoint out of startup logs unless the listener is enabled
- cover disabled and enabled behavior at the raw framed-JSON boundary and update the protocol and architecture docs