### PR TITLE
fix(protocol): reject ambiguous control envelopes

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -10,7 +10,7 @@ GoSpeak uses three transport layers: a **TCP/TLS 1.3 control plane** for signall
 - **Serialization**: JSON with `omitempty` — only the populated field in `ControlMessage` is serialized
 
 ### Message Envelope
-Every control message is a `ControlMessage` struct with exactly one field set:
+Every control message is a `ControlMessage` struct with exactly one field set. Writers reject empty envelopes, envelopes with multiple populated fields, and `null` message values. Readers additionally reject repeated top-level fields (including escaped equivalents), unknown top-level fields, and malformed or trailing JSON. Unknown fields are rejected deliberately: peers using a protocol version newer than the reader's must not send message types the reader does not know.
 
 - `AuthRequest`
 - `AuthResponse`
@@ -30,14 +30,20 @@ Every control message is a `ControlMessage` struct with exactly one field set:
 - `KickUserRequest`
 - `BanUserRequest`
 - `ChatMessage`
+- `ChatEvent`
 - `ScreenShareStartRequest`
 - `ScreenShareStopRequest`
 - `ScreenShareSubscribeRequest`
+- `ScreenShareShareRequest`
 - `ScreenShareUnsubscribeRequest`
 - `ScreenShareEvent`
+- `ScreenShareFrame`
 - `SetUserRoleRequest`
+- `SetUserRoleResponse`
 - `ExportDataRequest`
+- `ExportDataResponse`
 - `ImportChannelsRequest`
+- `ImportChannelsResponse`
 - `ErrorResponse`
 - `Ping` / `Pong`
 

--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -2,6 +2,7 @@
 package protocol
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -34,6 +35,26 @@ const (
 	// FrameSize is the number of samples per frame (SampleRate * FrameDuration / 1000).
 	FrameSize = SampleRate * FrameDuration / 1000 // 960
 )
+
+var controlMessageFields = map[string]struct{}{
+	"auth_request": {}, "auth_response": {},
+	"channel_list_request": {}, "channel_list_response": {},
+	"join_channel_request": {}, "channel_join_response": {},
+	"leave_channel_request": {}, "channel_joined_event": {}, "channel_left_event": {},
+	"user_state_update": {}, "server_state_event": {},
+	"create_channel_request": {}, "delete_channel_request": {},
+	"create_token_request": {}, "create_token_response": {},
+	"kick_user_request": {}, "ban_user_request": {},
+	"chat_message": {}, "chat_event": {},
+	"screen_share_start_request": {}, "screen_share_stop_request": {},
+	"screen_share_subscribe_request": {}, "screen_share_share_request": {},
+	"screen_share_unsubscribe_request": {}, "screen_share_event": {},
+	"screen_share_frame":    {},
+	"set_user_role_request": {}, "set_user_role_response": {},
+	"export_data_request": {}, "export_data_response": {},
+	"import_channels_request": {}, "import_channels_response": {},
+	"error_response": {}, "ping": {}, "pong": {},
+}
 
 // VoicePacket represents a voice data packet sent over UDP.
 type VoicePacket struct {
@@ -86,6 +107,9 @@ func WriteControlMessage(w io.Writer, msg *pb.ControlMessage) error {
 	if err != nil {
 		return fmt.Errorf("protocol: marshal: %w", err)
 	}
+	if err := validateControlEnvelope(data); err != nil {
+		return err
+	}
 	if len(data) > MaxControlMessage {
 		return fmt.Errorf("protocol: message too large: %d bytes", len(data))
 	}
@@ -127,10 +151,104 @@ func ReadControlMessage(r io.Reader) (*pb.ControlMessage, error) {
 	if _, err := io.ReadFull(r, data); err != nil {
 		return nil, fmt.Errorf("protocol: read payload: %w", err)
 	}
+	if err := validateControlEnvelope(data); err != nil {
+		return nil, err
+	}
 
 	msg := &pb.ControlMessage{}
 	if err := json.Unmarshal(data, msg); err != nil {
 		return nil, fmt.Errorf("protocol: unmarshal: %w", err)
 	}
 	return msg, nil
+}
+
+func validateControlEnvelope(data []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+
+	token, err := dec.Token()
+	if err != nil {
+		return fmt.Errorf("protocol: invalid control envelope: %w", err)
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '{' {
+		return fmt.Errorf("protocol: invalid control envelope: expected JSON object")
+	}
+
+	fields := 0
+	seen := make(map[string]struct{})
+	for dec.More() {
+		keyToken, err := dec.Token()
+		if err != nil {
+			return fmt.Errorf("protocol: invalid control envelope: %w", err)
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return fmt.Errorf("protocol: invalid control envelope: expected string key")
+		}
+		if _, dup := seen[key]; dup {
+			return fmt.Errorf("protocol: invalid control envelope: duplicate field %q", key)
+		}
+		seen[key] = struct{}{}
+		if _, ok := controlMessageFields[key]; !ok {
+			return fmt.Errorf("protocol: invalid control envelope: unknown field %q", key)
+		}
+		fields++
+		value, err := dec.Token()
+		if err != nil {
+			return fmt.Errorf("protocol: invalid control envelope: field %q: %w", key, err)
+		}
+		if value == nil {
+			return fmt.Errorf("protocol: invalid control envelope: field %q is null", key)
+		}
+		switch v := value.(type) {
+		case json.Delim:
+			if v == '{' || v == '[' {
+				for dec.More() {
+					if err := skipJSONValue(dec); err != nil {
+						return fmt.Errorf("protocol: invalid control envelope: field %q: %w", key, err)
+					}
+				}
+				if _, err := dec.Token(); err != nil {
+					return fmt.Errorf("protocol: invalid control envelope: field %q: %w", key, err)
+				}
+			}
+		}
+	}
+	if fields != 1 {
+		return fmt.Errorf("protocol: invalid control envelope: got %d fields, want exactly one", fields)
+	}
+	closing, err := dec.Token()
+	if err != nil {
+		return fmt.Errorf("protocol: invalid control envelope: %w", err)
+	}
+	if delim, ok := closing.(json.Delim); !ok || delim != '}' {
+		return fmt.Errorf("protocol: invalid control envelope: expected closing object delimiter")
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		return fmt.Errorf("protocol: invalid control envelope: unexpected data after object")
+	}
+	return nil
+}
+
+// skipJSONValue consumes one JSON value from the decoder, ensuring its raw
+// bytes are fully parsed and validated by the standard library.
+func skipJSONValue(dec *json.Decoder) error {
+	token, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if delim, ok := token.(json.Delim); ok {
+		if delim == '{' || delim == '[' {
+			for dec.More() {
+				if err := skipJSONValue(dec); err != nil {
+					return err
+				}
+			}
+			if _, err := dec.Token(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/protocol/protocol_test.go
+++ b/pkg/protocol/protocol_test.go
@@ -2,6 +2,9 @@ package protocol
 
 import (
 	"bytes"
+	"encoding/binary"
+	"reflect"
+	"strings"
 	"testing"
 
 	pb "github.com/NicolasHaas/gospeak/pkg/protocol/pb"
@@ -33,6 +36,119 @@ func TestWriteControlMessageHandlesShortWrites(t *testing.T) {
 	}
 	if got.Ping == nil || got.Ping.Timestamp != want.Ping.Timestamp {
 		t.Fatalf("Ping mismatch: got %#v, want timestamp %d", got.Ping, want.Ping.Timestamp)
+	}
+}
+
+func TestWriteControlMessageRejectsInvalidEnvelopeCardinality(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  *pb.ControlMessage
+	}{
+		{name: "empty", msg: &pb.ControlMessage{}},
+		{
+			name: "multiple",
+			msg: &pb.ControlMessage{
+				Ping: &pb.Ping{Timestamp: 1},
+				Pong: &pb.Pong{Timestamp: 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := WriteControlMessage(&bytes.Buffer{}, tt.msg); err == nil {
+				t.Fatal("WriteControlMessage accepted invalid envelope")
+			}
+		})
+	}
+}
+
+func TestReadControlMessageRejectsInvalidEnvelope(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+	}{
+		{name: "empty", json: `{}`},
+		{name: "multiple", json: `{"ping":{},"pong":{}}`},
+		{name: "unknown", json: `{"unexpected":{}}`},
+		{name: "null", json: `{"ping":null}`},
+		{name: "duplicate", json: `{"ping":null,"ping":{}}`},
+		{name: "duplicateEscaped", json: `{"ping":{},"\u0070ing":{}}`},
+		{name: "notObject", json: `[]`},
+		{name: "scalar", json: `42`},
+		{name: "stringRoot", json: `"ping"`},
+		{name: "nullRoot", json: `null`},
+		{name: "malformed", json: `{"ping":`},
+		{name: "trailing", json: `{"ping":{}} {"pong":{}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := []byte(tt.json)
+			frame := make([]byte, 4+len(payload))
+			binary.BigEndian.PutUint32(frame[:4], uint32(len(payload))) //nolint:gosec // fixed test payloads are far below uint32
+			copy(frame[4:], payload)
+
+			if _, err := ReadControlMessage(bytes.NewReader(frame)); err == nil {
+				t.Fatal("ReadControlMessage accepted invalid envelope")
+			}
+		})
+	}
+}
+
+func TestControlEnvelopeFieldListMatchesMessageTags(t *testing.T) {
+	typ := reflect.TypeOf(pb.ControlMessage{})
+	if typ.NumField() != len(controlMessageFields) {
+		t.Fatalf("ControlMessage has %d fields, envelope list has %d", typ.NumField(), len(controlMessageFields))
+	}
+	seenTags := make(map[string]string, typ.NumField())
+	seenList := make(map[string]string, len(controlMessageFields))
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		name := strings.Split(field.Tag.Get("json"), ",")[0]
+		if name == "" || name == "-" {
+			t.Fatalf("ControlMessage field %s has no usable JSON name %q", field.Name, name)
+		}
+		if prev, ok := seenTags[name]; ok {
+			t.Fatalf("ControlMessage fields %s and %s share JSON name %q", prev, field.Name, name)
+		}
+		seenTags[name] = field.Name
+		if _, ok := controlMessageFields[name]; !ok {
+			t.Errorf("ControlMessage field %s with JSON name %q is missing from envelope list", field.Name, name)
+		}
+	}
+	for name := range controlMessageFields {
+		if _, ok := seenTags[name]; !ok {
+			t.Errorf("envelope list entry %q matches no ControlMessage field", name)
+		}
+		if prev, ok := seenList[name]; ok {
+			t.Fatalf("envelope list contains duplicate entry %q (%s and %s)", name, prev, name)
+		}
+		seenList[name] = name
+	}
+}
+
+func TestReadControlMessageRejectsTrailingDuplicateWithEscapedKey(t *testing.T) {
+	payload := []byte(`{"ping":{}} {"\u0070ing":{}}`)
+	frame := make([]byte, 4+len(payload))
+	binary.BigEndian.PutUint32(frame[:4], uint32(len(payload))) //nolint:gosec // fixed test payload is far below uint32
+	copy(frame[4:], payload)
+
+	if _, err := ReadControlMessage(bytes.NewReader(frame)); err == nil {
+		t.Fatal("ReadControlMessage accepted trailing duplicate data")
+	}
+}
+
+func TestValidateControlEnvelopeRejectsTrailingData(t *testing.T) {
+	for _, payload := range []string{
+		`{"ping":{}} {"pong":{}}`,
+		`{"ping":{}} {}`,
+		`{"ping":{}}x`,
+		`{"ping":{}} 42`,
+	} {
+		if err := validateControlEnvelope([]byte(payload)); err == nil {
+			t.Errorf("validateControlEnvelope accepted trailing data %q", payload)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- require exactly one populated, known, non-null field in every control message envelope on both the read and write paths
- reject repeated top-level fields (including escaped equivalents), unknown fields, empty envelopes, multi-field envelopes, null values, non-object roots, malformed JSON, and trailing data
- validate with a token-stream parser and explicit EOF enforcement so malformed frames cannot slip through unmarshal fallbacks
- add a bidirectional regression that keeps the field allowlist synchronized with ControlMessage and document the complete message list