### PR TITLE
Fix/screen sequence exhaustion

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -143,7 +143,7 @@ For each voice packet:
 - Encrypted screen packets travel on the dedicated screen TLS connection.
 - The server forwards opaque encrypted packets to subscribed viewers without decoding frame contents.
 
-Screen packet nonces follow the same deterministic pattern as voice, using the sharer's `SessionID` and a monotonically increasing screen packet sequence number.
+Screen packet nonces follow the same deterministic pattern as voice, using the sharer's `SessionID` and a sequence number that increases for the lifetime of the screen-share key. Repeated announcements of the same key do not reset the sequence; a new key starts a new sequence, and sharing stops before the sequence can wrap.
 
 ## Authentication & Token System
 

--- a/pkg/client/engine.go
+++ b/pkg/client/engine.go
@@ -60,10 +60,17 @@ const (
 )
 
 type audioResources struct {
-	capture  audio.Capturer
-	playback audio.Player
-	encoder  audio.AudioEncoder
-	warnings []error
+	capture   audio.Capturer
+	playback  audio.Player
+	encoder   audio.AudioEncoder
+	encoderMu sync.Mutex
+	warnings  []error
+}
+
+func (r *audioResources) encode(frame []int16) ([]byte, error) {
+	r.encoderMu.Lock()
+	defer r.encoderMu.Unlock()
+	return r.encoder.Encode(frame)
 }
 
 func (r *audioResources) close() {
@@ -84,16 +91,17 @@ type connectionGeneration struct {
 	wg     sync.WaitGroup
 	done   chan struct{}
 
-	disconnectOnce sync.Once
-	doneOnce       sync.Once
-	mu             sync.Mutex
-	control        *ControlClient
-	voice          *VoiceClient
-	screen         *ScreenClient
-	cipher         *gospeakCrypto.VoiceCipher
-	audio          *audioResources
-	keepaliveNow   chan struct{}
-	pendingJoins   map[int64]uint32
+	disconnectOnce  sync.Once
+	terminalErrOnce sync.Once
+	doneOnce        sync.Once
+	mu              sync.Mutex
+	control         *ControlClient
+	voice           *VoiceClient
+	screen          *ScreenClient
+	cipher          *gospeakCrypto.VoiceCipher
+	audio           *audioResources
+	keepaliveNow    chan struct{}
+	pendingJoins    map[int64]uint32
 }
 
 func newConnectionGeneration() *connectionGeneration {
@@ -725,7 +733,7 @@ func (e *Engine) captureLoop(g *connectionGeneration) {
 			frameTimestamp -= offset
 		}
 		for _, frame := range frames {
-			opusData, err := resources.encoder.Encode(frame)
+			opusData, err := resources.encode(frame)
 			if err != nil {
 				slog.Debug("encode error", "err", err)
 				frameTimestamp += 960
@@ -733,6 +741,9 @@ func (e *Engine) captureLoop(g *connectionGeneration) {
 			}
 
 			if err := voice.SendVoice(opusData, frameTimestamp); err != nil {
+				if e.handleVoiceSendError(g, err) {
+					return
+				}
 				slog.Debug("voice send error", "err", err)
 			} else if e.voiceDebugEnabled {
 				e.voiceDebugMu.Lock()
@@ -1023,13 +1034,16 @@ func (e *Engine) trySendKeepalive(g *connectionGeneration, timestamp *uint32, re
 		return
 	}
 
-	silenceData, err := resources.encoder.Encode(silenceBuf)
+	silenceData, err := resources.encode(silenceBuf)
 	if err != nil {
 		slog.Debug("keepalive encode error", "err", err)
 		return
 	}
 
 	if err := voice.SendVoice(silenceData, *timestamp); err != nil {
+		if e.handleVoiceSendError(g, err) {
+			return
+		}
 		slog.Debug("keepalive send error", "err", err)
 		return
 	}
@@ -1044,6 +1058,21 @@ func (e *Engine) trySendKeepalive(g *connectionGeneration, timestamp *uint32, re
 	e.mu.Lock()
 	e.lastSendTime = time.Now()
 	e.mu.Unlock()
+}
+
+func (e *Engine) handleVoiceSendError(g *connectionGeneration, err error) bool {
+	if !errors.Is(err, ErrVoiceSequenceExhausted) {
+		return false
+	}
+	g.terminalErrOnce.Do(func() {
+		if callback := e.OnError; callback != nil {
+			e.callbackMu.Lock()
+			e.enqueueReliableGenerationCallbackLocked(g, func() { callback(err) })
+			e.callbackMu.Unlock()
+		}
+		e.requestDisconnect(g, "voice sequence exhausted")
+	})
+	return true
 }
 
 // handleEvent dispatches incoming server events.

--- a/pkg/client/engine.go
+++ b/pkg/client/engine.go
@@ -22,6 +22,8 @@ import (
 )
 
 var (
+	ErrScreenSequenceExhausted    = errors.New("client: screen sequence exhausted; stop sharing required")
+	errScreenShareChanged         = errors.New("screen share changed while preparing frame")
 	errScreenShareCaptureTimedOut = errors.New("screen capture timed out")
 	errScreenShareStartTimedOut   = errors.New("screen share start timed out")
 	screenCaptureSlot             = make(chan struct{}, 1)
@@ -212,20 +214,26 @@ type Engine struct {
 
 	channels []pb.ChannelInfo
 
-	screenMu           sync.Mutex
-	screenSharePending bool
-	screenShareRunning bool
-	screenShareDisplay int
-	screenShareCancel  context.CancelFunc
-	screenShareAttempt uint64
-	screenCipher       *gospeakCrypto.VoiceCipher
-	screenSeqNum       uint32
-	activeScreenShare  *pb.ScreenShareEvent
-	screenShareEnabled bool
-	captureScreenFn    func(displayIndex int) (image.Image, error)
-	encodeScreenFn     func(img image.Image, maxWidth, quality int) ([]byte, int32, int32, error)
-	screenCaptureWait  time.Duration
-	screenStartWait    time.Duration
+	screenMu            sync.Mutex
+	screenSendMu        sync.Mutex
+	screenSharePending  bool
+	screenShareRunning  bool
+	screenShareDisplay  int
+	screenShareCancel   context.CancelFunc
+	screenShareLoopID   uint64
+	screenShareAttempt  uint64
+	screenCipher        *gospeakCrypto.VoiceCipher
+	screenKey           []byte
+	screenKeyID         [16]byte
+	screenKeySequences  map[[16]byte]uint32
+	screenSeqNum        uint32
+	activeScreenShare   *pb.ScreenShareEvent
+	screenShareEnabled  bool
+	captureScreenFn     func(displayIndex int) (image.Image, error)
+	encodeScreenFn      func(img image.Image, maxWidth, quality int) ([]byte, int32, int32, error)
+	beforeScreenPublish func()
+	screenCaptureWait   time.Duration
+	screenStartWait     time.Duration
 
 	// Audio initialization functions allow platform-specific audio backends.
 	initAudioFn   func() (*audioResources, error)
@@ -1806,11 +1814,16 @@ func (e *Engine) handleDisconnectGeneration(g *connectionGeneration, reason stri
 	e.callbackMu.Unlock()
 
 	e.stopScreenShareLoop()
+	e.screenSendMu.Lock()
 	e.screenMu.Lock()
 	e.activeScreenShare = nil
 	e.screenCipher = nil
+	e.screenKey = nil
+	e.screenKeyID = [16]byte{}
+	e.screenKeySequences = nil
 	e.screenSeqNum = 0
 	e.screenMu.Unlock()
+	e.screenSendMu.Unlock()
 
 	g.closeResources()
 	g.wg.Wait()
@@ -1859,32 +1872,45 @@ func (e *Engine) handleScreenShareEvent(g *connectionGeneration, event *pb.Scree
 		}
 	}
 
+	e.screenSendMu.Lock()
 	e.screenMu.Lock()
 	previous := e.activeScreenShare
 	if !event.Active {
 		if previous == nil || previous.SessionID == event.SessionID {
 			e.activeScreenShare = nil
 			e.screenCipher = nil
+			e.screenKey = nil
+			e.screenKeyID = [16]byte{}
 			e.screenSeqNum = 0
 		}
 	} else if len(event.EncryptionKey) > 0 {
-		cipher, err := gospeakCrypto.NewVoiceCipher(event.EncryptionKey)
-		if err != nil {
-			e.screenMu.Unlock()
-			slog.Error("screen cipher init failed", "err", err)
-			return
+		sameKey := previous != nil && previous.SessionID == event.SessionID && bytes.Equal(e.screenKey, event.EncryptionKey)
+		if !sameKey {
+			cipher, err := gospeakCrypto.NewVoiceCipher(event.EncryptionKey)
+			if err != nil {
+				e.screenMu.Unlock()
+				e.screenSendMu.Unlock()
+				slog.Error("screen cipher init failed", "err", err)
+				return
+			}
+			e.screenCipher = cipher
+			e.screenKey = append(e.screenKey[:0], event.EncryptionKey...)
+			e.screenKeyID = [16]byte{}
+			copy(e.screenKeyID[:], event.EncryptionKey)
+			e.screenSeqNum = e.screenKeySequences[e.screenKeyID]
 		}
 		e.activeScreenShare = event
-		e.screenCipher = cipher
-		e.screenSeqNum = 0
 	} else {
 		e.activeScreenShare = event
 		if previous == nil || previous.SessionID != event.SessionID {
 			e.screenCipher = nil
+			e.screenKey = nil
+			e.screenKeyID = [16]byte{}
 			e.screenSeqNum = 0
 		}
 	}
 	e.screenMu.Unlock()
+	e.screenSendMu.Unlock()
 
 	if callback := e.OnScreenFrame; !event.Active && callback != nil {
 		e.enqueueGenerationCallbackLocked(g, func() { callback(nil) })
@@ -1911,11 +1937,15 @@ func (e *Engine) clearScreenShareStateGeneration(g *connectionGeneration) {
 
 func (e *Engine) clearScreenShareStateGenerationLocked(g *connectionGeneration) {
 	e.stopScreenShareLoop()
+	e.screenSendMu.Lock()
 	e.screenMu.Lock()
 	e.activeScreenShare = nil
 	e.screenCipher = nil
+	e.screenKey = nil
+	e.screenKeyID = [16]byte{}
 	e.screenSeqNum = 0
 	e.screenMu.Unlock()
+	e.screenSendMu.Unlock()
 	if callback := e.OnScreenFrame; callback != nil {
 		e.enqueueOptionalGenerationCallbackLocked(g, func() { callback(nil) })
 	}
@@ -1972,19 +2002,21 @@ func (e *Engine) startScreenShareLoop(g *connectionGeneration) {
 	}
 	displayIndex := e.screenShareDisplay
 	ctx, cancel := context.WithCancel(g.ctx)
+	e.screenShareLoopID++
+	loopID := e.screenShareLoopID
 	e.screenShareCancel = cancel
 	e.screenShareRunning = true
 	e.screenSharePending = false
 	e.screenMu.Unlock()
 
-	g.run(func(context.Context) {
+	started := g.run(func(context.Context) {
 		ticker := time.NewTicker(time.Second)
 		defer ticker.Stop()
-		defer e.stopScreenShareLoop()
+		defer e.finishScreenShareLoop(loopID)
 
 		for {
-			if err := e.sendScreenShareFrame(g, displayIndex); err != nil {
-				if errors.Is(err, errScreenShareCaptureTimedOut) {
+			if err := e.sendScreenShareFrame(ctx, g, displayIndex); err != nil {
+				if errors.Is(err, errScreenShareCaptureTimedOut) || errors.Is(err, ErrScreenSequenceExhausted) {
 					e.requestScreenShareStop(g)
 					if callback := e.OnError; callback != nil {
 						e.invokeGenerationCallback(g, func() { callback(fmt.Errorf("screen share stopped: %w", err)) })
@@ -2001,11 +2033,17 @@ func (e *Engine) startScreenShareLoop(g *connectionGeneration) {
 			}
 		}
 	})
+	if !started {
+		cancel()
+		e.finishScreenShareLoop(loopID)
+	}
 }
 
 func (e *Engine) stopScreenShareLoop() {
+	e.screenSendMu.Lock()
 	e.screenMu.Lock()
 	cancel := e.screenShareCancel
+	e.screenShareLoopID++
 	e.screenShareCancel = nil
 	e.screenShareRunning = false
 	e.screenSharePending = false
@@ -2013,6 +2051,17 @@ func (e *Engine) stopScreenShareLoop() {
 	if cancel != nil {
 		cancel()
 	}
+	e.screenSendMu.Unlock()
+}
+
+func (e *Engine) finishScreenShareLoop(loopID uint64) {
+	e.screenMu.Lock()
+	if e.screenShareLoopID == loopID {
+		e.screenShareCancel = nil
+		e.screenShareRunning = false
+		e.screenSharePending = false
+	}
+	e.screenMu.Unlock()
 }
 
 func (e *Engine) handleScreenDisconnectGeneration(g *connectionGeneration) {
@@ -2037,11 +2086,15 @@ func (e *Engine) handleScreenDisconnectGeneration(g *connectionGeneration) {
 	_ = screen.Close()
 
 	e.stopScreenShareLoop()
+	e.screenSendMu.Lock()
 	e.screenMu.Lock()
 	e.activeScreenShare = nil
 	e.screenCipher = nil
+	e.screenKey = nil
+	e.screenKeyID = [16]byte{}
 	e.screenSeqNum = 0
 	e.screenMu.Unlock()
+	e.screenSendMu.Unlock()
 
 	if callback := e.OnScreenFrame; callback != nil {
 		e.enqueueGenerationCallbackLocked(g, func() { callback(nil) })
@@ -2058,7 +2111,7 @@ func (e *Engine) handleScreenDisconnectGeneration(g *connectionGeneration) {
 	}
 }
 
-func (e *Engine) sendScreenShareFrame(g *connectionGeneration, displayIndex int) error {
+func (e *Engine) sendScreenShareFrame(ctx context.Context, g *connectionGeneration, displayIndex int) error {
 	g.mu.Lock()
 	screen := g.screen
 	g.mu.Unlock()
@@ -2069,7 +2122,25 @@ func (e *Engine) sendScreenShareFrame(g *connectionGeneration, displayIndex int)
 	if screen == nil {
 		return fmt.Errorf("not connected")
 	}
-	data, width, height, err := e.prepareScreenShareFrame(g.ctx, displayIndex)
+	e.screenMu.Lock()
+	cipher := e.screenCipher
+	if cipher == nil {
+		e.screenMu.Unlock()
+		return fmt.Errorf("screen share encryption is not ready")
+	}
+	if e.screenSeqNum == math.MaxUint32 {
+		e.screenMu.Unlock()
+		return ErrScreenSequenceExhausted
+	}
+	e.screenSeqNum++
+	seqNum := e.screenSeqNum
+	if e.screenKeySequences == nil {
+		e.screenKeySequences = make(map[[16]byte]uint32)
+	}
+	e.screenKeySequences[e.screenKeyID] = seqNum
+	e.screenMu.Unlock()
+
+	data, width, height, err := e.prepareScreenShareFrame(ctx, displayIndex)
 	if err != nil {
 		return err
 	}
@@ -2083,18 +2154,22 @@ func (e *Engine) sendScreenShareFrame(g *connectionGeneration, displayIndex int)
 	if err != nil {
 		return err
 	}
-	e.screenMu.Lock()
-	cipher := e.screenCipher
-	if cipher == nil {
-		e.screenMu.Unlock()
-		return fmt.Errorf("screen share encryption is not ready")
+	if e.beforeScreenPublish != nil {
+		e.beforeScreenPublish()
 	}
-	e.screenSeqNum++
-	seqNum := e.screenSeqNum
+	e.screenSendMu.Lock()
+	e.screenMu.Lock()
+	currentCipher := ctx.Err() == nil && e.screenCipher == cipher
 	e.screenMu.Unlock()
+	if !currentCipher {
+		e.screenSendMu.Unlock()
+		return errScreenShareChanged
+	}
 	pkt := &protocol.ScreenPacket{SessionID: sessionID, SeqNum: seqNum}
 	pkt.Payload = cipher.Encrypt(sessionID, seqNum, pkt.MarshalHeader(), frameData)
-	return screen.Send(pkt)
+	err = screen.Send(pkt)
+	e.screenSendMu.Unlock()
+	return err
 }
 
 type screenSharePrepareResult struct {
@@ -2119,7 +2194,7 @@ func (e *Engine) prepareScreenShareFrame(ctx context.Context, displayIndex int) 
 	case <-timer.C:
 		return nil, 0, 0, errScreenShareCaptureTimedOut
 	case <-ctx.Done():
-		return nil, 0, 0, fmt.Errorf("not connected")
+		return nil, 0, 0, fmt.Errorf("screen capture canceled: %w", ctx.Err())
 	}
 
 	resultCh := make(chan screenSharePrepareResult, 1)
@@ -2140,7 +2215,7 @@ func (e *Engine) prepareScreenShareFrame(ctx context.Context, displayIndex int) 
 	case <-timer.C:
 		return nil, 0, 0, errScreenShareCaptureTimedOut
 	case <-ctx.Done():
-		return nil, 0, 0, fmt.Errorf("not connected")
+		return nil, 0, 0, fmt.Errorf("screen capture canceled: %w", ctx.Err())
 	}
 }
 

--- a/pkg/client/engine_screen_sequence_test.go
+++ b/pkg/client/engine_screen_sequence_test.go
@@ -1,0 +1,340 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"image"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	gospeakCrypto "github.com/NicolasHaas/gospeak/pkg/crypto"
+	"github.com/NicolasHaas/gospeak/pkg/protocol"
+	pb "github.com/NicolasHaas/gospeak/pkg/protocol/pb"
+)
+
+type deadlineRecordingConn struct {
+	recordingConn
+	deadlineMu sync.Mutex
+	deadlines  []time.Time
+}
+
+func waitForValue[T any](t *testing.T, values <-chan T, message string) T {
+	t.Helper()
+	select {
+	case value := <-values:
+		return value
+	case <-time.After(time.Second):
+		t.Fatal(message)
+		var zero T
+		return zero
+	}
+}
+
+func (c *deadlineRecordingConn) SetWriteDeadline(deadline time.Time) error {
+	c.deadlineMu.Lock()
+	c.deadlines = append(c.deadlines, deadline)
+	c.deadlineMu.Unlock()
+	return nil
+}
+
+func TestScreenClientSendBoundsWrite(t *testing.T) {
+	conn := &deadlineRecordingConn{}
+	client := &ScreenClient{conn: conn}
+	started := time.Now()
+	if err := client.Send(&protocol.ScreenPacket{SessionID: 1, SeqNum: 1, Payload: []byte("frame")}); err != nil {
+		t.Fatal(err)
+	}
+	conn.deadlineMu.Lock()
+	deadlines := append([]time.Time(nil), conn.deadlines...)
+	conn.deadlineMu.Unlock()
+	if len(deadlines) != 2 {
+		t.Fatalf("write deadline calls = %d, want 2", len(deadlines))
+	}
+	if !deadlines[0].After(started) || deadlines[0].After(started.Add(connectTimeout+time.Second)) {
+		t.Fatalf("bounded screen write deadline = %v, started at %v", deadlines[0], started)
+	}
+	if !deadlines[1].IsZero() {
+		t.Fatalf("cleared screen write deadline = %v, want zero", deadlines[1])
+	}
+}
+
+func TestSendScreenShareFrameRejectsExhaustedSequence(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	conn := &recordingConn{}
+	g.screen = &ScreenClient{conn: conn}
+	e.generation = g
+	e.state = StateConnected
+	e.sessionID = 10
+
+	cipher, err := gospeakCrypto.NewVoiceCipher(make([]byte, 16))
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.screenCipher = cipher
+	e.screenSeqNum = math.MaxUint32
+	captureCalled := false
+	e.captureScreenFn = func(int) (image.Image, error) {
+		captureCalled = true
+		return image.NewRGBA(image.Rect(0, 0, 1, 1)), nil
+	}
+
+	err = e.sendScreenShareFrame(g.ctx, g, 0)
+	if !errors.Is(err, ErrScreenSequenceExhausted) {
+		t.Fatalf("sendScreenShareFrame() error = %v, want %v", err, ErrScreenSequenceExhausted)
+	}
+	if captureCalled {
+		t.Fatal("screen capture ran after sequence exhaustion")
+	}
+	if conn.b.Len() != 0 {
+		t.Fatalf("screen bytes written after sequence exhaustion = %d, want 0", conn.b.Len())
+	}
+	if e.screenSeqNum != math.MaxUint32 {
+		t.Fatalf("screen sequence = %d, want %d", e.screenSeqNum, uint32(math.MaxUint32))
+	}
+}
+
+func TestSendScreenShareFrameDiscardsStaleCaptureAfterKeyRotation(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	conn := &recordingConn{}
+	g.screen = &ScreenClient{conn: conn}
+	e.generation = g
+	e.state = StateConnected
+	e.sessionID = 10
+	e.channelID = 1
+	oldEvent := &pb.ScreenShareEvent{Active: true, SessionID: 10, ChannelID: 1, EncryptionKey: bytes.Repeat([]byte{1}, 16)}
+	e.handleScreenShareEvent(g, oldEvent)
+	e.captureScreenFn = func(int) (image.Image, error) {
+		return image.NewRGBA(image.Rect(0, 0, 1, 1)), nil
+	}
+	e.encodeScreenFn = func(image.Image, int, int) ([]byte, int32, int32, error) {
+		return []byte("frame"), 1, 1, nil
+	}
+	publishReached := make(chan struct{})
+	releasePublish := make(chan struct{})
+	e.beforeScreenPublish = func() {
+		close(publishReached)
+		<-releasePublish
+	}
+
+	result := make(chan error, 1)
+	go func() { result <- e.sendScreenShareFrame(context.Background(), g, 0) }()
+	waitForSignal(t, publishReached, "screen sender did not reach key-rotation publication boundary")
+	newEvent := &pb.ScreenShareEvent{Active: true, SessionID: 10, ChannelID: 1, EncryptionKey: bytes.Repeat([]byte{2}, 16)}
+	e.handleScreenShareEvent(g, newEvent)
+	close(releasePublish)
+
+	if err := waitForValue(t, result, "screen sender did not return after publication state changed"); !errors.Is(err, errScreenShareChanged) {
+		t.Fatalf("sendScreenShareFrame() error = %v, want %v", err, errScreenShareChanged)
+	}
+	if conn.b.Len() != 0 {
+		t.Fatalf("stale screen bytes written after key rotation = %d, want 0", conn.b.Len())
+	}
+}
+
+func TestSendScreenShareFrameDiscardsCaptureAfterStop(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	conn := &recordingConn{}
+	g.screen = &ScreenClient{conn: conn}
+	e.sessionID = 10
+	cipher, err := gospeakCrypto.NewVoiceCipher(bytes.Repeat([]byte{1}, 16))
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.screenCipher = cipher
+	e.captureScreenFn = func(int) (image.Image, error) {
+		return image.NewRGBA(image.Rect(0, 0, 1, 1)), nil
+	}
+	e.encodeScreenFn = func(image.Image, int, int) ([]byte, int32, int32, error) {
+		return []byte("frame"), 1, 1, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	e.screenShareCancel = cancel
+	e.screenShareRunning = true
+	publishReached := make(chan struct{})
+	releasePublish := make(chan struct{})
+	e.beforeScreenPublish = func() {
+		close(publishReached)
+		<-releasePublish
+	}
+	result := make(chan error, 1)
+	go func() { result <- e.sendScreenShareFrame(ctx, g, 0) }()
+	waitForSignal(t, publishReached, "screen sender did not reach stop publication boundary")
+	e.stopScreenShareLoop()
+	close(releasePublish)
+
+	if err := waitForValue(t, result, "screen sender did not return after publication state changed"); !errors.Is(err, errScreenShareChanged) {
+		t.Fatalf("sendScreenShareFrame() error = %v, want %v", err, errScreenShareChanged)
+	}
+	if conn.b.Len() != 0 {
+		t.Fatalf("screen bytes written after stop = %d, want 0", conn.b.Len())
+	}
+}
+
+func TestRetiredScreenLoopCannotCancelReplacement(t *testing.T) {
+	e := NewEngine()
+	replacementCtx, replacementCancel := context.WithCancel(context.Background())
+	defer replacementCancel()
+	e.screenShareLoopID = 2
+	e.screenShareCancel = replacementCancel
+	e.screenShareRunning = true
+
+	e.finishScreenShareLoop(1)
+
+	if !e.screenShareRunning {
+		t.Fatal("retired loop cleared replacement running state")
+	}
+	select {
+	case <-replacementCtx.Done():
+		t.Fatal("retired loop canceled replacement context")
+	default:
+	}
+}
+
+func TestRetiredScreenKeyResumesSequenceAfterRotation(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	g.screen = &ScreenClient{conn: &recordingConn{}}
+	e.generation = g
+	e.state = StateConnected
+	e.sessionID = 10
+	e.channelID = 1
+	e.captureScreenFn = func(int) (image.Image, error) {
+		return image.NewRGBA(image.Rect(0, 0, 1, 1)), nil
+	}
+	e.encodeScreenFn = func(image.Image, int, int) ([]byte, int32, int32, error) {
+		return []byte("frame"), 1, 1, nil
+	}
+	key1 := bytes.Repeat([]byte{1}, 16)
+	key2 := bytes.Repeat([]byte{2}, 16)
+	e.handleScreenShareEvent(g, &pb.ScreenShareEvent{Active: true, SessionID: 10, ChannelID: 1, EncryptionKey: key1})
+	if err := e.sendScreenShareFrame(context.Background(), g, 0); err != nil {
+		t.Fatal(err)
+	}
+	e.handleScreenShareEvent(g, &pb.ScreenShareEvent{Active: true, SessionID: 10, ChannelID: 1, EncryptionKey: key2})
+	e.handleScreenShareEvent(g, &pb.ScreenShareEvent{Active: true, SessionID: 10, ChannelID: 1, EncryptionKey: key1})
+	if e.screenSeqNum != 1 {
+		t.Fatalf("restored screen sequence = %d, want 1", e.screenSeqNum)
+	}
+	if err := e.sendScreenShareFrame(context.Background(), g, 0); err != nil {
+		t.Fatal(err)
+	}
+	if e.screenSeqNum != 2 {
+		t.Fatalf("screen sequence after retired-key replay = %d, want 2", e.screenSeqNum)
+	}
+}
+
+func TestRetiredScreenKeyResumesSequenceAfterInactiveEvent(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	g.screen = &ScreenClient{conn: &recordingConn{}}
+	e.generation = g
+	e.state = StateConnected
+	e.sessionID = 10
+	e.channelID = 1
+	e.captureScreenFn = func(int) (image.Image, error) {
+		return image.NewRGBA(image.Rect(0, 0, 1, 1)), nil
+	}
+	e.encodeScreenFn = func(image.Image, int, int) ([]byte, int32, int32, error) {
+		return []byte("frame"), 1, 1, nil
+	}
+	key := bytes.Repeat([]byte{1}, 16)
+	e.handleScreenShareEvent(g, &pb.ScreenShareEvent{Active: true, SessionID: 10, ChannelID: 1, EncryptionKey: key})
+	if err := e.sendScreenShareFrame(context.Background(), g, 0); err != nil {
+		t.Fatal(err)
+	}
+	e.handleScreenShareEvent(g, &pb.ScreenShareEvent{Active: false, SessionID: 10, ChannelID: 1})
+	e.handleScreenShareEvent(g, &pb.ScreenShareEvent{Active: true, SessionID: 10, ChannelID: 1, EncryptionKey: key})
+	if e.screenSeqNum != 1 {
+		t.Fatalf("restored screen sequence = %d, want 1", e.screenSeqNum)
+	}
+	if err := e.sendScreenShareFrame(context.Background(), g, 0); err != nil {
+		t.Fatal(err)
+	}
+	if e.screenSeqNum != 2 {
+		t.Fatalf("screen sequence after inactive-key replay = %d, want 2", e.screenSeqNum)
+	}
+}
+
+func TestRepeatedScreenShareKeyDoesNotResetSequence(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	e.generation = g
+	e.state = StateConnected
+	e.sessionID = 10
+	e.channelID = 1
+	event := &pb.ScreenShareEvent{
+		Active:        true,
+		SessionID:     10,
+		ChannelID:     1,
+		EncryptionKey: bytes.Repeat([]byte{1}, 16),
+	}
+
+	e.handleScreenShareEvent(g, event)
+	e.screenSeqNum = 5
+	e.handleScreenShareEvent(g, event)
+	if e.screenSeqNum != 5 {
+		t.Fatalf("screen sequence after repeated key = %d, want 5", e.screenSeqNum)
+	}
+
+	rotated := *event
+	rotated.EncryptionKey = bytes.Repeat([]byte{2}, 16)
+	e.handleScreenShareEvent(g, &rotated)
+	if e.screenSeqNum != 0 {
+		t.Fatalf("screen sequence after key rotation = %d, want 0", e.screenSeqNum)
+	}
+}
+
+func TestScreenShareLoopStopsAndReportsSequenceExhaustion(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	screenConn := &recordingConn{}
+	controlConn := &recordingConn{}
+	g.screen = &ScreenClient{conn: screenConn}
+	g.control = &ControlClient{conn: controlConn}
+	e.generation = g
+	e.state = StateConnected
+	e.sessionID = 10
+
+	cipher, err := gospeakCrypto.NewVoiceCipher(make([]byte, 16))
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.screenCipher = cipher
+	e.screenSeqNum = math.MaxUint32
+	errCh := make(chan error, 1)
+	e.OnError = func(err error) { errCh <- err }
+
+	e.startScreenShareLoop(g)
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrScreenSequenceExhausted) {
+			t.Fatalf("OnError() = %v, want %v", err, ErrScreenSequenceExhausted)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("screen loop did not report sequence exhaustion")
+	}
+	if screenConn.b.Len() != 0 {
+		t.Fatalf("screen bytes written after sequence exhaustion = %d, want 0", screenConn.b.Len())
+	}
+	msg, err := protocol.ReadControlMessage(bytes.NewReader(controlConn.b.Bytes()))
+	if err != nil {
+		t.Fatalf("read screen stop request: %v", err)
+	}
+	if msg.ScreenShareStopReq == nil {
+		t.Fatalf("control message = %#v, want screen share stop request", msg)
+	}
+
+	g.cancel()
+	done := make(chan struct{})
+	go func() {
+		g.wg.Wait()
+		close(done)
+	}()
+	waitForSignal(t, done, "screen generation workers did not stop")
+}

--- a/pkg/client/engine_voice_sequence_test.go
+++ b/pkg/client/engine_voice_sequence_test.go
@@ -1,0 +1,241 @@
+package client
+
+import (
+	"errors"
+	"math"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+type sequenceCapturer struct {
+	frame []int16
+}
+
+func (*sequenceCapturer) Start() error { return nil }
+func (c *sequenceCapturer) ReadFrame() ([]int16, error) {
+	return append([]int16(nil), c.frame...), nil
+}
+func (*sequenceCapturer) Stop() error  { return nil }
+func (*sequenceCapturer) Close() error { return nil }
+
+type sequenceEncoder struct{}
+
+func (*sequenceEncoder) Encode([]int16) ([]byte, error) { return []byte("opus"), nil }
+
+type barrierEncoder struct {
+	mu      sync.Mutex
+	count   int
+	ready   chan struct{}
+	release chan struct{}
+}
+
+func (e *barrierEncoder) Encode([]int16) ([]byte, error) {
+	e.mu.Lock()
+	e.count++
+	first := e.count == 1
+	if first {
+		close(e.ready)
+	}
+	e.mu.Unlock()
+	if first {
+		<-e.release
+	}
+	return []byte("opus"), nil
+}
+
+func waitForSignal(t *testing.T, signal <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(time.Second):
+		t.Fatal(message)
+	}
+}
+
+func exhaustedVoiceClient(t *testing.T) (*VoiceClient, *net.UDPConn) {
+	t.Helper()
+	receiver, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sender, err := net.DialUDP("udp", nil, receiver.LocalAddr().(*net.UDPAddr))
+	if err != nil {
+		_ = receiver.Close()
+		t.Fatal(err)
+	}
+	return &VoiceClient{conn: sender, seqNum: math.MaxUint32}, receiver
+}
+
+func assertVoiceExhaustion(t *testing.T, g *connectionGeneration, errCh <-chan error, receiver *net.UDPConn) {
+	t.Helper()
+	select {
+	case <-g.ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("voice sequence exhaustion did not cancel the connection generation")
+	}
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrVoiceSequenceExhausted) {
+			t.Fatalf("OnError() = %v, want %v", err, ErrVoiceSequenceExhausted)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("voice sequence exhaustion was not reported")
+	}
+	select {
+	case <-g.done:
+	case <-time.After(time.Second):
+		t.Fatal("voice sequence exhaustion did not finish disconnect")
+	}
+	if err := receiver.SetReadDeadline(time.Now().Add(20 * time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	if n, _, err := receiver.ReadFromUDP(make([]byte, 64)); err == nil {
+		t.Fatalf("received %d voice bytes after sequence exhaustion, want none", n)
+	} else if netErr, ok := err.(net.Error); !ok || !netErr.Timeout() {
+		t.Fatalf("read after sequence exhaustion: %v", err)
+	}
+}
+
+func TestCaptureLoopDisconnectsOnVoiceSequenceExhaustion(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	voice, receiver := exhaustedVoiceClient(t)
+	defer receiver.Close()
+	g.voice = voice
+	g.audio = &audioResources{
+		capture: &sequenceCapturer{frame: make([]int16, voiceFrameSamples)},
+		encoder: &sequenceEncoder{},
+	}
+	for i := range g.audio.capture.(*sequenceCapturer).frame {
+		g.audio.capture.(*sequenceCapturer).frame[i] = 1000
+	}
+	e.generation = g
+	e.state = StateConnected
+	e.channelID = 1
+	errCh := make(chan error, 1)
+	e.OnError = func(err error) { errCh <- err }
+
+	e.captureLoop(g)
+
+	assertVoiceExhaustion(t, g, errCh, receiver)
+}
+
+func TestKeepaliveDisconnectsOnVoiceSequenceExhaustion(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	voice, receiver := exhaustedVoiceClient(t)
+	defer receiver.Close()
+	g.voice = voice
+	g.audio = &audioResources{encoder: &sequenceEncoder{}}
+	e.generation = g
+	e.state = StateConnected
+	e.channelID = 1
+	e.silenceBuf = make([]int16, voiceFrameSamples)
+	errCh := make(chan error, 1)
+	e.OnError = func(err error) { errCh <- err }
+	timestamp := uint32(0)
+
+	e.trySendKeepalive(g, &timestamp, false)
+
+	assertVoiceExhaustion(t, g, errCh, receiver)
+}
+
+func TestConcurrentVoiceSequenceExhaustionReportsOnce(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	voice, receiver := exhaustedVoiceClient(t)
+	defer receiver.Close()
+	encoder := &barrierEncoder{ready: make(chan struct{}), release: make(chan struct{})}
+	capture := &sequenceCapturer{frame: make([]int16, voiceFrameSamples)}
+	for i := range capture.frame {
+		capture.frame[i] = 1000
+	}
+	g.voice = voice
+	g.audio = &audioResources{capture: capture, encoder: encoder}
+	e.generation = g
+	e.state = StateConnected
+	e.channelID = 1
+	e.silenceBuf = make([]int16, voiceFrameSamples)
+	callbackStarted := make(chan struct{})
+	releaseCallback := make(chan struct{})
+	e.OnError = func(error) {
+		close(callbackStarted)
+		<-releaseCallback
+	}
+
+	var callers sync.WaitGroup
+	callers.Add(2)
+	callersDone := make(chan struct{})
+	go func() {
+		defer callers.Done()
+		e.captureLoop(g)
+	}()
+	waitForSignal(t, encoder.ready, "capture encoder did not reach concurrency barrier")
+	keepaliveStarted := make(chan struct{})
+	go func() {
+		defer callers.Done()
+		close(keepaliveStarted)
+		timestamp := uint32(0)
+		e.trySendKeepalive(g, &timestamp, false)
+	}()
+	waitForSignal(t, keepaliveStarted, "keepalive caller did not start")
+	close(encoder.release)
+	waitForSignal(t, callbackStarted, "voice exhaustion callback did not start")
+	go func() {
+		callers.Wait()
+		close(callersDone)
+	}()
+	waitForSignal(t, callersDone, "concurrent voice callers did not return")
+
+	e.callbackQueueMu.Lock()
+	queuedCallbacks := len(e.callbackQueue)
+	e.callbackQueueMu.Unlock()
+	if queuedCallbacks != 0 {
+		t.Fatalf("queued callbacks after concurrent exhaustion = %d, want 0", queuedCallbacks)
+	}
+	close(releaseCallback)
+	select {
+	case <-g.done:
+	case <-time.After(time.Second):
+		t.Fatal("concurrent voice sequence exhaustion did not finish disconnect")
+	}
+	if err := receiver.SetReadDeadline(time.Now().Add(20 * time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	if n, _, err := receiver.ReadFromUDP(make([]byte, 64)); err == nil {
+		t.Fatalf("received %d voice bytes after concurrent sequence exhaustion, want none", n)
+	} else if netErr, ok := err.(net.Error); !ok || !netErr.Timeout() {
+		t.Fatalf("read after concurrent sequence exhaustion: %v", err)
+	}
+}
+
+func TestVoiceSequenceExhaustionUsesReliableCallbackCapacity(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	e.generation = g
+	e.state = StateConnected
+	e.OnError = func(error) {}
+
+	e.callbackQueueMu.Lock()
+	e.callbackQueue = make([]func(), maxCallbackQueue)
+	e.callbackQueueRunning = true
+	e.callbackQueueMu.Unlock()
+
+	if !e.handleVoiceSendError(g, ErrVoiceSequenceExhausted) {
+		t.Fatal("voice sequence exhaustion was not handled")
+	}
+
+	e.callbackQueueMu.Lock()
+	queuedCallbacks := len(e.callbackQueue)
+	e.callbackQueueMu.Unlock()
+	if queuedCallbacks != maxCallbackQueue+1 {
+		t.Fatalf("callbacks queued after voice exhaustion = %d, want %d", queuedCallbacks, maxCallbackQueue+1)
+	}
+	select {
+	case <-g.done:
+	case <-time.After(time.Second):
+		t.Fatal("voice sequence exhaustion did not finish disconnect")
+	}
+}

--- a/pkg/client/screen.go
+++ b/pkg/client/screen.go
@@ -65,7 +65,18 @@ func (c *ScreenClient) SetPacketHandler(handler ScreenPacketHandler) {
 func (c *ScreenClient) Send(pkt *protocol.ScreenPacket) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return protocol.WriteScreenPacket(c.conn, pkt)
+	if err := c.conn.SetWriteDeadline(time.Now().Add(connectTimeout)); err != nil {
+		return fmt.Errorf("client: set screen write deadline: %w", err)
+	}
+	writeErr := protocol.WriteScreenPacket(c.conn, pkt)
+	clearErr := c.conn.SetWriteDeadline(time.Time{})
+	if writeErr != nil {
+		return writeErr
+	}
+	if clearErr != nil {
+		return fmt.Errorf("client: clear screen write deadline: %w", clearErr)
+	}
+	return nil
 }
 
 func (c *ScreenClient) StartReceiving() {


### PR DESCRIPTION
## Summary

- disconnect the active client generation when voice sequence numbers are exhausted, report the terminal error once, and serialize capture and keepalive encoder access
- stop screen sharing before sequence wrap, retain sequence high-water marks for retired keys, and discard stale captures after stop or key rotation
- bound screen writes so lifecycle operations cannot block indefinitely, document the nonce lifecycle, and add deterministic concurrency regressions
- keep the change client-only and wire-compatible with existing servers
