### PR TITLE
Fix/channel import integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,12 @@ channels:
   - name: Gaming
     description: Gaming channels
     allow_sub_channels: true
-    children:
+    channels:
       - name: FPS
       - name: MMO
 ```
+
+The parser requires a `channels` sequence in one YAML document of at most 512 KiB and rejects unknown fields, aliases and merges, duplicate sibling names, and configurations above 8 levels or 256 channels. Imports create missing channels; channels that already exist under the same parent keep their current settings. Older examples used `children:`; that field was ignored instead of creating subchannels, so replace it with `channels:` before upgrading.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ channels:
       - name: MMO
 ```
 
-The parser requires a `channels` sequence in one YAML document of at most 512 KiB and rejects unknown fields, aliases and merges, duplicate sibling names, and configurations above 8 levels or 256 channels. Imports create missing channels; channels that already exist under the same parent keep their current settings. Older examples used `children:`; that field was ignored instead of creating subchannels, so replace it with `channels:` before upgrading.
+The parser requires a `channels` sequence in one YAML document of at most 512 KiB and rejects unknown fields, aliases and merges, duplicate sibling names, and configurations above 8 levels or 256 channels. Imports create missing channels atomically; channels that already exist under the same parent keep their current settings. Older examples used `children:`; that field was ignored instead of creating subchannels, so replace it with `channels:` before upgrading.
+
+Upgrades also reject an existing database that already contains channels with the same name under one parent. GoSpeak does not guess which channel to keep because the rows may have different settings or references. Back up the database, inspect the conflicting `(parent_id, name)` rows, and resolve them before restarting the upgraded server.
 
 ## Tech Stack
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -50,6 +50,12 @@ func main() {
 }
 
 func run(cfg server.Config) (err error) {
+	if !cfg.ExportUsers && !cfg.ExportChannels && cfg.ChannelsFile != "" {
+		if err := server.ValidateChannelsFile(cfg.ChannelsFile); err != nil {
+			return fmt.Errorf("validate channels config: %w", err)
+		}
+	}
+
 	st, err := datastore.NewProviderFactory(cfg.DBPath)
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/NicolasHaas/gospeak/pkg/server"
+)
+
+func TestRunRejectsInvalidChannelsFileBeforeOpeningDatabase(t *testing.T) {
+	dir := t.TempDir()
+	channelsPath := filepath.Join(dir, "channels.yaml")
+	if err := os.WriteFile(channelsPath, []byte("channels:\n  - unknown: true\n"), 0o600); err != nil {
+		t.Fatalf("write channels config: %v", err)
+	}
+	cfg := server.DefaultConfig()
+	cfg.ChannelsFile = channelsPath
+	cfg.DBPath = filepath.Join(dir, "gospeak.db")
+
+	err := run(cfg)
+	if err == nil || !strings.Contains(err.Error(), "validate channels config") {
+		t.Fatalf("run() error = %v, want channels validation error", err)
+	}
+	for _, path := range []string{cfg.DBPath, cfg.DBPath + "-wal", cfg.DBPath + "-shm"} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("database artifact %q exists after validation failure (stat error %v)", path, statErr)
+		}
+	}
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -73,6 +73,8 @@ These flags map directly to `gospeak-server` and are all supported options.
 | `-log-level` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
 | `-log-format` | `text` | Log format: `text` or `json` |
 
+Channel files use a single `channels:` YAML document; nested channels use the same `channels:` key. The parser rejects the older `children:` example, unknown fields, aliases, merges, oversized files, and duplicate sibling names. An upgrade also stops if the existing database already has two channels with the same name under one parent; back up the database and resolve those conflicts rather than deleting an arbitrary row.
+
 ## Ports
 
 - `9600/tcp`: TLS control plane

--- a/pkg/datastore/channel_uniqueness_test.go
+++ b/pkg/datastore/channel_uniqueness_test.go
@@ -1,0 +1,113 @@
+package datastore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/NicolasHaas/gospeak/pkg/model"
+)
+
+func TestCreateChannelRejectsDuplicateSiblingName(t *testing.T) {
+	st := newChannelUniquenessStore(t)
+	first := &model.Channel{Name: "duplicate", ParentID: 7}
+	if err := st.NonTx().CreateChannel(first); err != nil {
+		t.Fatalf("create first channel: %v", err)
+	}
+
+	second := &model.Channel{Name: "duplicate", ParentID: 7}
+	if err := st.NonTx().CreateChannel(second); !errors.Is(err, ErrChannelNameTaken) {
+		t.Fatalf("create duplicate error = %v, want %v", err, ErrChannelNameTaken)
+	}
+}
+
+func TestCreateChannelAllowsSameNameUnderDifferentParents(t *testing.T) {
+	st := newChannelUniquenessStore(t)
+	for _, parentID := range []int64{1, 2} {
+		channel := &model.Channel{Name: "shared", ParentID: parentID}
+		if err := st.NonTx().CreateChannel(channel); err != nil {
+			t.Fatalf("create channel under parent %d: %v", parentID, err)
+		}
+	}
+}
+
+func TestSiblingUniquenessMigrationRejectsExistingDuplicates(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "duplicates.db")
+	st, err := NewProviderFactory(path)
+	if err != nil {
+		t.Fatalf("open datastore: %v", err)
+	}
+	if _, err := st.DB.ExecContext(ctx, "DROP INDEX IF EXISTS idx_channels_parent_name"); err != nil {
+		t.Fatalf("drop sibling index: %v", err)
+	}
+	if _, err := st.DB.ExecContext(ctx, "UPDATE schema_migrations SET version = 5"); err != nil {
+		t.Fatalf("rewind schema version: %v", err)
+	}
+	if _, err := st.DB.ExecContext(ctx, "INSERT INTO channels (name, parent_id) VALUES ('duplicate', 3), ('duplicate', 3)"); err != nil {
+		t.Fatalf("seed duplicate channels: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close seeded datastore: %v", err)
+	}
+
+	reopened, err := NewProviderFactory(path)
+	if err == nil {
+		_ = reopened.Close()
+		t.Fatal("NewProviderFactory() error = nil, want duplicate migration failure")
+	}
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open failed-migration datastore: %v", err)
+	}
+	var version, duplicates, indexes int
+	if err := raw.QueryRowContext(ctx, "SELECT version FROM schema_migrations").Scan(&version); err != nil {
+		t.Fatalf("read schema version: %v", err)
+	}
+	if err := raw.QueryRowContext(ctx, "SELECT COUNT(*) FROM channels WHERE name = 'duplicate' AND parent_id = 3").Scan(&duplicates); err != nil {
+		t.Fatalf("count preserved duplicates: %v", err)
+	}
+	if err := raw.QueryRowContext(ctx, "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_channels_parent_name'").Scan(&indexes); err != nil {
+		t.Fatalf("check failed index: %v", err)
+	}
+	if version != 5 || duplicates != 2 || indexes != 0 {
+		t.Fatalf("failed migration state = version %d, duplicates %d, indexes %d; want 5, 2, 0", version, duplicates, indexes)
+	}
+	if _, err := raw.ExecContext(ctx, "DELETE FROM channels WHERE id = (SELECT MAX(id) FROM channels WHERE name = 'duplicate' AND parent_id = 3)"); err != nil {
+		t.Fatalf("resolve duplicate channel: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close repaired datastore: %v", err)
+	}
+
+	reopened, err = NewProviderFactory(path)
+	if err != nil {
+		t.Fatalf("reopen repaired datastore: %v", err)
+	}
+	if err := reopened.DB.QueryRowContext(ctx, "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_channels_parent_name'").Scan(&indexes); err != nil {
+		t.Fatalf("check migrated index: %v", err)
+	}
+	if indexes != 1 {
+		t.Fatalf("migrated index count = %d, want 1", indexes)
+	}
+	if err := reopened.Close(); err != nil {
+		t.Fatalf("close migrated datastore: %v", err)
+	}
+}
+
+func newChannelUniquenessStore(t *testing.T) *ProviderFactory {
+	t.Helper()
+	st, err := NewProviderFactory(filepath.Join(t.TempDir(), "channels.db"))
+	if err != nil {
+		t.Fatalf("open datastore: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := st.Close(); err != nil {
+			t.Errorf("close datastore: %v", err)
+		}
+	})
+	return st
+}

--- a/pkg/datastore/interface.go
+++ b/pkg/datastore/interface.go
@@ -46,6 +46,7 @@ type DataStore interface {
 // ErrUsernameTaken is returned when a CreateUser call fails due to a
 // duplicate username constraint.
 var ErrUsernameTaken = errors.New("datastore: username already taken")
+var ErrChannelNameTaken = errors.New("datastore: channel name already exists under parent")
 
 var _ DataProviderFactory = (*ProviderFactory)(nil)
 

--- a/pkg/datastore/sql.go
+++ b/pkg/datastore/sql.go
@@ -212,6 +212,12 @@ func (s *ProviderFactory) migrate() error {
 				"ALTER TABLE users ADD COLUMN channel_scope INTEGER NOT NULL DEFAULT 0",
 			},
 		},
+		{
+			version: 6,
+			statements: []string{
+				"CREATE UNIQUE INDEX IF NOT EXISTS idx_channels_parent_name ON channels(parent_id, name)",
+			},
+		},
 	}
 
 	for _, m := range migrations {
@@ -496,6 +502,9 @@ func (s *baseProvider) CreateChannel(channel *model.Channel) error {
 		allowSubInt,
 	)
 	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed: channels.parent_id, channels.name") {
+			return fmt.Errorf("datastore: create channel: %w", ErrChannelNameTaken)
+		}
 		return fmt.Errorf("datastore: create channel: %w", err)
 	}
 	channel.ID, err = res.LastInsertId()

--- a/pkg/model/channel.go
+++ b/pkg/model/channel.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 )
 
@@ -21,8 +22,12 @@ const (
 )
 
 var ErrChannelNameEmpty = errors.New("channel name must not be empty")
+var ErrChannelNameInvalidUTF8 = errors.New("channel name is not valid UTF-8")
 var ErrChannelNameTooLong = errors.New("channel name too long")
+var ErrChannelNameControl = errors.New("channel name contains control or format characters")
 var ErrChannelDescTooLong = errors.New("channel description too long")
+var ErrChannelDescInvalidUTF8 = errors.New("channel description is not valid UTF-8")
+var ErrChannelDescControl = errors.New("channel description contains control or format characters")
 var ErrChannelMaxUsers = errors.New("channel max users out of range")
 var ErrChannelParentID = errors.New("channel parent id out of range")
 
@@ -57,13 +62,21 @@ func (ch *Channel) Validate() error {
 	// Name
 	if strings.TrimSpace(ch.Name) == "" {
 		return ErrChannelNameEmpty
+	} else if !utf8.ValidString(ch.Name) {
+		return ErrChannelNameInvalidUTF8
 	} else if utf8.RuneCountInString(ch.Name) > MaxChannelNameLength {
 		return ErrChannelNameTooLong
+	} else if containsControlCharacter(ch.Name) {
+		return ErrChannelNameControl
 	}
 
 	// Description
-	if utf8.RuneCountInString(ch.Description) > MaxChannelDescLength {
+	if !utf8.ValidString(ch.Description) {
+		return ErrChannelDescInvalidUTF8
+	} else if utf8.RuneCountInString(ch.Description) > MaxChannelDescLength {
 		return ErrChannelDescTooLong
+	} else if containsControlCharacter(ch.Description) {
+		return ErrChannelDescControl
 	}
 
 	// MaxUsers
@@ -77,4 +90,10 @@ func (ch *Channel) Validate() error {
 	}
 
 	return nil
+}
+
+func containsControlCharacter(value string) bool {
+	return strings.IndexFunc(value, func(r rune) bool {
+		return unicode.IsControl(r) || unicode.Is(unicode.Cf, r)
+	}) >= 0
 }

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -61,12 +61,42 @@ func TestChannel_Validate(t *testing.T) {
 			ErrChannelNameTooLong,
 		},
 		{
+			"name with invalid UTF-8",
+			&Channel{Name: string([]byte{'s', 'a', 'f', 'e', 0xff})},
+			ErrChannelNameInvalidUTF8,
+		},
+		{
+			"name with control character",
+			&Channel{Name: "General\x1b"},
+			ErrChannelNameControl,
+		},
+		{
+			"name with Unicode format character",
+			&Channel{Name: "safe\u202eevil"},
+			ErrChannelNameControl,
+		},
+		{
 			"description too long",
 			&Channel{
 				Name:        "Valid",
 				Description: strings.Repeat("x", MaxChannelDescLength+1),
 			},
 			ErrChannelDescTooLong,
+		},
+		{
+			"description with invalid UTF-8",
+			&Channel{Name: "Valid", Description: string([]byte{'b', 'a', 'd', 0xff})},
+			ErrChannelDescInvalidUTF8,
+		},
+		{
+			"description with control character",
+			&Channel{Name: "Valid", Description: "first line\nsecond line"},
+			ErrChannelDescControl,
+		},
+		{
+			"description with Unicode format character",
+			&Channel{Name: "Valid", Description: "zero\u200bwidth"},
+			ErrChannelDescControl,
 		},
 		{
 			"max users negative",

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -1,13 +1,22 @@
 package server
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 
 	"github.com/NicolasHaas/gospeak/pkg/datastore"
 	"github.com/NicolasHaas/gospeak/pkg/model"
+	"github.com/NicolasHaas/gospeak/pkg/protocol"
 	"gopkg.in/yaml.v3"
+)
+
+const (
+	maxChannelImportDepth = 8
+	maxChannelImportCount = 256
+	maxChannelImportBytes = protocol.MaxControlMessage
 )
 
 // ChannelYAML represents a channel in YAML config.
@@ -37,30 +46,162 @@ type UsersExport struct {
 	Users []UserYAML `yaml:"users"`
 }
 
-// LoadChannelsFromYAML reads a channels YAML file and creates/updates channels in the datastore.
+// LoadChannelsFromYAML reads a channels YAML file and creates missing channels.
 func LoadChannelsFromYAML(path string, st datastore.DataProviderFactory) error {
-	data, err := os.ReadFile(path) //nolint:gosec // path from user-provided CLI config
+	data, err := readChannelsYAML(path)
 	if err != nil {
-		return fmt.Errorf("read channels config: %w", err)
+		return err
 	}
 	return ImportChannelsFromYAML(data, st)
 }
 
-// ImportChannelsFromYAML parses YAML data and creates/updates channels in the datastore.
+// ValidateChannelsFile checks a channel configuration without changing the datastore.
+func ValidateChannelsFile(path string) error {
+	data, err := readChannelsYAML(path)
+	if err != nil {
+		return err
+	}
+	_, err = parseChannelsYAML(data)
+	return err
+}
+
+// ImportChannelsFromYAML parses YAML data and creates missing channels atomically.
 func ImportChannelsFromYAML(data []byte, st datastore.DataProviderFactory) error {
-	var cfg ChannelsConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return fmt.Errorf("parse channels config: %w", err)
+	cfg, err := parseChannelsYAML(data)
+	if err != nil {
+		return err
+	}
+	return applyChannelsConfig(cfg, st)
+}
+
+func readChannelsYAML(path string) ([]byte, error) {
+	file, err := os.Open(path) //nolint:gosec // path from user-provided CLI config
+	if err != nil {
+		return nil, fmt.Errorf("read channels config: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	data, err := io.ReadAll(io.LimitReader(file, int64(maxChannelImportBytes)+1))
+	if err != nil {
+		return nil, fmt.Errorf("read channels config: %w", err)
+	}
+	if len(data) > maxChannelImportBytes {
+		return nil, fmt.Errorf("read channels config: maximum size %d bytes exceeded", maxChannelImportBytes)
+	}
+	return data, nil
+}
+
+func parseChannelsYAML(data []byte) (ChannelsConfig, error) {
+	if len(data) > maxChannelImportBytes {
+		return ChannelsConfig{}, fmt.Errorf("parse channels config: maximum size %d bytes exceeded", maxChannelImportBytes)
+	}
+	var document yaml.Node
+	nodeDecoder := yaml.NewDecoder(bytes.NewReader(data))
+	if err := nodeDecoder.Decode(&document); err != nil {
+		return ChannelsConfig{}, fmt.Errorf("parse channels config: %w", err)
+	}
+	if err := validateChannelsDocument(&document); err != nil {
+		return ChannelsConfig{}, err
+	}
+	if hasYAMLAliasOrMerge(&document) {
+		return ChannelsConfig{}, fmt.Errorf("parse channels config: YAML aliases and merges are not allowed")
+	}
+	var extra yaml.Node
+	if err := nodeDecoder.Decode(&extra); err != io.EOF {
+		if err != nil {
+			return ChannelsConfig{}, fmt.Errorf("parse channels config: %w", err)
+		}
+		return ChannelsConfig{}, fmt.Errorf("parse channels config: multiple YAML documents are not allowed")
 	}
 
-	for _, ch := range cfg.Channels {
-		if err := ensureChannel(st, ch, 0); err != nil {
-			slog.Error("failed to create channel from config", "name", ch.Name, "err", err)
+	var cfg ChannelsConfig
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&cfg); err != nil {
+		return ChannelsConfig{}, fmt.Errorf("parse channels config: %w", err)
+	}
+	if err := validateChannelImport(cfg.Channels); err != nil {
+		return ChannelsConfig{}, err
+	}
+	return cfg, nil
+}
+
+func validateChannelsDocument(document *yaml.Node) error {
+	if document.Kind != yaml.DocumentNode || len(document.Content) != 1 {
+		return fmt.Errorf("parse channels config: expected one document")
+	}
+	root := document.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return fmt.Errorf("parse channels config: root must be a mapping")
+	}
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value == "channels" {
+			if root.Content[i+1].Kind != yaml.SequenceNode {
+				return fmt.Errorf("parse channels config: channels must be a sequence")
+			}
+			return nil
 		}
 	}
+	return fmt.Errorf("parse channels config: channels field is required")
+}
 
+func hasYAMLAliasOrMerge(root *yaml.Node) bool {
+	stack := []*yaml.Node{root}
+	for len(stack) > 0 {
+		node := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if node.Kind == yaml.AliasNode || node.Tag == "!!merge" {
+			return true
+		}
+		stack = append(stack, node.Content...)
+	}
+	return false
+}
+
+func applyChannelsConfig(cfg ChannelsConfig, st datastore.DataProviderFactory) error {
+	for _, ch := range cfg.Channels {
+		if err := ensureChannel(st, ch, 0); err != nil {
+			return fmt.Errorf("apply channel import: %w", err)
+		}
+	}
 	slog.Info("imported channels from YAML", "count", countChannels(cfg.Channels))
 	return nil
+}
+
+func validateChannelImport(channels []ChannelYAML) error {
+	count := 0
+	var validate func([]ChannelYAML, int) error
+	validate = func(entries []ChannelYAML, depth int) error {
+		if depth > maxChannelImportDepth {
+			return fmt.Errorf("validate channels config: maximum depth %d exceeded", maxChannelImportDepth)
+		}
+		siblings := make(map[string]struct{}, len(entries))
+		for _, ch := range entries {
+			if _, exists := siblings[ch.Name]; exists {
+				return fmt.Errorf("validate channels config: duplicate channel %q under the same parent", ch.Name)
+			}
+			siblings[ch.Name] = struct{}{}
+			count++
+			if count > maxChannelImportCount {
+				return fmt.Errorf("validate channels config: maximum channel count %d exceeded", maxChannelImportCount)
+			}
+			candidate := &model.Channel{
+				Name:             ch.Name,
+				Description:      ch.Description,
+				MaxUsers:         ch.MaxUsers,
+				AllowSubChannels: ch.AllowSubChannels,
+			}
+			if err := candidate.Validate(); err != nil {
+				return fmt.Errorf("validate channel %q: %w", ch.Name, err)
+			}
+			if len(ch.Channels) > 0 {
+				if err := validate(ch.Channels, depth+1); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	return validate(channels, 1)
 }
 
 func ensureChannel(st datastore.DataProviderFactory, ch ChannelYAML, parentID int64) error {
@@ -86,7 +227,6 @@ func ensureChannel(st datastore.DataProviderFactory, ch ChannelYAML, parentID in
 			return err
 		}
 		channelID = channel.ID
-		slog.Debug("created channel from config", "name", ch.Name, "parent", parentID)
 	}
 
 	// Recurse into sub-channels

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -2,10 +2,12 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
+	"sync"
 
 	"github.com/NicolasHaas/gospeak/pkg/datastore"
 	"github.com/NicolasHaas/gospeak/pkg/model"
@@ -18,6 +20,8 @@ const (
 	maxChannelImportCount = 256
 	maxChannelImportBytes = protocol.MaxControlMessage
 )
+
+var channelImportMu sync.Mutex
 
 // ChannelYAML represents a channel in YAML config.
 type ChannelYAML struct {
@@ -158,12 +162,66 @@ func hasYAMLAliasOrMerge(root *yaml.Node) bool {
 }
 
 func applyChannelsConfig(cfg ChannelsConfig, st datastore.DataProviderFactory) error {
+	channelImportMu.Lock()
+	defer channelImportMu.Unlock()
+
+	tx, err := st.Tx(context.Background())
+	if err != nil {
+		return fmt.Errorf("begin channel import: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := applyMissingChannels(tx, cfg); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit channel import: %w", err)
+	}
+
+	slog.Info("imported channels from YAML", "count", countChannels(cfg.Channels))
+	return nil
+}
+
+func initializeChannels(cfg *ChannelsConfig, st datastore.DataProviderFactory) error {
+	tx, err := st.Tx(context.Background())
+	if err != nil {
+		return fmt.Errorf("begin channel initialization: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	channels, err := tx.ListChannels()
+	if err != nil {
+		return fmt.Errorf("list channels: %w", err)
+	}
+	createdLobby := false
+	if len(channels) == 0 {
+		if err := tx.CreateChannel(model.NewChannel()); err != nil {
+			return fmt.Errorf("create lobby: %w", err)
+		}
+		createdLobby = true
+	}
+	if cfg != nil {
+		if err := applyMissingChannels(tx, *cfg); err != nil {
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit channel initialization: %w", err)
+	}
+	if createdLobby {
+		slog.Info("created default Lobby channel")
+	}
+	if cfg != nil {
+		slog.Info("imported channels from YAML", "count", countChannels(cfg.Channels))
+	}
+	return nil
+}
+
+func applyMissingChannels(st datastore.DataStore, cfg ChannelsConfig) error {
 	for _, ch := range cfg.Channels {
 		if err := ensureChannel(st, ch, 0); err != nil {
 			return fmt.Errorf("apply channel import: %w", err)
 		}
 	}
-	slog.Info("imported channels from YAML", "count", countChannels(cfg.Channels))
 	return nil
 }
 
@@ -204,9 +262,9 @@ func validateChannelImport(channels []ChannelYAML) error {
 	return validate(channels, 1)
 }
 
-func ensureChannel(st datastore.DataProviderFactory, ch ChannelYAML, parentID int64) error {
+func ensureChannel(st datastore.DataStore, ch ChannelYAML, parentID int64) error {
 	// Check if channel already exists under this parent
-	existing, err := st.NonTx().GetChannelByNameAndParent(ch.Name, parentID)
+	existing, err := st.GetChannelByNameAndParent(ch.Name, parentID)
 	if err != nil {
 		return err
 	}
@@ -223,7 +281,7 @@ func ensureChannel(st datastore.DataProviderFactory, ch ChannelYAML, parentID in
 			IsTemp:           false,
 			AllowSubChannels: ch.AllowSubChannels,
 		}
-		if err := st.NonTx().CreateChannel(channel); err != nil {
+		if err := st.CreateChannel(channel); err != nil {
 			return err
 		}
 		channelID = channel.ID

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -2,11 +2,16 @@ package server
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/NicolasHaas/gospeak/pkg/datastore"
+	"github.com/NicolasHaas/gospeak/pkg/model"
+	"github.com/NicolasHaas/gospeak/pkg/protocol"
+	pb "github.com/NicolasHaas/gospeak/pkg/protocol/pb"
 )
 
 func TestImportChannelsFromYAMLRejectsUnknownFieldsAndExtraDocuments(t *testing.T) {
@@ -125,6 +130,155 @@ func TestImportChannelsFromYAMLRejectsDuplicateSiblingDeclarations(t *testing.T)
 
 	if err := ImportChannelsFromYAML(input, st); err == nil {
 		t.Fatal("ImportChannelsFromYAML() error = nil, want duplicate sibling error")
+	}
+	assertNoImportedChannels(t, st)
+}
+
+func TestImportChannelsFromYAMLRollsBackOnStoreFailure(t *testing.T) {
+	st := newChannelImportStore(t)
+	if _, err := st.DB.Exec(`CREATE TRIGGER reject_broken_channel
+		BEFORE INSERT ON channels WHEN NEW.name = 'broken'
+		BEGIN SELECT RAISE(FAIL, 'injected channel failure'); END`); err != nil {
+		t.Fatalf("create failure trigger: %v", err)
+	}
+	input := []byte("channels:\n  - name: valid\n  - name: broken\n")
+
+	if err := ImportChannelsFromYAML(input, st); err == nil {
+		t.Fatal("ImportChannelsFromYAML() error = nil, want store error")
+	}
+	assertNoImportedChannels(t, st)
+}
+
+func TestImportChannelsFromYAMLPreservesExistingChannels(t *testing.T) {
+	st := newChannelImportStore(t)
+	original := []byte("channels:\n  - name: existing\n    description: original\n    max_users: 5\n    channels:\n      - name: child\n        description: child-original\n        max_users: 3\n")
+	if err := ImportChannelsFromYAML(original, st); err != nil {
+		t.Fatalf("initial import: %v", err)
+	}
+	parentBefore, err := st.NonTx().GetChannelByNameAndParent("existing", 0)
+	if err != nil || parentBefore == nil {
+		t.Fatalf("get original parent: channel = %#v, error = %v", parentBefore, err)
+	}
+	childBefore, err := st.NonTx().GetChannelByNameAndParent("child", parentBefore.ID)
+	if err != nil || childBefore == nil {
+		t.Fatalf("get original child: channel = %#v, error = %v", childBefore, err)
+	}
+
+	changed := []byte("channels:\n  - name: existing\n    description: replacement\n    max_users: 10\n    channels:\n      - name: child\n        description: child-replacement\n        max_users: 8\n        channels:\n          - name: grandchild\n  - name: child\n")
+	if err := ImportChannelsFromYAML(changed, st); err != nil {
+		t.Fatalf("second import: %v", err)
+	}
+
+	parentAfter, err := st.NonTx().GetChannelByNameAndParent("existing", 0)
+	if err != nil {
+		t.Fatalf("get existing channel: %v", err)
+	}
+	if parentAfter == nil || parentAfter.ID != parentBefore.ID || parentAfter.Description != "original" || parentAfter.MaxUsers != 5 {
+		t.Fatalf("existing parent = %#v, want original channel %#v preserved", parentAfter, parentBefore)
+	}
+	childAfter, err := st.NonTx().GetChannelByNameAndParent("child", parentAfter.ID)
+	if err != nil {
+		t.Fatalf("get existing child: %v", err)
+	}
+	if childAfter == nil || childAfter.ID != childBefore.ID || childAfter.Description != "child-original" || childAfter.MaxUsers != 3 {
+		t.Fatalf("existing child = %#v, want original channel %#v preserved", childAfter, childBefore)
+	}
+	grandchild, err := st.NonTx().GetChannelByNameAndParent("grandchild", childAfter.ID)
+	if err != nil || grandchild == nil {
+		t.Fatalf("get missing descendant after import: channel = %#v, error = %v", grandchild, err)
+	}
+	rootChild, err := st.NonTx().GetChannelByNameAndParent("child", 0)
+	if err != nil || rootChild == nil || rootChild.ID == childAfter.ID {
+		t.Fatalf("same-name root channel = %#v, nested child = %#v, error = %v", rootChild, childAfter, err)
+	}
+}
+
+func TestImportChannelsFromYAMLConcurrentImportsDoNotDuplicateSiblings(t *testing.T) {
+	st := newChannelImportStore(t)
+	input := []byte("channels:\n  - name: shared\n")
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- ImportChannelsFromYAML(input, st)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent idempotent import failed: %v", err)
+		}
+	}
+	channels, err := st.NonTx().ListChannels()
+	if err != nil {
+		t.Fatalf("list channels: %v", err)
+	}
+	if len(channels) != 1 || channels[0].Name != "shared" {
+		t.Fatalf("channels = %#v, want one shared sibling", channels)
+	}
+}
+
+func TestHandleImportChannelsReturnsGenericFailure(t *testing.T) {
+	srv, st, handler := newTestServer(t)
+	conn := &bufferConn{}
+	session := mustCreateSession(t, srv.sessions, 1, "admin", model.RoleAdmin)
+
+	srv.handleImportChannels(session.ID, &pb.ImportChannelsRequest{
+		YAML: "channels:\n  - name: invalid\n    internal_path: /private/operator/path\n",
+	}, st, conn, handler)
+
+	response, err := protocol.ReadControlMessage(conn)
+	if err != nil {
+		t.Fatalf("read import response: %v", err)
+	}
+	if response.ImportChannelsResp == nil {
+		t.Fatalf("import response = %#v, want ImportChannelsResponse", response)
+	}
+	if response.ImportChannelsResp.Success || response.ImportChannelsResp.Message != "channel import failed" {
+		t.Fatalf("import response = %#v, want generic failure", response.ImportChannelsResp)
+	}
+}
+
+func TestRunRollsBackLobbyWhenChannelInitializationFails(t *testing.T) {
+	st := newChannelImportStore(t)
+	if _, err := st.DB.Exec(`CREATE TRIGGER reject_broken_startup_channel
+		BEFORE INSERT ON channels WHEN NEW.name = 'broken'
+		BEGIN SELECT RAISE(FAIL, 'injected startup failure'); END`); err != nil {
+		t.Fatalf("create failure trigger: %v", err)
+	}
+	channelsPath := filepath.Join(t.TempDir(), "channels.yaml")
+	if err := os.WriteFile(channelsPath, []byte("channels:\n  - name: valid\n  - name: broken\n"), 0o600); err != nil {
+		t.Fatalf("write channels config: %v", err)
+	}
+	cfg := DefaultConfig()
+	cfg.ChannelsFile = channelsPath
+	cfg.ControlAddr = "invalid-address"
+	srv := New(cfg, Dependencies{Store: st})
+
+	err := srv.Run()
+	if err == nil || !strings.Contains(err.Error(), "initialize channels") {
+		t.Fatalf("Run() error = %v, want channel initialization error", err)
+	}
+	assertNoImportedChannels(t, st)
+}
+
+func TestRunFailsForExplicitMissingChannelsFile(t *testing.T) {
+	st := newChannelImportStore(t)
+	cfg := DefaultConfig()
+	cfg.ChannelsFile = filepath.Join(t.TempDir(), "missing.yaml")
+	cfg.ControlAddr = "invalid-address"
+	srv := New(cfg, Dependencies{Store: st})
+
+	err := srv.Run()
+	if err == nil || !strings.Contains(err.Error(), "load channels config") {
+		t.Fatalf("Run() error = %v, want channels config startup error", err)
 	}
 	assertNoImportedChannels(t, st)
 }

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -1,0 +1,169 @@
+package server
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/NicolasHaas/gospeak/pkg/datastore"
+)
+
+func TestImportChannelsFromYAMLRejectsUnknownFieldsAndExtraDocuments(t *testing.T) {
+	tests := map[string]string{
+		"unknown root field":   "channels: []\nunexpected: true\n",
+		"unknown nested field": "channels:\n  - name: Lobby\n    unexpected: true\n",
+		"extra document":       "channels: []\n---\nchannels: []\n",
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			st := newChannelImportStore(t)
+			if err := ImportChannelsFromYAML([]byte(input), st); err == nil {
+				t.Fatal("ImportChannelsFromYAML() error = nil, want invalid YAML error")
+			}
+		})
+	}
+}
+
+func TestImportChannelsFromYAMLRejectsOversizedAndAliasedInput(t *testing.T) {
+	tests := map[string][]byte{
+		"oversized":          []byte("channels: []\n#" + strings.Repeat("x", 512*1024)),
+		"alias":              []byte("channels:\n  - &shared\n    name: shared\n  - *shared\n"),
+		"binary name":        []byte("channels:\n  - name: !!binary c2FmZf8=\n"),
+		"binary description": []byte("channels:\n  - name: safe\n    description: !!binary YmFk/w==\n"),
+	}
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			st := newChannelImportStore(t)
+			if err := ImportChannelsFromYAML(input, st); err == nil {
+				t.Fatal("ImportChannelsFromYAML() error = nil, want bounded parser error")
+			}
+			assertNoImportedChannels(t, st)
+		})
+	}
+}
+
+func TestImportChannelsFromYAMLRequiresExplicitChannelsSequence(t *testing.T) {
+	for name, input := range map[string]string{
+		"null document":   "null\n",
+		"empty mapping":   "{}\n",
+		"null channels":   "channels:\n",
+		"empty document":  "---\n",
+		"scalar channels": "channels: invalid\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			st := newChannelImportStore(t)
+			if err := ImportChannelsFromYAML([]byte(input), st); err == nil {
+				t.Fatal("ImportChannelsFromYAML() error = nil, want document shape error")
+			}
+			assertNoImportedChannels(t, st)
+		})
+	}
+
+	t.Run("explicit empty sequence", func(t *testing.T) {
+		st := newChannelImportStore(t)
+		if err := ImportChannelsFromYAML([]byte("channels: []\n"), st); err != nil {
+			t.Fatalf("ImportChannelsFromYAML() error = %v, want success", err)
+		}
+		assertNoImportedChannels(t, st)
+	})
+}
+
+func TestImportChannelsFromYAMLRejectsDepthAndCountOverLimits(t *testing.T) {
+	t.Run("maximum depth accepted", func(t *testing.T) {
+		if _, err := parseChannelsYAML([]byte(nestedChannelsYAML(8))); err != nil {
+			t.Fatalf("parseChannelsYAML() error = %v, want 8 levels accepted", err)
+		}
+	})
+
+	t.Run("depth", func(t *testing.T) {
+		st := newChannelImportStore(t)
+		if err := ImportChannelsFromYAML([]byte(nestedChannelsYAML(9)), st); err == nil {
+			t.Fatal("ImportChannelsFromYAML() error = nil, want depth limit error")
+		}
+		assertNoImportedChannels(t, st)
+	})
+
+	channelsYAML := func(count int) []byte {
+		var input strings.Builder
+		input.WriteString("channels:\n")
+		for i := 0; i < count; i++ {
+			fmt.Fprintf(&input, "  - name: channel-%d\n", i)
+		}
+		return []byte(input.String())
+	}
+
+	t.Run("maximum count accepted", func(t *testing.T) {
+		if _, err := parseChannelsYAML(channelsYAML(256)); err != nil {
+			t.Fatalf("parseChannelsYAML() error = %v, want 256 channels accepted", err)
+		}
+	})
+
+	t.Run("count", func(t *testing.T) {
+		st := newChannelImportStore(t)
+		if err := ImportChannelsFromYAML(channelsYAML(257), st); err == nil {
+			t.Fatal("ImportChannelsFromYAML() error = nil, want channel count limit error")
+		}
+		assertNoImportedChannels(t, st)
+	})
+}
+
+func TestImportChannelsFromYAMLValidatesBeforeApplying(t *testing.T) {
+	st := newChannelImportStore(t)
+	input := []byte("channels:\n  - name: valid\n  - name: ''\n")
+
+	if err := ImportChannelsFromYAML(input, st); err == nil {
+		t.Fatal("ImportChannelsFromYAML() error = nil, want channel validation error")
+	}
+	assertNoImportedChannels(t, st)
+}
+
+func TestImportChannelsFromYAMLRejectsDuplicateSiblingDeclarations(t *testing.T) {
+	st := newChannelImportStore(t)
+	input := []byte("channels:\n  - name: duplicate\n    description: first\n  - name: duplicate\n    description: second\n")
+
+	if err := ImportChannelsFromYAML(input, st); err == nil {
+		t.Fatal("ImportChannelsFromYAML() error = nil, want duplicate sibling error")
+	}
+	assertNoImportedChannels(t, st)
+}
+
+func nestedChannelsYAML(levels int) string {
+	var input strings.Builder
+	input.WriteString("channels:\n")
+	for depth := 0; depth < levels; depth++ {
+		input.WriteString(strings.Repeat("  ", depth+1))
+		input.WriteString("- name: channel\n")
+		if depth < levels-1 {
+			input.WriteString(strings.Repeat("  ", depth+2))
+			input.WriteString("channels:\n")
+		}
+	}
+	return input.String()
+}
+
+func newChannelImportStore(t *testing.T) *datastore.ProviderFactory {
+	t.Helper()
+	st, err := datastore.NewProviderFactory(filepath.Join(t.TempDir(), "channels.db"))
+	if err != nil {
+		t.Fatalf("open datastore: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := st.Close(); err != nil {
+			t.Errorf("close datastore: %v", err)
+		}
+	})
+	return st
+}
+
+func assertNoImportedChannels(t *testing.T, st *datastore.ProviderFactory) {
+	t.Helper()
+	channels, err := st.NonTx().ListChannels()
+	if err != nil {
+		t.Fatalf("list channels: %v", err)
+	}
+	if len(channels) != 0 {
+		t.Fatalf("imported channels = %#v, want none", channels)
+	}
+}

--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -1334,10 +1334,11 @@ func (s *Server) handleImportChannels(sessionID uint32, req *pb.ImportChannelsRe
 	}
 
 	if err := ImportChannelsFromYAML([]byte(req.YAML), st); err != nil {
+		slog.Warn("channel import failed", "by", session.Username, "err", err)
 		_ = writeControlMessage(conn, &pb.ControlMessage{
 			ImportChannelsResp: &pb.ImportChannelsResponse{
 				Success: false,
-				Message: "import failed: " + err.Error(),
+				Message: "channel import failed",
 			},
 		})
 		return

--- a/pkg/server/run.go
+++ b/pkg/server/run.go
@@ -35,20 +35,21 @@ func (s *Server) Run() error {
 	// stable value (avoids a data race with the assignment below).
 	s.voiceDebugEnabled = slog.Default().Enabled(context.Background(), slog.LevelDebug)
 
-	// Ensure default "Lobby" channel exists
-	channels, _ := st.NonTx().ListChannels()
-	if len(channels) == 0 {
-		if err := st.NonTx().CreateChannel(model.NewChannel()); err != nil {
-			return fmt.Errorf("server: create lobby: %w", err)
+	var channelConfig *ChannelsConfig
+	if s.cfg.ChannelsFile != "" {
+		data, err := readChannelsYAML(s.cfg.ChannelsFile)
+		if err != nil {
+			return fmt.Errorf("server: load channels config: %w", err)
 		}
-		slog.Info("created default Lobby channel")
+		cfg, err := parseChannelsYAML(data)
+		if err != nil {
+			return fmt.Errorf("server: load channels config: %w", err)
+		}
+		channelConfig = &cfg
 	}
 
-	// Load channels from YAML config if provided
-	if s.cfg.ChannelsFile != "" {
-		if err := LoadChannelsFromYAML(s.cfg.ChannelsFile, st); err != nil {
-			slog.Error("failed to load channels config", "err", err)
-		}
+	if err := initializeChannels(channelConfig, st); err != nil {
+		return fmt.Errorf("server: initialize channels: %w", err)
 	}
 
 	// Ensure at least one admin token exists


### PR DESCRIPTION
## Summary

- strictly parse one YAML document of at most 512 KiB and reject unknown fields, aliases, merges, duplicate sibling names, control characters, more than 8 levels, or more than 256 channels
- validate the complete channel tree before writing, fail startup for an invalid explicit configuration, and create only missing channels without overwriting existing settings
- apply imports transactionally and enforce sibling-name uniqueness in SQLite, including root channels and concurrent creation
- return generic import failures to (admin) client while retaining detailed server-side logs