### PR TITLE
fix(server): harden bootstrap admin provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ docker compose -f compose.yaml -f compose.monitoring.yaml up -d
 Grafana is then available only on `127.0.0.1:3000`. Prometheus is not published
 on the host.
 
-On first run, an **admin token** is printed to stdout — save it to create more tokens and manage the server.
+On first run, GoSpeak writes an admin bootstrap credential to
+`bootstrap-admin.token` in the data directory. For this Compose setup, read it
+with `cat ./data/bootstrap-admin.token`. Use it for the first admin login and
+save the personal token returned by the server. Interrupted first logins can be
+retried for the same administrator. The server removes the bootstrap file once
+that personal token is used; the credential is never written to normal logs.
 
 ### Run the Server (Binary)
 
@@ -121,7 +126,7 @@ Existing bookmark files remain compatible. They gain a `trusted_server_pins` sec
 | `-voice` | `:9601` | UDP voice bind address |
 | `-screen` | `:9603` | TCP/TLS screen-share relay bind address |
 | `-db` | `gospeak.db` | SQLite database path |
-| `-data` | `.` | Data directory (TLS certs, etc.) |
+| `-data` | `.` | Data directory for generated TLS files and the first-run `bootstrap-admin.token` |
 | `-open` | `false` | Allow connections without a token |
 | `-screen-share` | `false` | Enable per-channel screen sharing |
 | `-channels-file` | | YAML file for initial channel setup |

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -30,8 +30,21 @@ This configuration is designed to be hands-off after first boot while staying se
 ## Open server mode
 
 The provided cloud-init starts GoSpeak with `-open` and `-screen-share`, which allows anyone to join without a token and enables per-channel screen sharing.
-To require tokens, remove `-open` from `deploy/cloud-init.yaml` and then use the admin token
-printed on first start to generate user tokens.
+To require tokens, remove `-open` from `deploy/cloud-init.yaml`. On first start,
+GoSpeak writes an admin bootstrap credential to
+`/var/lib/gospeak/bootstrap-admin.token`; read it over SSH with:
+
+```bash
+sudo cat /var/lib/gospeak/bootstrap-admin.token
+```
+
+Use that credential for the first admin login and save the personal token
+returned by the server. Interrupted first logins can be retried for the same
+administrator. GoSpeak removes the bootstrap file after the personal token is
+used and logs only the file path, never the credential itself.
+
+With `deploy/compose.yaml`, the same file is in the named data volume. Read it
+with `docker compose exec gospeak cat /data/bootstrap-admin.token`.
 
 ## Bandwidth example (budget VPS)
 

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -1,8 +1,8 @@
 # GoSpeak Server example Docker Compose
 # Usage: docker compose up -d
 #
-# On first run, check logs for your admin token:
-#   docker compose logs gospeak
+# On first run, read the admin bootstrap credential from the data volume:
+#   docker compose exec gospeak cat /data/bootstrap-admin.token
 
 services:
   gospeak:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,7 +122,8 @@ sequenceDiagram
     Srv->>Srv: GenerateKey() → shared AES-128 voice key
     Srv->>Store: Ensure "Lobby" channel exists
     Srv->>Store: Load channels from YAML (if configured)
-    Srv->>Store: Ensure admin token exists (first run only)
+    Srv->>Srv: Securely publish bootstrap-admin.token (first run only)
+    Srv->>Store: Install its retryable, single-admin credential; log path only
     Srv->>TLS: StartControl(:9600)
     Srv->>UDP: StartVoice(:9601)
     opt screen sharing enabled

--- a/docs/security.md
+++ b/docs/security.md
@@ -166,7 +166,14 @@ graph TB
 - Only the SHA-256 hash is stored in the database (invite + personal tokens). Personal tokens are stored on the user record and are shown only once.
 - Saved client bookmarks contain personal tokens in plaintext so the client can reconnect. The bookmark file is atomically written with mode `0600` under the operating system's user config directory (`gospeak/`). On upgrade, legacy bookmark and settings files beside the executable are migrated there and removed only after the protected replacement is written successfully. Protect the user account and its config directory accordingly.
 - Invite tokens can have: role assignment, channel scope, max uses, expiration. A non-zero channel scope is enforced by the server: the client auto-joins that channel and cannot join another channel. The generated personal token retains this restriction on later logins. Existing users and unscoped tokens remain server-wide. Older clients remain wire-compatible but must be upgraded to select the scoped channel automatically.
-- On first server run, an admin token is automatically generated and logged
+- On first server run, an admin bootstrap credential is written atomically to
+  `bootstrap-admin.token` in the configured data directory. It is protected by
+  mode `0600` and owner checks on POSIX, or a protected owner-only ACL on
+  Windows, and is read without following the final symlink/reparse component.
+  Provisioning is transactional and retryable for one administrator, including
+  after response-delivery failures. The server invalidates the credential and
+  removes its file after that administrator proves possession of the returned
+  personal token. Normal logs contain only the credential path.
 
 ### Open Server Mode
 
@@ -218,4 +225,4 @@ Used internally for potential future password-based auth:
 2. **Restart the server** periodically to generate fresh voice encryption keys (a new key is generated on every startup)
 3. **Use strong tokens** (the default 256-bit random is good)
 4. **Restrict network access** — only expose ports 9600/tcp, 9601/udp, and 9603/tcp when screen sharing is enabled
-5. **Monitor admin token usage** — the auto-generated admin token is logged at startup
+5. **Protect bootstrap credentials** — read `bootstrap-admin.token` only through the server administrator account and retain the returned personal token

--- a/pkg/datastore/interface.go
+++ b/pkg/datastore/interface.go
@@ -47,6 +47,15 @@ type DataStore interface {
 // duplicate username constraint.
 var ErrUsernameTaken = errors.New("datastore: username already taken")
 var ErrChannelNameTaken = errors.New("datastore: channel name already exists under parent")
+var ErrBootstrapAlreadyProvisioned = errors.New("datastore: bootstrap credential already provisioned another user")
+
+type BootstrapTokenState uint8
+
+const (
+	BootstrapTokenAbsent BootstrapTokenState = iota
+	BootstrapTokenPending
+	BootstrapTokenFinalized
+)
 
 var _ DataProviderFactory = (*ProviderFactory)(nil)
 
@@ -81,14 +90,18 @@ type ChannelWriteProvider interface {
 
 type TokenReadProvider interface {
 	HasTokens() (bool, error)
+	BootstrapTokenState() (BootstrapTokenState, error)
 }
 
 type TokenWriteProvider interface {
 	CreateToken(hash string, role model.Role, channelScope int64, createdBy int64, maxUses int, expiresAt time.Time) error
+	CreateBootstrapToken(hash string) error
+	FinalizeBootstrapToken(userID int64) (bool, error)
 }
 
 type TokenTransactionProvider interface {
 	ValidateToken(hash string) (*model.Token, error)
+	ProvisionBootstrapUser(hash, username, personalTokenHash string, createdAt time.Time) (*model.User, error)
 }
 
 type BanReadProvider interface {

--- a/pkg/datastore/sql.go
+++ b/pkg/datastore/sql.go
@@ -12,7 +12,11 @@ import (
 	"github.com/NicolasHaas/gospeak/pkg/model"
 )
 
-const dbTimeLayout = "2006-01-02 15:04:05"
+const (
+	dbTimeLayout       = "2006-01-02 15:04:05"
+	tokenKindInvite    = 0
+	tokenKindBootstrap = 1
+)
 
 type DB interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
@@ -177,6 +181,7 @@ func (s *ProviderFactory) migrate() error {
 		version      int
 		statements   []string
 		ignoreErrors bool
+		column       string
 	}{
 		{
 			version:    1,
@@ -218,11 +223,30 @@ func (s *ProviderFactory) migrate() error {
 				"CREATE UNIQUE INDEX IF NOT EXISTS idx_channels_parent_name ON channels(parent_id, name)",
 			},
 		},
+		{
+			version: 7,
+			statements: []string{
+				"ALTER TABLE tokens ADD COLUMN kind INTEGER NOT NULL DEFAULT 0 CHECK(kind IN (0, 1))",
+			},
+			column: "kind",
+		},
 	}
 
 	for _, m := range migrations {
 		if m.version <= currentVersion {
 			continue
+		}
+		if m.column != "" {
+			exists, err := s.tokenColumnExists(ctx, m.column)
+			if err != nil {
+				return err
+			}
+			if exists {
+				if err := s.setSchemaVersion(ctx, m.version); err != nil {
+					return err
+				}
+				continue
+			}
 		}
 		for _, stmt := range m.statements {
 			if err := s.execMigration(ctx, stmt, m.ignoreErrors); err != nil {
@@ -234,6 +258,16 @@ func (s *ProviderFactory) migrate() error {
 		}
 	}
 	return nil
+}
+
+func (s *ProviderFactory) tokenColumnExists(ctx context.Context, column string) (bool, error) {
+	var exists int
+	if err := s.DB.QueryRowContext(ctx,
+		"SELECT EXISTS(SELECT 1 FROM pragma_table_info('tokens') WHERE name = ?)", column,
+	).Scan(&exists); err != nil {
+		return false, fmt.Errorf("datastore: inspect schema column: %w", err)
+	}
+	return exists != 0, nil
 }
 
 func (s *ProviderFactory) ensureSchemaMigrations(ctx context.Context) error {
@@ -611,20 +645,91 @@ func (s *baseProvider) HasTokens() (bool, error) {
 	return count > 0, nil
 }
 
+func (s *baseProvider) BootstrapTokenState() (BootstrapTokenState, error) {
+	rows, err := s.QueryContext(context.Background(),
+		"SELECT max_uses, use_count, created_by FROM tokens WHERE kind = ?", tokenKindBootstrap,
+	)
+	if err != nil {
+		return BootstrapTokenAbsent, fmt.Errorf("datastore: read bootstrap token state: %w", err)
+	}
+	defer rows.Close()
+	state := BootstrapTokenAbsent
+	for rows.Next() {
+		if state != BootstrapTokenAbsent {
+			return BootstrapTokenAbsent, fmt.Errorf("datastore: multiple bootstrap token records")
+		}
+		var maxUses, useCount int
+		var createdBy int64
+		if err := rows.Scan(&maxUses, &useCount, &createdBy); err != nil {
+			return BootstrapTokenAbsent, fmt.Errorf("datastore: scan bootstrap token state: %w", err)
+		}
+		switch {
+		case maxUses == -1 && useCount == 0 && createdBy == 0:
+			state = BootstrapTokenPending
+		case maxUses == -1 && useCount == 1 && createdBy > 0:
+			state = BootstrapTokenPending
+		case maxUses == 1 && useCount == 1 && createdBy > 0:
+			state = BootstrapTokenFinalized
+		default:
+			return BootstrapTokenAbsent, fmt.Errorf("datastore: invalid bootstrap token state")
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return BootstrapTokenAbsent, fmt.Errorf("datastore: iterate bootstrap token state: %w", err)
+	}
+	return state, nil
+}
+
 // CreateToken stores a new token (hash only).
 func (s *baseProvider) CreateToken(hash string, role model.Role, channelScope int64, createdBy int64, maxUses int, expiresAt time.Time) error {
+	if maxUses < 0 {
+		return fmt.Errorf("datastore: create token: max uses must not be negative")
+	}
 	var expStr *string
 	if !expiresAt.IsZero() {
-		s := formatDBTime(expiresAt)
-		expStr = &s
+		value := formatDBTime(expiresAt)
+		expStr = &value
 	}
 	_, err := s.ExecContext(context.Background(),
-		"INSERT INTO tokens (hash, role, channel_scope, created_by, max_uses, expires_at) VALUES (?, ?, ?, ?, ?, ?)",
-		hash, int(role), channelScope, createdBy, maxUses, expStr)
+		"INSERT INTO tokens (hash, role, channel_scope, created_by, kind, max_uses, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		hash, int(role), channelScope, createdBy, tokenKindInvite, maxUses, expStr)
 	if err != nil {
 		return fmt.Errorf("datastore: create token: %w", err)
 	}
 	return nil
+}
+
+func (s *baseProvider) CreateBootstrapToken(hash string) error {
+	_, err := s.ExecContext(context.Background(),
+		"INSERT INTO tokens (hash, role, channel_scope, created_by, kind, max_uses) VALUES (?, ?, 0, 0, ?, -1)",
+		hash, int(model.RoleAdmin), tokenKindBootstrap)
+	if err != nil {
+		return fmt.Errorf("datastore: create bootstrap token: %w", err)
+	}
+	return nil
+}
+
+// FinalizeBootstrapToken makes a provisioned bootstrap credential permanently
+// exhausted after the client proves possession of its personal token.
+func (s *baseProvider) FinalizeBootstrapToken(userID int64) (bool, error) {
+	ctx := context.Background()
+	var belongs int
+	if err := s.QueryRowContext(ctx,
+		"SELECT EXISTS(SELECT 1 FROM tokens WHERE created_by = ? AND kind = ? AND max_uses IN (-1, 1) AND use_count = 1)",
+		userID, tokenKindBootstrap,
+	).Scan(&belongs); err != nil {
+		return false, fmt.Errorf("datastore: inspect bootstrap finalization: %w", err)
+	}
+	if belongs == 0 {
+		return false, nil
+	}
+	if _, err := s.ExecContext(ctx,
+		"UPDATE tokens SET max_uses = 1 WHERE created_by = ? AND kind = ? AND max_uses = -1 AND use_count = 1",
+		userID, tokenKindBootstrap,
+	); err != nil {
+		return false, fmt.Errorf("datastore: finalize bootstrap token: %w", err)
+	}
+	return true, nil
 }
 
 // ValidateToken checks if a token hash is valid and returns its authorization data.
@@ -634,16 +739,19 @@ func (s *txProvider) ValidateToken(hash string) (*model.Token, error) {
 
 	var roleInt int
 	var channelScope int64
-	var maxUses, useCount int
+	var kind, maxUses, useCount int
 	var expiresAt *string
 	err := s.QueryRowContext(ctx,
-		"SELECT role, channel_scope, max_uses, use_count, expires_at FROM tokens WHERE hash = ?", hash).
-		Scan(&roleInt, &channelScope, &maxUses, &useCount, &expiresAt)
+		"SELECT role, channel_scope, kind, max_uses, use_count, expires_at FROM tokens WHERE hash = ?", hash).
+		Scan(&roleInt, &channelScope, &kind, &maxUses, &useCount, &expiresAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("datastore: invalid token")
 	}
 	if err != nil {
 		return nil, fmt.Errorf("datastore: validate token: %w", err)
+	}
+	if kind != tokenKindInvite || maxUses < 0 {
+		return nil, fmt.Errorf("datastore: invalid token")
 	}
 
 	if expiresAt != nil {
@@ -675,6 +783,82 @@ func (s *txProvider) ValidateToken(hash string) (*model.Token, error) {
 	}
 
 	return &model.Token{Role: model.Role(roleInt), ChannelScope: channelScope}, nil
+}
+
+// ProvisionBootstrapUser atomically binds the internal bootstrap credential to
+// one administrator and a deterministic personal token. Repeating the same
+// provisioning request returns the existing user; a different username is
+// rejected.
+func (s *txProvider) ProvisionBootstrapUser(hash, username, personalTokenHash string, createdAt time.Time) (*model.User, error) {
+	ctx := context.Background()
+	var roleInt, kind, maxUses, useCount int
+	var channelScope, createdBy int64
+	if err := s.QueryRowContext(ctx,
+		"SELECT role, channel_scope, created_by, kind, max_uses, use_count FROM tokens WHERE hash = ?", hash,
+	).Scan(&roleInt, &channelScope, &createdBy, &kind, &maxUses, &useCount); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("datastore: invalid bootstrap credential")
+		}
+		return nil, fmt.Errorf("datastore: read bootstrap credential: %w", err)
+	}
+	if model.Role(roleInt) != model.RoleAdmin || channelScope != 0 || kind != tokenKindBootstrap || maxUses != -1 {
+		return nil, fmt.Errorf("datastore: invalid bootstrap credential")
+	}
+	if useCount == 0 && createdBy != 0 {
+		return nil, fmt.Errorf("datastore: invalid bootstrap credential state")
+	}
+	if useCount != 0 {
+		if useCount != 1 || createdBy <= 0 {
+			return nil, fmt.Errorf("datastore: invalid bootstrap credential state")
+		}
+		user, err := s.GetUserByID(createdBy)
+		if err != nil {
+			return nil, err
+		}
+		if user == nil || user.Username != username || user.PersonalTokenHash != personalTokenHash {
+			return nil, ErrBootstrapAlreadyProvisioned
+		}
+		return user, nil
+	}
+
+	result, err := s.ExecContext(ctx,
+		"UPDATE tokens SET use_count = 1 WHERE hash = ? AND kind = ? AND max_uses = -1 AND use_count = 0",
+		hash, tokenKindBootstrap,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("datastore: claim bootstrap credential: %w", err)
+	}
+	claimed, err := result.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("datastore: inspect bootstrap claim: %w", err)
+	}
+	if claimed != 1 {
+		return nil, fmt.Errorf("datastore: bootstrap credential changed concurrently")
+	}
+	user, err := s.CreateUserWithChannelScope(username, model.RoleAdmin, 0)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.UpdateUserPersonalToken(user.ID, personalTokenHash, createdAt); err != nil {
+		return nil, err
+	}
+	result, err = s.ExecContext(ctx,
+		"UPDATE tokens SET created_by = ? WHERE hash = ? AND kind = ? AND max_uses = -1 AND use_count = 1 AND created_by = 0",
+		user.ID, hash, tokenKindBootstrap,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("datastore: bind bootstrap credential: %w", err)
+	}
+	bound, err := result.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("datastore: inspect bootstrap binding: %w", err)
+	}
+	if bound != 1 {
+		return nil, fmt.Errorf("datastore: bootstrap credential changed concurrently")
+	}
+	user.PersonalTokenHash = personalTokenHash
+	user.PersonalTokenCreatedAt = createdAt
+	return user, nil
 }
 
 // ---- Bans ----

--- a/pkg/datastore/sql_test.go
+++ b/pkg/datastore/sql_test.go
@@ -864,6 +864,71 @@ func TestCreateToken(t *testing.T) {
 	}
 }
 
+func TestCreateTokenRejectsNegativeMaxUses(t *testing.T) {
+	t.Parallel()
+	store, err := NewTestSqlConn(t)
+	if err != nil {
+		t.Fatalf("failed to open test connection: %v", err)
+	}
+	if err := store.NonTx().CreateToken("negative-invite", model.RoleAdmin, 0, 1, -1, time.Time{}); err == nil {
+		t.Fatal("CreateToken() accepted negative max uses")
+	}
+}
+
+func TestLegacyNegativeInviteCannotFinalizeBootstrap(t *testing.T) {
+	t.Parallel()
+	store, err := NewTestSqlConn(t)
+	if err != nil {
+		t.Fatalf("failed to open test connection: %v", err)
+	}
+	user, err := store.NonTx().CreateUser("legacy-owner", model.RoleAdmin)
+	if err != nil {
+		t.Fatalf("CreateUser() error = %v", err)
+	}
+	if _, err := store.DB.Exec(
+		"INSERT INTO tokens (hash, role, channel_scope, created_by, max_uses, use_count) VALUES (?, ?, 0, ?, -1, 1)",
+		"legacy-negative", int(model.RoleAdmin), user.ID,
+	); err != nil {
+		t.Fatalf("insert legacy negative invite: %v", err)
+	}
+	finalized, err := store.NonTx().FinalizeBootstrapToken(user.ID)
+	if err != nil {
+		t.Fatalf("FinalizeBootstrapToken() error = %v", err)
+	}
+	if finalized {
+		t.Fatal("legacy negative invite was mistaken for a bootstrap credential")
+	}
+}
+
+func TestBootstrapFinalizationIsRetryable(t *testing.T) {
+	t.Parallel()
+	store, err := NewTestSqlConn(t)
+	if err != nil {
+		t.Fatalf("failed to open test connection: %v", err)
+	}
+	user, err := store.NonTx().CreateUser("bootstrap-owner", model.RoleAdmin)
+	if err != nil {
+		t.Fatalf("CreateUser() error = %v", err)
+	}
+	if err := store.NonTx().CreateBootstrapToken("bootstrap-hash"); err != nil {
+		t.Fatalf("CreateBootstrapToken() error = %v", err)
+	}
+	if _, err := store.DB.Exec(
+		"UPDATE tokens SET created_by = ?, use_count = 1 WHERE hash = ?", user.ID, "bootstrap-hash",
+	); err != nil {
+		t.Fatalf("bind bootstrap token: %v", err)
+	}
+	for attempt := 1; attempt <= 2; attempt++ {
+		finalized, err := store.NonTx().FinalizeBootstrapToken(user.ID)
+		if err != nil {
+			t.Fatalf("FinalizeBootstrapToken() attempt %d error = %v", attempt, err)
+		}
+		if !finalized {
+			t.Fatalf("FinalizeBootstrapToken() attempt %d did not recognize the binding", attempt)
+		}
+	}
+}
+
 func TestValidateToken(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/server/bootstrap.go
+++ b/pkg/server/bootstrap.go
@@ -1,0 +1,188 @@
+package server
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/NicolasHaas/gospeak/pkg/crypto"
+	"github.com/NicolasHaas/gospeak/pkg/datastore"
+	"github.com/NicolasHaas/gospeak/pkg/model"
+)
+
+const (
+	bootstrapAdminCredentialName = "bootstrap-admin.token"
+	bootstrapTokenHexLength      = 64
+)
+
+// ensureAdminToken creates a retryable admin credential only when the store
+// contains no tokens. The raw credential is delivered through a private file,
+// never through normal process logs.
+func (s *Server) ensureAdminToken(st datastore.DataProviderFactory) error {
+	credentialPath := filepath.Join(serverDataDir(s.cfg), bootstrapAdminCredentialName)
+	hasTokens, err := st.NonTx().HasTokens()
+	if err != nil {
+		return fmt.Errorf("server: check tokens: %w", err)
+	}
+	if hasTokens {
+		state, err := st.NonTx().BootstrapTokenState()
+		if err != nil {
+			return fmt.Errorf("server: inspect admin bootstrap state: %w", err)
+		}
+		switch state {
+		case datastore.BootstrapTokenPending:
+			if _, err := readBootstrapCredential(credentialPath); err != nil {
+				return fmt.Errorf("server: inspect admin bootstrap credential: %w", err)
+			}
+		case datastore.BootstrapTokenFinalized, datastore.BootstrapTokenAbsent:
+			if err := removeBootstrapCredential(credentialPath); err != nil {
+				return fmt.Errorf("server: retire admin bootstrap credential: %w", err)
+			}
+		}
+		return nil
+	}
+
+	rawToken, err := loadOrCreateBootstrapCredential(credentialPath)
+	if err != nil {
+		return fmt.Errorf("server: prepare admin bootstrap credential: %w", err)
+	}
+
+	hash := crypto.HashToken(rawToken)
+	if err := st.NonTx().CreateBootstrapToken(hash); err != nil {
+		return fmt.Errorf("server: store admin bootstrap token: %w", err)
+	}
+
+	slog.Info("admin bootstrap credential created", "path", credentialPath)
+	return nil
+}
+
+func (s *Server) bootstrapCredentialMatches(rawToken string) (bool, error) {
+	credentialPath := filepath.Join(serverDataDir(s.cfg), bootstrapAdminCredentialName)
+	want, err := readBootstrapCredential(credentialPath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return subtle.ConstantTimeCompare([]byte(rawToken), []byte(want)) == 1, nil
+}
+
+func deriveBootstrapPersonalToken(rawToken, username string) string {
+	mac := hmac.New(sha256.New, []byte(rawToken))
+	_, _ = mac.Write([]byte("gospeak bootstrap personal token\x00"))
+	_, _ = mac.Write([]byte(username))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func (s *Server) tryProvisionBootstrapUser(st datastore.DataProviderFactory, tokenHash, rawToken, username string) (*model.User, string, bool, error) {
+	s.bootstrapMu.Lock()
+	defer s.bootstrapMu.Unlock()
+
+	matches, err := s.bootstrapCredentialMatches(rawToken)
+	if err != nil || !matches {
+		return nil, "", false, err
+	}
+	rawPersonalToken := deriveBootstrapPersonalToken(rawToken, username)
+	tx, err := st.Tx(context.Background())
+	if err != nil {
+		return nil, "", true, fmt.Errorf("start transaction: %w", err)
+	}
+	user, err := tx.ProvisionBootstrapUser(tokenHash, username, crypto.HashToken(rawPersonalToken), time.Now().UTC())
+	if err != nil {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil {
+			return nil, "", true, fmt.Errorf("provision user: %w (rollback: %v)", err, rollbackErr)
+		}
+		return nil, "", true, err
+	}
+	if err := tx.Commit(); err != nil {
+		_ = tx.Rollback()
+		return nil, "", true, fmt.Errorf("commit transaction: %w", err)
+	}
+	return user, rawPersonalToken, true, nil
+}
+
+func (s *Server) finalizeBootstrapCredential(st datastore.DataProviderFactory, userID int64) error {
+	s.bootstrapMu.Lock()
+	defer s.bootstrapMu.Unlock()
+
+	finalized, err := st.NonTx().FinalizeBootstrapToken(userID)
+	if err != nil || !finalized {
+		return err
+	}
+	credentialPath := filepath.Join(serverDataDir(s.cfg), bootstrapAdminCredentialName)
+	if err := removeBootstrapCredential(credentialPath); err != nil {
+		slog.Warn("remove finalized bootstrap credential", "path", credentialPath, "err", err)
+	}
+	return nil
+}
+
+func removeBootstrapCredential(path string) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func serverDataDir(cfg Config) string {
+	if cfg.DataDir == "" {
+		return "."
+	}
+	return cfg.DataDir
+}
+
+func loadOrCreateBootstrapCredential(path string) (string, error) {
+	rawToken, err := readBootstrapCredential(path)
+	if err == nil {
+		return rawToken, nil
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return "", err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("create data directory: %w", err)
+	}
+	rawToken, err = crypto.GenerateToken()
+	if err != nil {
+		return "", fmt.Errorf("generate token: %w", err)
+	}
+	tempPath, err := prepareBootstrapCredentialFile(path, []byte(rawToken+"\n"))
+	if err != nil {
+		return "", fmt.Errorf("prepare credential file: %w", err)
+	}
+	defer func() { _ = os.Remove(tempPath) }()
+	if err := os.Link(tempPath, path); err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return readBootstrapCredential(path)
+		}
+		return "", fmt.Errorf("publish credential file without overwrite: %w", err)
+	}
+	if err := syncBootstrapCredentialDirectory(filepath.Dir(path)); err != nil {
+		return "", fmt.Errorf("sync credential directory: %w", err)
+	}
+	return rawToken, nil
+}
+
+func readBootstrapCredential(path string) (string, error) {
+	data, err := readBootstrapCredentialFile(path)
+	if err != nil {
+		return "", err
+	}
+	rawToken := strings.TrimSuffix(string(data), "\n")
+	decoded, err := hex.DecodeString(rawToken)
+	if err != nil || len(decoded) != bootstrapTokenHexLength/2 {
+		return "", fmt.Errorf("credential file %q contains an invalid token", path)
+	}
+	return rawToken, nil
+}

--- a/pkg/server/bootstrap_file_unix.go
+++ b/pkg/server/bootstrap_file_unix.go
@@ -1,0 +1,78 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package server
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func prepareBootstrapCredentialFile(path string, data []byte) (string, error) {
+	return prepareTLSFile(path, data, 0o600)
+}
+
+func syncBootstrapCredentialDirectory(path string) error {
+	dir, err := os.Open(path) //nolint:gosec // path comes from operator-provided DataDir
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dir.Close() }()
+	return dir.Sync()
+}
+
+func readBootstrapCredentialFile(path string) ([]byte, error) {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	file := os.NewFile(uintptr(fd), path)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("open credential file %q: invalid file descriptor", path)
+	}
+	defer func() { _ = file.Close() }()
+
+	before, err := inspectBootstrapCredentialFD(fd, path)
+	if err != nil {
+		return nil, err
+	}
+	data, err := io.ReadAll(io.LimitReader(file, bootstrapTokenHexLength+2))
+	if err != nil {
+		return nil, fmt.Errorf("read credential file %q: %w", path, err)
+	}
+	if len(data) != bootstrapTokenHexLength+1 {
+		return nil, fmt.Errorf("credential file %q has an invalid size", path)
+	}
+	after, err := inspectBootstrapCredentialFD(fd, path)
+	if err != nil {
+		return nil, err
+	}
+	if before.Dev != after.Dev || before.Ino != after.Ino || before.Mode != after.Mode || before.Uid != after.Uid || before.Size != after.Size {
+		return nil, fmt.Errorf("credential file %q changed while being read", path)
+	}
+	return data, nil
+}
+
+func inspectBootstrapCredentialFD(fd int, path string) (*unix.Stat_t, error) {
+	stat := new(unix.Stat_t)
+	if err := unix.Fstat(fd, stat); err != nil {
+		return nil, fmt.Errorf("inspect credential file %q: %w", path, err)
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		return nil, fmt.Errorf("credential path %q is not a regular file", path)
+	}
+	euid := int64(os.Geteuid())
+	if int64(stat.Uid) != euid {
+		return nil, fmt.Errorf("credential file %q is owned by uid %d, want %d", path, stat.Uid, euid)
+	}
+	if permissions := stat.Mode & 0o7777; permissions != 0o600 {
+		return nil, fmt.Errorf("credential file %q permissions are %04o, want 0600", path, permissions)
+	}
+	if stat.Size != bootstrapTokenHexLength+1 {
+		return nil, fmt.Errorf("credential file %q has an invalid size", path)
+	}
+	return stat, nil
+}

--- a/pkg/server/bootstrap_file_windows.go
+++ b/pkg/server/bootstrap_file_windows.go
@@ -1,0 +1,234 @@
+//go:build windows
+
+package server
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const bootstrapFileFullControl windows.ACCESS_MASK = 0x001F01FF
+
+func currentProcessSID() (*windows.SID, error) {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return nil, fmt.Errorf("read process user SID: %w", err)
+	}
+	return user.User.Sid, nil
+}
+
+func bootstrapSecurityDescriptor() (*windows.SECURITY_DESCRIPTOR, error) {
+	owner, err := currentProcessSID()
+	if err != nil {
+		return nil, err
+	}
+	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
+		AccessPermissions: bootstrapFileFullControl,
+		AccessMode:        windows.SET_ACCESS,
+		Inheritance:       windows.NO_INHERITANCE,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  windows.TRUSTEE_IS_USER,
+			TrusteeValue: windows.TrusteeValueFromSID(owner),
+		},
+	}}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build credential ACL: %w", err)
+	}
+	descriptor, err := windows.NewSecurityDescriptor()
+	if err != nil {
+		return nil, fmt.Errorf("create credential security descriptor: %w", err)
+	}
+	if err := descriptor.SetOwner(owner, false); err != nil {
+		return nil, fmt.Errorf("set credential owner: %w", err)
+	}
+	if err := descriptor.SetDACL(acl, true, false); err != nil {
+		return nil, fmt.Errorf("set credential DACL: %w", err)
+	}
+	if err := descriptor.SetControl(windows.SE_DACL_PROTECTED, windows.SE_DACL_PROTECTED); err != nil {
+		return nil, fmt.Errorf("protect credential DACL: %w", err)
+	}
+	selfRelative, err := descriptor.ToSelfRelative()
+	if err != nil {
+		return nil, fmt.Errorf("encode credential security descriptor: %w", err)
+	}
+	return selfRelative, nil
+}
+
+func prepareBootstrapCredentialFile(path string, data []byte) (string, error) {
+	descriptor, err := bootstrapSecurityDescriptor()
+	if err != nil {
+		return "", err
+	}
+	attrs := &windows.SecurityAttributes{
+		Length:             uint32(unsafe.Sizeof(windows.SecurityAttributes{})),
+		SecurityDescriptor: descriptor,
+	}
+	for range 100 {
+		randomSuffix := make([]byte, 16)
+		if _, err := rand.Read(randomSuffix); err != nil {
+			return "", fmt.Errorf("generate temporary credential name: %w", err)
+		}
+		tempPath := filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+".tmp-"+hex.EncodeToString(randomSuffix))
+		pathPtr, err := windows.UTF16PtrFromString(tempPath)
+		if err != nil {
+			return "", err
+		}
+		handle, err := windows.CreateFile(
+			pathPtr,
+			windows.GENERIC_READ|windows.GENERIC_WRITE|windows.READ_CONTROL,
+			0,
+			attrs,
+			windows.CREATE_NEW,
+			windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+			0,
+		)
+		if errors.Is(err, windows.ERROR_FILE_EXISTS) || errors.Is(err, windows.ERROR_ALREADY_EXISTS) {
+			continue
+		}
+		if err != nil {
+			return "", &os.PathError{Op: "create", Path: tempPath, Err: err}
+		}
+		file := os.NewFile(uintptr(handle), tempPath)
+		if file == nil {
+			_ = windows.CloseHandle(handle)
+			_ = os.Remove(tempPath)
+			return "", fmt.Errorf("create credential file %q: invalid handle", tempPath)
+		}
+		if _, err := file.Write(data); err != nil {
+			_ = file.Close()
+			_ = os.Remove(tempPath)
+			return "", fmt.Errorf("write credential file %q: %w", tempPath, err)
+		}
+		if err := file.Sync(); err != nil {
+			_ = file.Close()
+			_ = os.Remove(tempPath)
+			return "", fmt.Errorf("sync credential file %q: %w", tempPath, err)
+		}
+		if err := file.Close(); err != nil {
+			_ = os.Remove(tempPath)
+			return "", fmt.Errorf("close credential file %q: %w", tempPath, err)
+		}
+		return tempPath, nil
+	}
+	return "", fmt.Errorf("create temporary credential file: too many name collisions")
+}
+
+// Windows does not provide a portable directory fsync equivalent. The file is
+// flushed before its hard-link is published.
+func syncBootstrapCredentialDirectory(string) error {
+	return nil
+}
+
+func openBootstrapCredentialHandle(path string, access uint32) (windows.Handle, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return windows.InvalidHandle, err
+	}
+	handle, err := windows.CreateFile(
+		pathPtr,
+		access,
+		windows.FILE_SHARE_READ,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return windows.InvalidHandle, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	return handle, nil
+}
+
+func readBootstrapCredentialFile(path string) ([]byte, error) {
+	handle, err := openBootstrapCredentialHandle(path, windows.GENERIC_READ|windows.READ_CONTROL)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, fmt.Errorf("open credential file %q: invalid handle", path)
+	}
+	defer func() { _ = file.Close() }()
+
+	if fileType, err := windows.GetFileType(handle); err != nil || fileType != windows.FILE_TYPE_DISK {
+		return nil, fmt.Errorf("credential path %q is not a disk file", path)
+	}
+	info := new(windows.ByHandleFileInformation)
+	if err := windows.GetFileInformationByHandle(handle, info); err != nil {
+		return nil, fmt.Errorf("inspect credential file %q: %w", path, err)
+	}
+	if info.FileAttributes&(windows.FILE_ATTRIBUTE_DIRECTORY|windows.FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
+		return nil, fmt.Errorf("credential path %q is not a regular file", path)
+	}
+	size := uint64(info.FileSizeHigh)<<32 | uint64(info.FileSizeLow)
+	if size != bootstrapTokenHexLength+1 {
+		return nil, fmt.Errorf("credential file %q has an invalid size", path)
+	}
+	if err := verifyBootstrapCredentialACL(handle, path); err != nil {
+		return nil, err
+	}
+
+	data, err := io.ReadAll(io.LimitReader(file, bootstrapTokenHexLength+2))
+	if err != nil {
+		return nil, fmt.Errorf("read credential file %q: %w", path, err)
+	}
+	if len(data) != bootstrapTokenHexLength+1 {
+		return nil, fmt.Errorf("credential file %q has an invalid size", path)
+	}
+	return data, nil
+}
+
+func verifyBootstrapCredentialACL(handle windows.Handle, path string) error {
+	descriptor, err := windows.GetSecurityInfo(
+		handle,
+		windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		return fmt.Errorf("inspect credential ACL %q: %w", path, err)
+	}
+	control, _, err := descriptor.Control()
+	if err != nil {
+		return fmt.Errorf("inspect credential ACL %q: %w", path, err)
+	}
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		return fmt.Errorf("credential file %q ACL inherits permissions", path)
+	}
+	owner, _, err := descriptor.Owner()
+	if err != nil || owner == nil {
+		return fmt.Errorf("inspect credential owner %q: %w", path, err)
+	}
+	processSID, err := currentProcessSID()
+	if err != nil {
+		return err
+	}
+	if !owner.Equals(processSID) {
+		return fmt.Errorf("credential file %q is not owned by the server process user", path)
+	}
+	dacl, _, err := descriptor.DACL()
+	if err != nil || dacl == nil || dacl.AceCount != 1 {
+		return fmt.Errorf("credential file %q does not have an owner-only ACL", path)
+	}
+	var ace *windows.ACCESS_ALLOWED_ACE
+	if err := windows.GetAce(dacl, 0, &ace); err != nil {
+		return fmt.Errorf("inspect credential ACL %q: %w", path, err)
+	}
+	if ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE || ace.Header.AceFlags&(windows.INHERITED_ACE|windows.INHERIT_ONLY_ACE) != 0 {
+		return fmt.Errorf("credential file %q ACL contains an unsupported entry", path)
+	}
+	sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+	if !sid.Equals(owner) || ace.Mask != bootstrapFileFullControl {
+		return fmt.Errorf("credential file %q ACL does not grant only its owner full access", path)
+	}
+	return nil
+}

--- a/pkg/server/bootstrap_file_windows_test.go
+++ b/pkg/server/bootstrap_file_windows_test.go
@@ -1,0 +1,81 @@
+//go:build windows
+
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NicolasHaas/gospeak/pkg/crypto"
+	"golang.org/x/sys/windows"
+)
+
+func TestReadBootstrapCredentialRejectsPermissiveWindowsACL(t *testing.T) {
+	rawToken, err := crypto.GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken() error = %v", err)
+	}
+	path, err := prepareBootstrapCredentialFile(filepath.Join(t.TempDir(), bootstrapAdminCredentialName), []byte(rawToken+"\n"))
+	if err != nil {
+		t.Fatalf("prepareBootstrapCredentialFile() error = %v", err)
+	}
+	defer func() { _ = os.Remove(path) }()
+	if got, err := readBootstrapCredential(path); err != nil || got != rawToken {
+		t.Fatalf("untouched Windows credential round trip = %q, %v", got, err)
+	}
+
+	handle, err := openBootstrapCredentialHandle(path, windows.READ_CONTROL|windows.WRITE_DAC)
+	if err != nil {
+		t.Fatalf("open credential handle: %v", err)
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+	owner, err := currentProcessSID()
+	if err != nil {
+		t.Fatalf("currentProcessSID() error = %v", err)
+	}
+	everyone, err := windows.CreateWellKnownSid(windows.WinWorldSid)
+	if err != nil {
+		t.Fatalf("CreateWellKnownSid() error = %v", err)
+	}
+	entries := []windows.EXPLICIT_ACCESS{
+		{
+			AccessPermissions: bootstrapFileFullControl,
+			AccessMode:        windows.SET_ACCESS,
+			Inheritance:       windows.NO_INHERITANCE,
+			Trustee: windows.TRUSTEE{
+				TrusteeForm:  windows.TRUSTEE_IS_SID,
+				TrusteeType:  windows.TRUSTEE_IS_USER,
+				TrusteeValue: windows.TrusteeValueFromSID(owner),
+			},
+		},
+		{
+			AccessPermissions: windows.GENERIC_READ,
+			AccessMode:        windows.SET_ACCESS,
+			Inheritance:       windows.NO_INHERITANCE,
+			Trustee: windows.TRUSTEE{
+				TrusteeForm:  windows.TRUSTEE_IS_SID,
+				TrusteeType:  windows.TRUSTEE_IS_WELL_KNOWN_GROUP,
+				TrusteeValue: windows.TrusteeValueFromSID(everyone),
+			},
+		},
+	}
+	acl, err := windows.ACLFromEntries(entries, nil)
+	if err != nil {
+		t.Fatalf("ACLFromEntries() error = %v", err)
+	}
+	if err := windows.SetSecurityInfo(
+		handle,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		acl,
+		nil,
+	); err != nil {
+		t.Fatalf("SetSecurityInfo() error = %v", err)
+	}
+	if _, err := readBootstrapCredential(path); err == nil {
+		t.Fatal("readBootstrapCredential() accepted an Everyone-readable ACL")
+	}
+}

--- a/pkg/server/bootstrap_test.go
+++ b/pkg/server/bootstrap_test.go
@@ -1,0 +1,559 @@
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/NicolasHaas/gospeak/pkg/crypto"
+	"github.com/NicolasHaas/gospeak/pkg/datastore"
+	"github.com/NicolasHaas/gospeak/pkg/model"
+	"github.com/NicolasHaas/gospeak/pkg/protocol"
+	pb "github.com/NicolasHaas/gospeak/pkg/protocol/pb"
+)
+
+func newBootstrapTestServer(t *testing.T) (*Server, datastore.DataProviderFactory, string) {
+	t.Helper()
+	dataDir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.DataDir = dataDir
+	cfg.DBPath = filepath.Join(dataDir, "gospeak.db")
+	st, err := datastore.NewProviderFactory(cfg.DBPath)
+	if err != nil {
+		t.Fatalf("NewProviderFactory() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := st.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+	return New(cfg, Dependencies{Store: st}), st, filepath.Join(dataDir, "bootstrap-admin.token")
+}
+
+func readBootstrapToken(t *testing.T, path string) string {
+	t.Helper()
+	credential, err := os.ReadFile(path) //nolint:gosec // path is inside t.TempDir
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	return strings.TrimSpace(string(credential))
+}
+
+func authenticateBootstrap(t *testing.T, srv *Server, st datastore.DataProviderFactory, username, token string) (*pb.AuthResponse, error) {
+	t.Helper()
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		srv.handleControlConn(newControlHandler(srv, st), serverConn, st)
+		close(done)
+	}()
+	if err := protocol.WriteControlMessage(clientConn, &pb.ControlMessage{
+		AuthRequest: &pb.AuthRequest{Username: username, Token: token},
+	}); err != nil {
+		_ = clientConn.Close()
+		t.Fatalf("WriteControlMessage() error = %v", err)
+	}
+	response, err := protocol.ReadControlMessage(clientConn)
+	_ = clientConn.Close()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("control handler did not return")
+	}
+	if err != nil {
+		return nil, err
+	}
+	if response.ErrorResponse != nil {
+		return nil, fmt.Errorf("auth failed: %s", response.ErrorResponse.Message)
+	}
+	if response.AuthResponse == nil {
+		return nil, fmt.Errorf("response = %#v, want AuthResponse", response)
+	}
+	return response.AuthResponse, nil
+}
+
+func TestEnsureAdminTokenWritesRetryableCredentialWithoutLoggingSecret(t *testing.T) {
+	srv, st, credentialPath := newBootstrapTestServer(t)
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	if err := srv.ensureAdminToken(st); err != nil {
+		t.Fatalf("ensureAdminToken() error = %v", err)
+	}
+	rawToken := readBootstrapToken(t, credentialPath)
+	if rawToken == "" {
+		t.Fatal("bootstrap credential is empty")
+	}
+	if _, err := readBootstrapCredential(credentialPath); err != nil {
+		t.Fatalf("read protected bootstrap credential: %v", err)
+	}
+	if strings.Contains(logs.String(), rawToken) {
+		t.Fatalf("normal logs contain bootstrap credential: %q", logs.String())
+	}
+	if !strings.Contains(logs.String(), credentialPath) {
+		t.Fatalf("normal logs do not identify bootstrap credential path: %q", logs.String())
+	}
+}
+
+func TestBootstrapProvisioningRetriesAfterAuthResponseWriteFailure(t *testing.T) {
+	srv, st, credentialPath := newBootstrapTestServer(t)
+	if err := srv.ensureAdminToken(st); err != nil {
+		t.Fatalf("ensureAdminToken() error = %v", err)
+	}
+	rawToken := readBootstrapToken(t, credentialPath)
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		srv.handleControlConn(newControlHandler(srv, st), serverConn, st)
+		close(done)
+	}()
+	if err := protocol.WriteControlMessage(clientConn, &pb.ControlMessage{
+		AuthRequest: &pb.AuthRequest{Username: "bootstrap-admin", Token: rawToken},
+	}); err != nil {
+		t.Fatalf("WriteControlMessage() error = %v", err)
+	}
+	if err := clientConn.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("control handler did not return after failed AuthResponse write")
+	}
+
+	firstRetry, err := authenticateBootstrap(t, srv, st, "bootstrap-admin", rawToken)
+	if err != nil {
+		t.Fatalf("first retry error = %v", err)
+	}
+	if firstRetry.Role != "admin" || firstRetry.AutoToken == "" {
+		t.Fatalf("first retry = %#v, want admin with personal token", firstRetry)
+	}
+	secondRetry, err := authenticateBootstrap(t, srv, st, "bootstrap-admin", rawToken)
+	if err != nil {
+		t.Fatalf("second retry error = %v", err)
+	}
+	if secondRetry.AutoToken != firstRetry.AutoToken {
+		t.Fatal("bootstrap retry rotated the personal token")
+	}
+	if _, err := authenticateBootstrap(t, srv, st, "other-admin", rawToken); err == nil {
+		t.Fatal("bootstrap credential provisioned a second admin")
+	}
+	users, err := st.NonTx().ListUsers()
+	if err != nil {
+		t.Fatalf("ListUsers() error = %v", err)
+	}
+	if len(users) != 1 || users[0].Username != "bootstrap-admin" {
+		t.Fatalf("users = %#v, want one bootstrap admin", users)
+	}
+}
+
+func TestEnsureAdminTokenRetiresStaleCredentialForExistingStore(t *testing.T) {
+	srv, st, credentialPath := newBootstrapTestServer(t)
+	if err := st.NonTx().CreateToken(crypto.HashToken("existing-invite"), model.RoleUser, 0, 1, 1, time.Time{}); err != nil {
+		t.Fatalf("CreateToken() error = %v", err)
+	}
+	rawToken, err := crypto.GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken() error = %v", err)
+	}
+	if err := os.WriteFile(credentialPath, []byte(rawToken+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := srv.ensureAdminToken(st); err != nil {
+		t.Fatalf("ensureAdminToken() error = %v", err)
+	}
+	if _, err := os.Stat(credentialPath); !os.IsNotExist(err) {
+		t.Fatalf("stale credential error = %v, want not exist", err)
+	}
+}
+
+func TestEnsureAdminTokenRecoversPublishedCredential(t *testing.T) {
+	srv, st, credentialPath := newBootstrapTestServer(t)
+	rawToken, err := crypto.GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken() error = %v", err)
+	}
+	if err := os.WriteFile(credentialPath, []byte(rawToken+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if err := srv.ensureAdminToken(st); err != nil {
+		t.Fatalf("ensureAdminToken() error = %v", err)
+	}
+	got, err := os.ReadFile(credentialPath) //nolint:gosec // path is inside t.TempDir
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != rawToken+"\n" {
+		t.Fatalf("credential was rotated during recovery")
+	}
+	if _, err := authenticateBootstrap(t, srv, st, "recovered-admin", rawToken); err != nil {
+		t.Fatalf("recovered bootstrap authentication error = %v", err)
+	}
+}
+
+func TestEnsureAdminTokenRejectsUnsafePublishedCredential(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission fixture")
+	}
+	srv, st, credentialPath := newBootstrapTestServer(t)
+	rawToken, err := crypto.GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken() error = %v", err)
+	}
+	if err := os.WriteFile(credentialPath, []byte(rawToken+"\n"), 0o644); err != nil { //nolint:gosec // insecure mode is the regression fixture
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if err := srv.ensureAdminToken(st); err == nil {
+		t.Fatal("ensureAdminToken() accepted a group/world-readable credential")
+	}
+	hasTokens, err := st.NonTx().HasTokens()
+	if err != nil {
+		t.Fatalf("HasTokens() error = %v", err)
+	}
+	if hasTokens {
+		t.Fatal("unsafe bootstrap credential was installed in the datastore")
+	}
+}
+
+func TestEnsureAdminTokenRejectsCredentialMadeUnsafeAfterInitialization(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission fixture")
+	}
+	srv, st, credentialPath := newBootstrapTestServer(t)
+	if err := srv.ensureAdminToken(st); err != nil {
+		t.Fatalf("first ensureAdminToken() error = %v", err)
+	}
+	if err := os.Chmod(credentialPath, 0o644); err != nil { //nolint:gosec // insecure mode is the regression fixture
+		t.Fatalf("Chmod() error = %v", err)
+	}
+	if err := srv.ensureAdminToken(st); err == nil {
+		t.Fatal("ensureAdminToken() accepted a credential made group/world-readable after initialization")
+	}
+}
+
+func TestEnsureAdminTokenRejectsCredentialWithSpecialModeBits(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission fixture")
+	}
+	srv, st, credentialPath := newBootstrapTestServer(t)
+	if err := srv.ensureAdminToken(st); err != nil {
+		t.Fatalf("first ensureAdminToken() error = %v", err)
+	}
+	if err := os.Chmod(credentialPath, 0o600|os.ModeSticky); err != nil { //nolint:gosec // special mode is the regression fixture
+		t.Fatalf("Chmod() error = %v", err)
+	}
+	if err := srv.ensureAdminToken(st); err == nil {
+		t.Fatal("ensureAdminToken() accepted a credential with a sticky bit")
+	}
+}
+
+func TestEnsureAdminTokenRejectsCredentialSymlink(t *testing.T) {
+	srv, st, credentialPath := newBootstrapTestServer(t)
+	rawToken, err := crypto.GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken() error = %v", err)
+	}
+	target := filepath.Join(filepath.Dir(credentialPath), "redirected-token")
+	if err := os.WriteFile(target, []byte(rawToken+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := os.Symlink(target, credentialPath); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("symlink creation is unavailable: %v", err)
+		}
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	if err := srv.ensureAdminToken(st); err == nil {
+		t.Fatal("ensureAdminToken() accepted a credential symlink")
+	}
+}
+
+func TestBootstrapProvisioningRollsBackPersonalTokenStoreFailure(t *testing.T) {
+	srv, st, credentialPath := newBootstrapTestServer(t)
+	if err := srv.ensureAdminToken(st); err != nil {
+		t.Fatalf("ensureAdminToken() error = %v", err)
+	}
+	rawToken := readBootstrapToken(t, credentialPath)
+	provider := st.(*datastore.ProviderFactory)
+	if _, err := provider.DB.Exec(`CREATE TRIGGER fail_bootstrap_personal_token
+		BEFORE UPDATE OF personal_token_hash ON users
+		BEGIN SELECT RAISE(ABORT, 'forced personal token failure'); END`); err != nil {
+		t.Fatalf("create failure trigger: %v", err)
+	}
+	if _, err := authenticateBootstrap(t, srv, st, "bootstrap-admin", rawToken); err == nil {
+		t.Fatal("bootstrap authentication unexpectedly succeeded while token storage failed")
+	}
+	users, err := st.NonTx().ListUsers()
+	if err != nil {
+		t.Fatalf("ListUsers() error = %v", err)
+	}
+	if len(users) != 0 {
+		t.Fatalf("users after rolled-back provisioning = %d, want 0", len(users))
+	}
+	if _, err := provider.DB.Exec(`DROP TRIGGER fail_bootstrap_personal_token`); err != nil {
+		t.Fatalf("drop failure trigger: %v", err)
+	}
+	if _, err := authenticateBootstrap(t, srv, st, "bootstrap-admin", rawToken); err != nil {
+		t.Fatalf("bootstrap retry error = %v", err)
+	}
+}
+
+func TestBootstrapProvisioningRetriesAfterSessionFailure(t *testing.T) {
+	srv, st, credentialPath := newBootstrapTestServer(t)
+	if err := srv.ensureAdminToken(st); err != nil {
+		t.Fatalf("ensureAdminToken() error = %v", err)
+	}
+	rawToken := readBootstrapToken(t, credentialPath)
+	srv.sessions.issuedSessionIDs = usableSessionIDs
+	if _, err := authenticateBootstrap(t, srv, st, "bootstrap-admin", rawToken); err == nil {
+		t.Fatal("bootstrap authentication unexpectedly succeeded with exhausted sessions")
+	}
+	srv.sessions.issuedSessionIDs = 0
+	response, err := authenticateBootstrap(t, srv, st, "bootstrap-admin", rawToken)
+	if err != nil {
+		t.Fatalf("bootstrap retry error = %v", err)
+	}
+	if response.AutoToken == "" {
+		t.Fatal("bootstrap retry returned an empty personal token")
+	}
+}
+
+func TestBootstrapTokenFinalizesAfterPersonalAuthentication(t *testing.T) {
+	srv, st, credentialPath := newBootstrapTestServer(t)
+	if err := srv.ensureAdminToken(st); err != nil {
+		t.Fatalf("ensureAdminToken() error = %v", err)
+	}
+	rawToken := readBootstrapToken(t, credentialPath)
+	response, err := authenticateBootstrap(t, srv, st, "bootstrap-admin", rawToken)
+	if err != nil {
+		t.Fatalf("bootstrap authentication error = %v", err)
+	}
+	if _, err := authenticateBootstrap(t, srv, st, "bootstrap-admin", response.AutoToken); err != nil {
+		t.Fatalf("personal authentication error = %v", err)
+	}
+	if _, err := os.Stat(credentialPath); !os.IsNotExist(err) {
+		t.Fatalf("credential file after finalization error = %v, want not exist", err)
+	}
+	if _, err := authenticateBootstrap(t, srv, st, "bootstrap-admin", rawToken); err == nil {
+		t.Fatal("finalized bootstrap credential was accepted")
+	}
+	if _, err := authenticateBootstrap(t, srv, st, "bootstrap-admin", response.AutoToken); err != nil {
+		t.Fatalf("repeated personal authentication error = %v", err)
+	}
+}
+
+func TestBootstrapCredentialRemovalRetriesAfterFinalization(t *testing.T) {
+	srv, st, credentialPath := newBootstrapTestServer(t)
+	if err := srv.ensureAdminToken(st); err != nil {
+		t.Fatalf("ensureAdminToken() error = %v", err)
+	}
+	rawToken := readBootstrapToken(t, credentialPath)
+	response, err := authenticateBootstrap(t, srv, st, "bootstrap-admin", rawToken)
+	if err != nil {
+		t.Fatalf("bootstrap authentication error = %v", err)
+	}
+	if err := os.Remove(credentialPath); err != nil {
+		t.Fatalf("remove credential fixture: %v", err)
+	}
+	if err := os.Mkdir(credentialPath, 0o700); err != nil {
+		t.Fatalf("create removal blocker: %v", err)
+	}
+	blocker := filepath.Join(credentialPath, "blocker")
+	if err := os.WriteFile(blocker, []byte("block"), 0o600); err != nil {
+		t.Fatalf("write removal blocker: %v", err)
+	}
+	if _, err := authenticateBootstrap(t, srv, st, "bootstrap-admin", response.AutoToken); err != nil {
+		t.Fatalf("first personal authentication error = %v", err)
+	}
+	if err := os.Remove(blocker); err != nil {
+		t.Fatalf("remove blocker file: %v", err)
+	}
+	if err := os.Remove(credentialPath); err != nil {
+		t.Fatalf("remove blocker directory: %v", err)
+	}
+	if err := os.WriteFile(credentialPath, []byte(rawToken+"\n"), 0o600); err != nil {
+		t.Fatalf("restore stale credential fixture: %v", err)
+	}
+	restarted := New(srv.cfg, Dependencies{Store: st})
+	if err := restarted.ensureAdminToken(st); err != nil {
+		t.Fatalf("restart ensureAdminToken() error = %v", err)
+	}
+	if _, err := os.Stat(credentialPath); !os.IsNotExist(err) {
+		t.Fatalf("credential after restart removal retry error = %v, want not exist", err)
+	}
+}
+
+func TestConcurrentBootstrapProvisioningCreatesOneAdmin(t *testing.T) {
+	for _, usernames := range [][]string{{"same-admin", "same-admin"}, {"admin-one", "admin-two"}} {
+		t.Run(strings.Join(usernames, "-"), func(t *testing.T) {
+			srv, st, credentialPath := newBootstrapTestServer(t)
+			if err := srv.ensureAdminToken(st); err != nil {
+				t.Fatalf("ensureAdminToken() error = %v", err)
+			}
+			rawToken := readBootstrapToken(t, credentialPath)
+			start := make(chan struct{})
+			type result struct {
+				response *pb.AuthResponse
+				err      error
+			}
+			results := make(chan result, len(usernames))
+			var wg sync.WaitGroup
+			for _, username := range usernames {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					<-start
+					response, err := authenticateBootstrap(t, srv, st, username, rawToken)
+					results <- result{response: response, err: err}
+				}()
+			}
+			close(start)
+			wg.Wait()
+			close(results)
+			successes := 0
+			var returnedToken string
+			for result := range results {
+				if result.err != nil {
+					continue
+				}
+				successes++
+				if returnedToken != "" && returnedToken != result.response.AutoToken {
+					t.Fatal("same bootstrap identity returned different personal tokens")
+				}
+				returnedToken = result.response.AutoToken
+			}
+			wantSuccesses := 2
+			if usernames[0] != usernames[1] {
+				wantSuccesses = 1
+			}
+			if successes != wantSuccesses {
+				t.Fatalf("successful authentications = %d, want %d", successes, wantSuccesses)
+			}
+			users, err := st.NonTx().ListUsers()
+			if err != nil {
+				t.Fatalf("ListUsers() error = %v", err)
+			}
+			if len(users) != 1 {
+				t.Fatalf("users = %d, want 1", len(users))
+			}
+		})
+	}
+}
+
+func TestBootstrapProvisioningRetrySurvivesRestart(t *testing.T) {
+	srv, st, credentialPath := newBootstrapTestServer(t)
+	if err := srv.ensureAdminToken(st); err != nil {
+		t.Fatalf("ensureAdminToken() error = %v", err)
+	}
+	rawToken := readBootstrapToken(t, credentialPath)
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		srv.handleControlConn(newControlHandler(srv, st), serverConn, st)
+		close(done)
+	}()
+	if err := protocol.WriteControlMessage(clientConn, &pb.ControlMessage{
+		AuthRequest: &pb.AuthRequest{Username: "bootstrap-admin", Token: rawToken},
+	}); err != nil {
+		t.Fatalf("WriteControlMessage() error = %v", err)
+	}
+	_ = clientConn.Close()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("control handler did not return")
+	}
+	if err := st.(*datastore.ProviderFactory).Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	reopened, err := datastore.NewProviderFactory(srv.cfg.DBPath)
+	if err != nil {
+		t.Fatalf("NewProviderFactory() after restart error = %v", err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	restarted := New(srv.cfg, Dependencies{Store: reopened})
+	response, err := authenticateBootstrap(t, restarted, reopened, "bootstrap-admin", rawToken)
+	if err != nil {
+		t.Fatalf("bootstrap retry after restart error = %v", err)
+	}
+	if response.AutoToken != deriveBootstrapPersonalToken(rawToken, "bootstrap-admin") {
+		t.Fatal("bootstrap retry after restart returned a different personal token")
+	}
+}
+
+func TestOrdinarySingleUseInviteRemainsConsumedAfterResponseFailure(t *testing.T) {
+	srv, st, _ := newBootstrapTestServer(t)
+	creator, err := st.NonTx().CreateUser("token-creator", model.RoleAdmin)
+	if err != nil {
+		t.Fatalf("CreateUser() error = %v", err)
+	}
+	rawToken, err := crypto.GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken() error = %v", err)
+	}
+	if err := st.NonTx().CreateToken(crypto.HashToken(rawToken), model.RoleUser, 0, creator.ID, 1, st.NonTx().ZeroTime()); err != nil {
+		t.Fatalf("CreateToken() error = %v", err)
+	}
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		srv.handleControlConn(newControlHandler(srv, st), serverConn, st)
+		close(done)
+	}()
+	if err := protocol.WriteControlMessage(clientConn, &pb.ControlMessage{
+		AuthRequest: &pb.AuthRequest{Username: "first-invite-user", Token: rawToken},
+	}); err != nil {
+		t.Fatalf("WriteControlMessage() error = %v", err)
+	}
+	_ = clientConn.Close()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("control handler did not return")
+	}
+	if _, err := authenticateBootstrap(t, srv, st, "second-invite-user", rawToken); err == nil {
+		t.Fatal("ordinary single-use invite was reusable after response failure")
+	}
+}
+
+func TestHandleCreateTokenRejectsNegativeMaxUses(t *testing.T) {
+	srv, st, _ := newBootstrapTestServer(t)
+	admin, err := st.NonTx().CreateUser("admin", model.RoleAdmin)
+	if err != nil {
+		t.Fatalf("CreateUser() error = %v", err)
+	}
+	session, err := srv.sessions.Create(admin.ID, admin.Username, admin.Role)
+	if err != nil {
+		t.Fatalf("Create() session error = %v", err)
+	}
+	responseConn := &bufferConn{}
+	srv.handleCreateToken(session.ID, &pb.CreateTokenRequest{Role: model.RoleAdmin.String(), MaxUses: -1}, st, responseConn)
+	response, err := protocol.ReadControlMessage(responseConn)
+	if err != nil {
+		t.Fatalf("ReadControlMessage() error = %v", err)
+	}
+	if response.ErrorResponse == nil || response.ErrorResponse.Code != 31 {
+		t.Fatalf("response = %#v, want max-uses error", response)
+	}
+	hasTokens, err := st.NonTx().HasTokens()
+	if err != nil {
+		t.Fatalf("HasTokens() error = %v", err)
+	}
+	if hasTokens {
+		t.Fatal("negative max-uses request created a token")
+	}
+}

--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -491,9 +491,17 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 			return
 		}
 	}
+	if user != nil {
+		if err := s.finalizeBootstrapCredential(st, user.ID); err != nil {
+			slog.Error("finalize bootstrap credential", "err", err)
+			sendError(conn, 3, "internal error")
+			return
+		}
+	}
 
 	var tokenRole model.Role
 	var channelScope int64
+	bootstrapProvisioned := false
 	if user != nil {
 		sessionRole = user.Role
 		channelScope = user.ChannelScope
@@ -503,7 +511,7 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 			return
 		}
 
-		// New user: role comes from the token
+		// New user: role comes from the token.
 		if authReq.Token == "" {
 			if !s.cfg.AllowNoToken {
 				s.metrics.FailedAuths.Add(1)
@@ -512,64 +520,83 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 			}
 			tokenRole = model.RoleUser
 		} else {
-			ctx := context.Background()
-			tx, err := st.Tx(ctx)
-			if err != nil {
-				slog.Error("transaction error", "err", err)
-				sendError(conn, 3, "could not establish transaction")
-				return
-			}
-
-			committed := false
-			defer func() {
-				if !committed {
-					if err := tx.Rollback(); err != nil {
-						slog.Warn("tx rollback failed", "err", err)
-					}
-				}
-			}()
-
-			tokenAuth, validateErr := tx.ValidateToken(tokenHash)
-			err = validateErr
-			if err != nil {
+			bootstrapUser, bootstrapToken, isBootstrap, bootstrapErr := s.tryProvisionBootstrapUser(st, tokenHash, authReq.Token, authReq.Username)
+			if bootstrapErr != nil {
 				s.metrics.FailedAuths.Add(1)
-				slog.Warn("auth failed", "err", err)
+				slog.Warn("bootstrap provisioning failed", "err", bootstrapErr)
 				sendError(conn, 2, "authentication failed")
 				return
 			}
-			tokenRole = tokenAuth.Role
-			channelScope = tokenAuth.ChannelScope
-			if err := tx.Commit(); err != nil {
-				slog.Error("commit transaction", "err", err)
-				sendError(conn, 3, "database error")
-				return
+			if isBootstrap {
+				user = bootstrapUser
+				autoToken = bootstrapToken
+				tokenRole = user.Role
+				channelScope = user.ChannelScope
+				bootstrapProvisioned = true
+			} else {
+				ctx := context.Background()
+				tx, err := st.Tx(ctx)
+				if err != nil {
+					slog.Error("transaction error", "err", err)
+					sendError(conn, 3, "could not establish transaction")
+					return
+				}
+
+				committed := false
+				defer func() {
+					if !committed {
+						if err := tx.Rollback(); err != nil {
+							slog.Warn("tx rollback failed", "err", err)
+						}
+					}
+				}()
+
+				tokenAuth, validateErr := tx.ValidateToken(tokenHash)
+				err = validateErr
+				if err != nil {
+					s.metrics.FailedAuths.Add(1)
+					slog.Warn("auth failed", "err", err)
+					sendError(conn, 2, "authentication failed")
+					return
+				}
+				tokenRole = tokenAuth.Role
+				channelScope = tokenAuth.ChannelScope
+				if err := tx.Commit(); err != nil {
+					slog.Error("commit transaction", "err", err)
+					sendError(conn, 3, "database error")
+					return
+				}
+				committed = true
 			}
-			committed = true
 		}
 
-		user, err = st.NonTx().CreateUserWithChannelScope(authReq.Username, tokenRole, channelScope)
-		if err != nil {
-			if errors.Is(err, datastore.ErrUsernameTaken) {
-				s.metrics.FailedAuths.Add(1)
-				sendError(conn, 2, "authentication failed: personal token required")
+		if !bootstrapProvisioned {
+			user, err = st.NonTx().CreateUserWithChannelScope(authReq.Username, tokenRole, channelScope)
+			if err != nil {
+				if errors.Is(err, datastore.ErrUsernameTaken) {
+					s.metrics.FailedAuths.Add(1)
+					sendError(conn, 2, "authentication failed: personal token required")
+					return
+				}
+				slog.Error("create user", "err", err)
+				sendError(conn, 3, "could not create user")
 				return
 			}
-			slog.Error("create user", "err", err)
-			sendError(conn, 3, "could not create user")
-			return
-		}
-		sessionRole = tokenRole
+			sessionRole = tokenRole
 
-		rawToken, err := crypto.GenerateToken()
-		if err != nil {
-			sendError(conn, 3, "failed to generate personal token")
-			return
+			rawToken, err := crypto.GenerateToken()
+			if err != nil {
+				sendError(conn, 3, "failed to generate personal token")
+				return
+			}
+			if err := st.NonTx().UpdateUserPersonalToken(user.ID, crypto.HashToken(rawToken), time.Now().UTC()); err != nil {
+				sendError(conn, 3, "failed to store personal token")
+				return
+			}
+			autoToken = rawToken
+		} else {
+			sessionRole = user.Role
 		}
-		if err := st.NonTx().UpdateUserPersonalToken(user.ID, crypto.HashToken(rawToken), time.Now().UTC()); err != nil {
-			sendError(conn, 3, "failed to store personal token")
-			return
-		}
-		autoToken = rawToken
 	}
 
 	// Check ban
@@ -987,6 +1014,10 @@ func (s *Server) handleCreateToken(sessionID uint32, req *pb.CreateTokenRequest,
 	}
 	if errMsg := rbac.RequirePermission(session.Role, rbac.PermManageTokens); errMsg != "" {
 		sendError(conn, 30, errMsg)
+		return
+	}
+	if req.MaxUses < 0 {
+		sendError(conn, 31, "max uses must not be negative")
 		return
 	}
 

--- a/pkg/server/run.go
+++ b/pkg/server/run.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	"github.com/NicolasHaas/gospeak/pkg/crypto"
-	"github.com/NicolasHaas/gospeak/pkg/datastore"
-	"github.com/NicolasHaas/gospeak/pkg/model"
 )
 
 const metricsShutdownTimeout = 5 * time.Second
@@ -150,30 +148,4 @@ func (s *Server) Shutdown() {
 		s.closeScreenConns()
 		s.workers.Wait()
 	})
-}
-
-// ensureAdminToken creates an admin token only on first run (no tokens exist).
-func (s *Server) ensureAdminToken(st datastore.DataProviderFactory) error {
-	hasTokens, err := st.NonTx().HasTokens()
-	if err != nil {
-		return fmt.Errorf("server: check tokens: %w", err)
-	}
-	if hasTokens {
-		return nil // tokens already exist, don't generate more
-	}
-
-	rawToken, err := crypto.GenerateToken()
-	if err != nil {
-		return fmt.Errorf("server: generate admin token: %w", err)
-	}
-
-	hash := crypto.HashToken(rawToken)
-	if err := st.NonTx().CreateToken(hash, model.RoleAdmin, 0, 0, 0 /* unlimited uses, no expiry */, st.NonTx().ZeroTime()); err != nil {
-		return fmt.Errorf("server: store admin token: %w", err)
-	}
-
-	slog.Info("========================================")
-	slog.Info("ADMIN TOKEN (save this!):", "token", rawToken)
-	slog.Info("========================================")
-	return nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -80,6 +80,7 @@ type Server struct {
 	screenConns     map[uint32]*screenClientConn
 	voiceKey        []byte // shared AES-128 key for all voice encryption
 	authLimiter     *authRateLimiter
+	bootstrapMu     sync.Mutex
 	preAuthMu       sync.Mutex
 	acceptedConns   map[net.Conn]trackedConn
 	preAuthCount    map[preAuthPlane]int


### PR DESCRIPTION
## Summary

- replace the logged first-admin token with a private, persistent bootstrap credential file
- provision the first administrator transactionally and recover the same personal token after interrupted authentication, response delivery, or process restarts
- bind bootstrap state to exactly one administrator while keeping ordinary invitation tokens single-use
- isolate internal bootstrap records with an explicit datastore marker and reject negative max_uses values from normal token creation
- retire finalized or stale bootstrap credential files during authentication and subsequent server startups
- read credentials through opened descriptors or handles with bounded size and metadata validation
- reject POSIX symlinks, wrong ownership, non-regular files, and modes other than exact 0600
- reject Windows reparse points and require a protected owner-only full-control DACL
- persist the credential through the documented deployment volume and update the bootstrap workflow documentation
