### PR TITLE
fix: reject replayed media packets

### DIFF
--- a/pkg/client/engine.go
+++ b/pkg/client/engine.go
@@ -224,8 +224,7 @@ type Engine struct {
 	screenShareAttempt  uint64
 	screenCipher        *gospeakCrypto.VoiceCipher
 	screenKey           []byte
-	screenKeyID         [16]byte
-	screenKeySequences  map[[16]byte]uint32
+	screenReceiveSeq    uint32
 	screenSeqNum        uint32
 	activeScreenShare   *pb.ScreenShareEvent
 	screenShareEnabled  bool
@@ -818,6 +817,9 @@ func (e *Engine) playbackLoop(g *connectionGeneration) {
 // processIncomingVoice decrypts and queues a received voice packet. Decoding
 // and playback happen independently on the fixed playout clock.
 func (e *Engine) processIncomingVoice(g *connectionGeneration, pkt *protocol.VoicePacket) {
+	if pkt == nil {
+		return
+	}
 	g.mu.Lock()
 	cipher := g.cipher
 	g.mu.Unlock()
@@ -825,7 +827,16 @@ func (e *Engine) processIncomingVoice(g *connectionGeneration, pkt *protocol.Voi
 		return
 	}
 
-	// Get or create decoder for this speaker
+	// Authenticate before allocating per-speaker state so forged session IDs
+	// cannot create decoders or keep them alive.
+	header := pkt.MarshalHeader()
+	opusData, err := cipher.Decrypt(pkt.SessionID, pkt.SeqNum, header, pkt.Payload)
+	if err != nil {
+		slog.Debug("voice decrypt failed", "session", pkt.SessionID, "err", err)
+		return
+	}
+
+	// Get or create decoder for this authenticated speaker.
 	e.decoderMu.Lock()
 	_, ok := e.decoders[pkt.SessionID]
 	if !ok {
@@ -841,14 +852,6 @@ func (e *Engine) processIncomingVoice(g *connectionGeneration, pkt *protocol.Voi
 	jb := e.jitterBufs[pkt.SessionID]
 	e.speakerLastSeen[pkt.SessionID] = e.now()
 	e.decoderMu.Unlock()
-
-	// Decrypt the voice data
-	header := pkt.MarshalHeader()
-	opusData, err := cipher.Decrypt(pkt.SessionID, pkt.SeqNum, header, pkt.Payload)
-	if err != nil {
-		slog.Debug("voice decrypt failed", "session", pkt.SessionID, "err", err)
-		return
-	}
 
 	// Track received packet for debug logging
 	if e.voiceDebugEnabled {
@@ -1819,8 +1822,7 @@ func (e *Engine) handleDisconnectGeneration(g *connectionGeneration, reason stri
 	e.activeScreenShare = nil
 	e.screenCipher = nil
 	e.screenKey = nil
-	e.screenKeyID = [16]byte{}
-	e.screenKeySequences = nil
+	e.screenReceiveSeq = 0
 	e.screenSeqNum = 0
 	e.screenMu.Unlock()
 	e.screenSendMu.Unlock()
@@ -1880,8 +1882,7 @@ func (e *Engine) handleScreenShareEvent(g *connectionGeneration, event *pb.Scree
 			e.activeScreenShare = nil
 			e.screenCipher = nil
 			e.screenKey = nil
-			e.screenKeyID = [16]byte{}
-			e.screenSeqNum = 0
+			e.screenReceiveSeq = 0
 		}
 	} else if len(event.EncryptionKey) > 0 {
 		sameKey := previous != nil && previous.SessionID == event.SessionID && bytes.Equal(e.screenKey, event.EncryptionKey)
@@ -1895,9 +1896,7 @@ func (e *Engine) handleScreenShareEvent(g *connectionGeneration, event *pb.Scree
 			}
 			e.screenCipher = cipher
 			e.screenKey = append(e.screenKey[:0], event.EncryptionKey...)
-			e.screenKeyID = [16]byte{}
-			copy(e.screenKeyID[:], event.EncryptionKey)
-			e.screenSeqNum = e.screenKeySequences[e.screenKeyID]
+			e.screenReceiveSeq = 0
 		}
 		e.activeScreenShare = event
 	} else {
@@ -1905,8 +1904,7 @@ func (e *Engine) handleScreenShareEvent(g *connectionGeneration, event *pb.Scree
 		if previous == nil || previous.SessionID != event.SessionID {
 			e.screenCipher = nil
 			e.screenKey = nil
-			e.screenKeyID = [16]byte{}
-			e.screenSeqNum = 0
+			e.screenReceiveSeq = 0
 		}
 	}
 	e.screenMu.Unlock()
@@ -1942,8 +1940,7 @@ func (e *Engine) clearScreenShareStateGenerationLocked(g *connectionGeneration) 
 	e.activeScreenShare = nil
 	e.screenCipher = nil
 	e.screenKey = nil
-	e.screenKeyID = [16]byte{}
-	e.screenSeqNum = 0
+	e.screenReceiveSeq = 0
 	e.screenMu.Unlock()
 	e.screenSendMu.Unlock()
 	if callback := e.OnScreenFrame; callback != nil {
@@ -1965,17 +1962,28 @@ func (e *Engine) handleScreenPacketGeneration(g *connectionGeneration, pkt *prot
 	}
 }
 
-func (e *Engine) handleScreenPacket(g *connectionGeneration, pkt *protocol.ScreenPacket) {
+func (e *Engine) decryptScreenPacket(pkt *protocol.ScreenPacket) ([]byte, bool) {
 	e.screenMu.Lock()
-	cipher := e.screenCipher
+	defer e.screenMu.Unlock()
 	event := e.activeScreenShare
-	e.screenMu.Unlock()
-	if cipher == nil || event == nil || !event.Active || pkt == nil || pkt.SessionID != event.SessionID {
-		return
+	if e.screenCipher == nil || event == nil || !event.Active || pkt == nil || pkt.SeqNum == 0 || pkt.SessionID != event.SessionID {
+		return nil, false
 	}
-	frameData, err := cipher.Decrypt(pkt.SessionID, pkt.SeqNum, pkt.MarshalHeader(), pkt.Payload)
+	if pkt.SeqNum <= e.screenReceiveSeq {
+		return nil, false
+	}
+	frameData, err := e.screenCipher.Decrypt(pkt.SessionID, pkt.SeqNum, pkt.MarshalHeader(), pkt.Payload)
 	if err != nil {
 		slog.Debug("screen frame decrypt error", "err", err)
+		return nil, false
+	}
+	e.screenReceiveSeq = pkt.SeqNum
+	return frameData, true
+}
+
+func (e *Engine) handleScreenPacket(g *connectionGeneration, pkt *protocol.ScreenPacket) {
+	frameData, ok := e.decryptScreenPacket(pkt)
+	if !ok {
 		return
 	}
 	frame, err := protocol.UnmarshalScreenFrame(frameData)
@@ -2091,8 +2099,7 @@ func (e *Engine) handleScreenDisconnectGeneration(g *connectionGeneration) {
 	e.activeScreenShare = nil
 	e.screenCipher = nil
 	e.screenKey = nil
-	e.screenKeyID = [16]byte{}
-	e.screenSeqNum = 0
+	e.screenReceiveSeq = 0
 	e.screenMu.Unlock()
 	e.screenSendMu.Unlock()
 
@@ -2134,10 +2141,6 @@ func (e *Engine) sendScreenShareFrame(ctx context.Context, g *connectionGenerati
 	}
 	e.screenSeqNum++
 	seqNum := e.screenSeqNum
-	if e.screenKeySequences == nil {
-		e.screenKeySequences = make(map[[16]byte]uint32)
-	}
-	e.screenKeySequences[e.screenKeyID] = seqNum
 	e.screenMu.Unlock()
 
 	data, width, height, err := e.prepareScreenShareFrame(ctx, displayIndex)

--- a/pkg/client/engine_screen_sequence_test.go
+++ b/pkg/client/engine_screen_sequence_test.go
@@ -196,6 +196,32 @@ func TestRetiredScreenLoopCannotCancelReplacement(t *testing.T) {
 	}
 }
 
+func TestScreenSequenceResetsOnlyAtConnectionGenerationBoundary(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	g.screen = &ScreenClient{conn: &recordingConn{}}
+	e.generation = g
+	e.state = StateConnected
+	e.screenShareEnabled = true
+	e.screenSeqNum = 42
+
+	e.handleScreenDisconnectGeneration(g)
+	if e.screenSeqNum != 42 {
+		t.Fatalf("screen socket disconnect reset sequence to %d, want 42", e.screenSeqNum)
+	}
+	if e.generation != g {
+		t.Fatal("screen socket disconnect replaced the control generation")
+	}
+
+	e.handleDisconnectGeneration(g, "test generation teardown")
+	if e.screenSeqNum != 0 {
+		t.Fatalf("full generation teardown preserved sequence %d, want 0", e.screenSeqNum)
+	}
+	if e.generation != nil || e.state != StateDisconnected {
+		t.Fatalf("full generation teardown left generation=%p state=%v", e.generation, e.state)
+	}
+}
+
 func TestRetiredScreenKeyResumesSequenceAfterRotation(t *testing.T) {
 	e := NewEngine()
 	g := newConnectionGeneration()
@@ -285,8 +311,61 @@ func TestRepeatedScreenShareKeyDoesNotResetSequence(t *testing.T) {
 	rotated := *event
 	rotated.EncryptionKey = bytes.Repeat([]byte{2}, 16)
 	e.handleScreenShareEvent(g, &rotated)
-	if e.screenSeqNum != 0 {
-		t.Fatalf("screen sequence after key rotation = %d, want 0", e.screenSeqNum)
+	if e.screenSeqNum != 5 {
+		t.Fatalf("screen sequence after key rotation = %d, want 5", e.screenSeqNum)
+	}
+}
+
+func TestDecryptScreenPacketRejectsReplayAndPreservesSameKeyState(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	e.generation = g
+	e.state = StateConnected
+	e.sessionID = 20
+	e.channelID = 1
+	key1 := bytes.Repeat([]byte{1}, 16)
+	key2 := bytes.Repeat([]byte{2}, 16)
+	event := func(key []byte) *pb.ScreenShareEvent {
+		return &pb.ScreenShareEvent{Active: true, SessionID: 10, ChannelID: 1, EncryptionKey: key}
+	}
+	packet := func(key []byte, sequence uint32) *protocol.ScreenPacket {
+		cipher, err := gospeakCrypto.NewVoiceCipher(key)
+		if err != nil {
+			t.Fatalf("NewVoiceCipher: %v", err)
+		}
+		pkt := &protocol.ScreenPacket{SessionID: 10, SeqNum: sequence}
+		pkt.Payload = cipher.Encrypt(pkt.SessionID, pkt.SeqNum, pkt.MarshalHeader(), []byte("frame"))
+		return pkt
+	}
+
+	e.handleScreenShareEvent(g, event(key1))
+	if _, ok := e.decryptScreenPacket(packet(key1, 1)); !ok {
+		t.Fatal("first screen packet was rejected")
+	}
+	if _, ok := e.decryptScreenPacket(packet(key1, 1)); ok {
+		t.Fatal("duplicate screen packet was accepted")
+	}
+
+	forged := packet(key1, 1000)
+	forged.Payload[0] ^= 0xff
+	if _, ok := e.decryptScreenPacket(forged); ok {
+		t.Fatal("forged screen packet was accepted")
+	}
+	if _, ok := e.decryptScreenPacket(packet(key1, 2)); !ok {
+		t.Fatal("forged high sequence poisoned receive state")
+	}
+
+	e.handleScreenShareEvent(g, event(key1))
+	if _, ok := e.decryptScreenPacket(packet(key1, 2)); ok {
+		t.Fatal("same-key reannouncement reset receive sequence")
+	}
+	if _, ok := e.decryptScreenPacket(packet(key1, 3)); !ok {
+		t.Fatal("fresh packet after same-key reannouncement was rejected")
+	}
+
+	e.handleScreenShareEvent(g, event(key2))
+	if _, ok := e.decryptScreenPacket(packet(key2, 1)); !ok {
+		t.Fatal("new key did not start a fresh receive sequence")
 	}
 }
 

--- a/pkg/client/engine_test.go
+++ b/pkg/client/engine_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/NicolasHaas/gospeak/pkg/audio"
+	gospeakCrypto "github.com/NicolasHaas/gospeak/pkg/crypto"
+	"github.com/NicolasHaas/gospeak/pkg/protocol"
 	pb "github.com/NicolasHaas/gospeak/pkg/protocol/pb"
 )
 
@@ -99,6 +101,15 @@ func (d *fixedDecoder) Decode([]byte) ([]int16, error) {
 }
 func (d *fixedDecoder) DecodePLC() ([]int16, error) {
 	return append([]int16(nil), d.frame...), nil
+}
+
+type countingDecoderFactory struct {
+	created int
+}
+
+func (f *countingDecoderFactory) NewDecoder() (audio.AudioDecoder, error) {
+	f.created++
+	return &fixedDecoder{}, nil
 }
 
 var _ audio.Player = (*recordingPlayer)(nil)
@@ -214,6 +225,40 @@ func TestPlayoutMixesConcurrentSpeakersIntoOneFrame(t *testing.T) {
 	}
 	if got, want := player.frames[0][1], int16(-32768); got != want {
 		t.Fatalf("mixed negative sample = %d, want %d", got, want)
+	}
+}
+
+func TestIncomingVoiceAuthenticatesBeforeAllocatingSpeakerState(t *testing.T) {
+	e := NewEngine()
+	g := newConnectionGeneration()
+	key := bytes.Repeat([]byte{0x42}, 16)
+	cipher, err := gospeakCrypto.NewVoiceCipher(key)
+	if err != nil {
+		t.Fatalf("NewVoiceCipher: %v", err)
+	}
+	g.cipher = cipher
+	factory := &countingDecoderFactory{}
+	e.decoderFactory = factory
+
+	for sessionID := uint32(1); sessionID <= 64; sessionID++ {
+		e.processIncomingVoice(g, &protocol.VoicePacket{
+			SessionID: sessionID,
+			SeqNum:    1,
+			ChannelID: 1,
+			Payload:   bytes.Repeat([]byte{0xff}, 16),
+		})
+	}
+	if factory.created != 0 || len(e.decoders) != 0 || len(e.jitterBufs) != 0 || len(e.speakerLastSeen) != 0 {
+		t.Fatalf("invalid packets allocated state: decoders=%d jitter=%d last_seen=%d factory=%d",
+			len(e.decoders), len(e.jitterBufs), len(e.speakerLastSeen), factory.created)
+	}
+
+	valid := &protocol.VoicePacket{SessionID: 7, SeqNum: 2, ChannelID: 1}
+	valid.Payload = cipher.Encrypt(valid.SessionID, valid.SeqNum, valid.MarshalHeader(), []byte("opus"))
+	e.processIncomingVoice(g, valid)
+	if factory.created != 1 || e.decoders[7] == nil || e.jitterBufs[7] == nil || e.speakerLastSeen[7].IsZero() {
+		t.Fatalf("authenticated packet did not allocate expected state: decoders=%d jitter=%d last_seen=%d factory=%d",
+			len(e.decoders), len(e.jitterBufs), len(e.speakerLastSeen), factory.created)
 	}
 }
 

--- a/pkg/protocol/replay.go
+++ b/pkg/protocol/replay.go
@@ -1,0 +1,47 @@
+package protocol
+
+const replayWindowBits = 64
+
+// ReplayWindow accepts each positive, non-wrapping uint32 sequence at most once
+// while allowing bounded reordering. Callers must authenticate a packet before
+// mutating the window so forged high sequences cannot suppress valid traffic.
+type ReplayWindow struct {
+	highest     uint32
+	seen        uint64
+	initialized bool
+}
+
+// Accept records sequence and reports whether it is fresh and within the
+// 64-packet window. Sequence zero and uint32 wrap are rejected by design.
+func (w *ReplayWindow) Accept(sequence uint32) bool {
+	if sequence == 0 {
+		return false
+	}
+	if !w.initialized {
+		w.highest = sequence
+		w.seen = 1
+		w.initialized = true
+		return true
+	}
+	if sequence > w.highest {
+		advance := sequence - w.highest
+		if advance >= replayWindowBits {
+			w.seen = 1
+		} else {
+			w.seen = (w.seen << advance) | 1
+		}
+		w.highest = sequence
+		return true
+	}
+
+	age := w.highest - sequence
+	if age >= replayWindowBits {
+		return false
+	}
+	mask := uint64(1) << age
+	if w.seen&mask != 0 {
+		return false
+	}
+	w.seen |= mask
+	return true
+}

--- a/pkg/protocol/replay_test.go
+++ b/pkg/protocol/replay_test.go
@@ -1,0 +1,44 @@
+package protocol
+
+import (
+	"math"
+	"testing"
+)
+
+func TestReplayWindowAcceptsBoundedReorderingOnce(t *testing.T) {
+	var window ReplayWindow
+	for _, sequence := range []uint32{10, 12, 11, 9} {
+		if !window.Accept(sequence) {
+			t.Fatalf("Accept(%d) = false, want true", sequence)
+		}
+		if window.Accept(sequence) {
+			t.Fatalf("second Accept(%d) = true, want replay rejected", sequence)
+		}
+	}
+}
+
+func TestReplayWindowRejectsZeroAndPacketsOutsideWindow(t *testing.T) {
+	var window ReplayWindow
+	if window.Accept(0) {
+		t.Fatal("Accept(0) = true, want reserved sequence rejected")
+	}
+	if !window.Accept(1) || !window.Accept(65) {
+		t.Fatal("failed to establish replay window")
+	}
+	if window.Accept(1) {
+		t.Fatal("packet 64 behind highest sequence was accepted")
+	}
+	if !window.Accept(2) {
+		t.Fatal("packet 63 behind highest sequence was rejected")
+	}
+}
+
+func TestReplayWindowDoesNotTreatUint32WrapAsFresh(t *testing.T) {
+	var window ReplayWindow
+	if !window.Accept(math.MaxUint32-1) || !window.Accept(math.MaxUint32) {
+		t.Fatal("failed to accept final non-wrapping sequence values")
+	}
+	if window.Accept(0) || window.Accept(1) {
+		t.Fatal("wrapped sequence was accepted as fresh")
+	}
+}

--- a/pkg/server/run.go
+++ b/pkg/server/run.go
@@ -27,7 +27,12 @@ func (s *Server) Run() error {
 	if err != nil {
 		return fmt.Errorf("server: generate voice key: %w", err)
 	}
+	voiceCipher, err := crypto.NewVoiceCipher(voiceKey)
+	if err != nil {
+		return fmt.Errorf("server: initialize voice cipher: %w", err)
+	}
 	s.voiceKey = voiceKey
+	s.voiceCipher = voiceCipher
 
 	// Enable voice debug counters before listeners start so voiceLoop reads a
 	// stable value (avoids a data race with the assignment below).

--- a/pkg/server/screen.go
+++ b/pkg/server/screen.go
@@ -134,11 +134,10 @@ func (s *Server) handleScreenPacket(sessionID uint32, pkt *protocol.ScreenPacket
 	if !s.screenShare.IsSharer(sessionID, session.ChannelID) {
 		return
 	}
-	if !s.screenShare.AllowFrame(sessionID, minScreenShareFrameInterval) {
+	if !s.screenShare.AcceptFrame(sessionID, pkt, minScreenShareFrameInterval) {
 		return
 	}
 
-	pkt.SessionID = sessionID
 	frame, err := protocol.MarshalScreenPacketFrame(pkt)
 	if err != nil {
 		slog.Error("marshal screen packet", "session", sessionID, "err", err)

--- a/pkg/server/screenshare.go
+++ b/pkg/server/screenshare.go
@@ -7,18 +7,22 @@ import (
 	"time"
 
 	gospeakCrypto "github.com/NicolasHaas/gospeak/pkg/crypto"
+	"github.com/NicolasHaas/gospeak/pkg/protocol"
 	pb "github.com/NicolasHaas/gospeak/pkg/protocol/pb"
 )
 
 type ScreenShareManager struct {
-	mu                 sync.RWMutex
-	activeByChannel    map[int64]*pb.ScreenShareEvent
-	channelBySession   map[uint32]int64
-	authorizedByShare  map[uint32]map[uint32]bool
-	subscribersByShare map[uint32]map[uint32]bool
-	authorizedTarget   map[uint32]uint32
-	viewerTarget       map[uint32]uint32
-	lastFrameAt        map[uint32]time.Time
+	mu                      sync.RWMutex
+	activeByChannel         map[int64]*pb.ScreenShareEvent
+	channelBySession        map[uint32]int64
+	authorizedByShare       map[uint32]map[uint32]bool
+	subscribersByShare      map[uint32]map[uint32]bool
+	authorizedTarget        map[uint32]uint32
+	viewerTarget            map[uint32]uint32
+	lastFrameAt             map[uint32]time.Time
+	cipherByShare           map[uint32]*gospeakCrypto.VoiceCipher
+	lastFrameSequence       map[uint32]uint32
+	beforeFrameReplayCommit func()
 }
 
 func NewScreenShareManager() *ScreenShareManager {
@@ -30,6 +34,8 @@ func NewScreenShareManager() *ScreenShareManager {
 		authorizedTarget:   make(map[uint32]uint32),
 		viewerTarget:       make(map[uint32]uint32),
 		lastFrameAt:        make(map[uint32]time.Time),
+		cipherByShare:      make(map[uint32]*gospeakCrypto.VoiceCipher),
+		lastFrameSequence:  make(map[uint32]uint32),
 	}
 }
 
@@ -44,6 +50,13 @@ func (m *ScreenShareManager) Start(channelID int64, sessionID uint32, userID int
 	if err != nil {
 		return nil, fmt.Errorf("generate screen share key: %w", err)
 	}
+	cipher, err := gospeakCrypto.NewVoiceCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("initialize screen share cipher: %w", err)
+	}
+	if active, ok := m.activeByChannel[channelID]; ok && active.SessionID == sessionID {
+		m.stopBySessionLocked(sessionID)
+	}
 
 	event := &pb.ScreenShareEvent{
 		ChannelID:     channelID,
@@ -57,6 +70,8 @@ func (m *ScreenShareManager) Start(channelID int64, sessionID uint32, userID int
 	}
 	m.activeByChannel[channelID] = event
 	m.channelBySession[sessionID] = channelID
+	m.cipherByShare[sessionID] = cipher
+	delete(m.lastFrameSequence, sessionID)
 	if _, ok := m.authorizedByShare[sessionID]; !ok {
 		m.authorizedByShare[sessionID] = make(map[uint32]bool)
 	}
@@ -98,6 +113,8 @@ func (m *ScreenShareManager) ExpireInactive(idleTimeout time.Duration) []*pb.Scr
 }
 
 func (m *ScreenShareManager) stopBySessionLocked(sessionID uint32) (*pb.ScreenShareEvent, bool) {
+	delete(m.cipherByShare, sessionID)
+	delete(m.lastFrameSequence, sessionID)
 
 	channelID, ok := m.channelBySession[sessionID]
 	if !ok {
@@ -233,13 +250,44 @@ func (m *ScreenShareManager) SubscribersForSharer(sessionID uint32) []uint32 {
 	return result
 }
 
-func (m *ScreenShareManager) AllowFrame(sessionID uint32, minInterval time.Duration) bool {
+// AcceptFrame authenticates a frame before applying its strict monotonic
+// sequence check and rate gate. A rate-limited sequence remains consumed. The
+// cipher identity binds the result to the same active share across the
+// decrypt/unlock boundary.
+func (m *ScreenShareManager) AcceptFrame(sessionID uint32, pkt *protocol.ScreenPacket, minInterval time.Duration) bool {
+	if pkt == nil || pkt.SessionID != sessionID || pkt.SeqNum == 0 {
+		return false
+	}
+
+	m.mu.RLock()
+	channelID, ok := m.channelBySession[sessionID]
+	active := m.activeByChannel[channelID]
+	cipher := m.cipherByShare[sessionID]
+	validShare := ok && active != nil && active.Active && active.SessionID == sessionID && cipher != nil
+	m.mu.RUnlock()
+	if !validShare {
+		return false
+	}
+	if _, err := cipher.Decrypt(pkt.SessionID, pkt.SeqNum, pkt.MarshalHeader(), pkt.Payload); err != nil {
+		return false
+	}
+	if hook := m.beforeFrameReplayCommit; hook != nil {
+		hook()
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
-
+	current := m.activeByChannel[channelID]
+	if current == nil || !current.Active || current.SessionID != sessionID || m.cipherByShare[sessionID] != cipher {
+		return false
+	}
+	if pkt.SeqNum <= m.lastFrameSequence[sessionID] {
+		return false
+	}
+	m.lastFrameSequence[sessionID] = pkt.SeqNum
 	now := time.Now()
 	last := m.lastFrameAt[sessionID]
-	if !last.IsZero() && now.Sub(last) < minInterval {
+	if minInterval > 0 && !last.IsZero() && now.Sub(last) < minInterval {
 		return false
 	}
 	m.lastFrameAt[sessionID] = now

--- a/pkg/server/screenshare_test.go
+++ b/pkg/server/screenshare_test.go
@@ -1,11 +1,14 @@
 package server
 
 import (
+	"bytes"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	gospeakCrypto "github.com/NicolasHaas/gospeak/pkg/crypto"
 	"github.com/NicolasHaas/gospeak/pkg/protocol"
 )
 
@@ -122,6 +125,49 @@ func TestScreenShareManager_StopClearsSubscribers(t *testing.T) {
 	}
 }
 
+func TestScreenShareManager_RestartBySameSessionClearsViewerState(t *testing.T) {
+	mgr := NewScreenShareManager()
+
+	first, err := mgr.Start(1, 10, 20, "alice", 800, 600)
+	if err != nil {
+		t.Fatalf("Start(first): %v", err)
+	}
+	if _, viewers, err := mgr.ShareWithViewers(10, []uint32{30}); err != nil || len(viewers) != 1 {
+		t.Fatalf("ShareWithViewers(first) = (%v, %v), want one viewer and nil error", viewers, err)
+	}
+	if _, err := mgr.Subscribe(1, 30); err != nil {
+		t.Fatalf("Subscribe(first): %v", err)
+	}
+
+	replacement, err := mgr.Start(1, 10, 20, "alice", 800, 600)
+	if err != nil {
+		t.Fatalf("Start(replacement): %v", err)
+	}
+	if bytes.Equal(first.EncryptionKey, replacement.EncryptionKey) {
+		t.Fatal("replacement share reused encryption key")
+	}
+	if got := mgr.SubscribersForSharer(10); len(got) != 0 {
+		t.Fatalf("replacement subscribers = %v, want none", got)
+	}
+	if got := mgr.SubscriberCount(); got != 0 {
+		t.Fatalf("replacement subscriber count = %d, want 0", got)
+	}
+	if _, err := mgr.Subscribe(1, 30); err == nil {
+		t.Fatal("viewer remained authorized across replacement share")
+	}
+
+	shared, viewers, err := mgr.ShareWithViewers(10, []uint32{30})
+	if err != nil {
+		t.Fatalf("ShareWithViewers(replacement): %v", err)
+	}
+	if len(viewers) != 1 || viewers[0] != 30 {
+		t.Fatalf("replacement shared viewers = %v, want [30]", viewers)
+	}
+	if !bytes.Equal(shared.EncryptionKey, replacement.EncryptionKey) {
+		t.Fatal("replacement viewer received the wrong encryption key")
+	}
+}
+
 func TestScreenShareManager_ShareWithViewersRequiresActiveShare(t *testing.T) {
 	mgr := NewScreenShareManager()
 
@@ -147,6 +193,161 @@ func TestScreenShareManager_ExpireInactiveStopsShare(t *testing.T) {
 	}
 	if _, ok := mgr.ActiveForChannel(1); ok {
 		t.Fatalf("ActiveForChannel(1) = ok true, want false")
+	}
+}
+
+func TestScreenShareManagerAcceptFrameAuthenticatesBeforeMonotonicSequence(t *testing.T) {
+	mgr := NewScreenShareManager()
+	started, err := mgr.Start(1, 10, 20, "alice", 800, 600)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	cipher, err := gospeakCrypto.NewVoiceCipher(started.EncryptionKey)
+	if err != nil {
+		t.Fatalf("NewVoiceCipher: %v", err)
+	}
+	packet := func(sequence uint32, activeCipher *gospeakCrypto.VoiceCipher) *protocol.ScreenPacket {
+		pkt := &protocol.ScreenPacket{SessionID: 10, SeqNum: sequence}
+		pkt.Payload = activeCipher.Encrypt(pkt.SessionID, pkt.SeqNum, pkt.MarshalHeader(), []byte("frame"))
+		return pkt
+	}
+
+	if !mgr.AcceptFrame(10, packet(1, cipher), 0) {
+		t.Fatal("first authenticated frame was rejected")
+	}
+	if mgr.AcceptFrame(10, packet(1, cipher), 0) {
+		t.Fatal("duplicate frame was accepted")
+	}
+
+	forged := packet(1000, cipher)
+	forged.Payload[0] ^= 0xff
+	if mgr.AcceptFrame(10, forged, 0) {
+		t.Fatal("forged frame was accepted")
+	}
+	if !mgr.AcceptFrame(10, packet(2, cipher), 0) {
+		t.Fatal("forged high sequence poisoned screen replay state")
+	}
+	if mgr.AcceptFrame(10, packet(1, cipher), 0) {
+		t.Fatal("out-of-order screen frame was accepted on ordered transport")
+	}
+
+	if _, ok := mgr.StopBySession(10); !ok {
+		t.Fatal("StopBySession failed")
+	}
+	restarted, err := mgr.Start(1, 10, 20, "alice", 800, 600)
+	if err != nil {
+		t.Fatalf("restart share: %v", err)
+	}
+	if bytes.Equal(started.EncryptionKey, restarted.EncryptionKey) {
+		t.Fatal("restart reused screen encryption key")
+	}
+	newCipher, err := gospeakCrypto.NewVoiceCipher(restarted.EncryptionKey)
+	if err != nil {
+		t.Fatalf("NewVoiceCipher(restarted): %v", err)
+	}
+	if mgr.AcceptFrame(10, packet(3, cipher), 0) {
+		t.Fatal("frame from previous share key was accepted")
+	}
+	if !mgr.AcceptFrame(10, packet(1, newCipher), 0) {
+		t.Fatal("new share did not reset monotonic sequence state")
+	}
+}
+
+func TestScreenShareManagerRateLimitedFrameStillConsumesSequence(t *testing.T) {
+	mgr := NewScreenShareManager()
+	started, err := mgr.Start(1, 10, 20, "alice", 800, 600)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	cipher, err := gospeakCrypto.NewVoiceCipher(started.EncryptionKey)
+	if err != nil {
+		t.Fatalf("NewVoiceCipher: %v", err)
+	}
+	pkt := &protocol.ScreenPacket{SessionID: 10, SeqNum: 1}
+	pkt.Payload = cipher.Encrypt(pkt.SessionID, pkt.SeqNum, pkt.MarshalHeader(), []byte("frame"))
+
+	if mgr.AcceptFrame(10, pkt, time.Hour) {
+		t.Fatal("frame inside rate-limit interval was allowed")
+	}
+	if mgr.AcceptFrame(10, pkt, 0) {
+		t.Fatal("rate-limited frame sequence was reusable")
+	}
+}
+
+func TestScreenShareManagerStaleAuthenticationCannotAdvanceReplacementShare(t *testing.T) {
+	mgr := NewScreenShareManager()
+	started, err := mgr.Start(1, 10, 20, "alice", 800, 600)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	oldCipher, err := gospeakCrypto.NewVoiceCipher(started.EncryptionKey)
+	if err != nil {
+		t.Fatalf("NewVoiceCipher: %v", err)
+	}
+	oldPacket := &protocol.ScreenPacket{SessionID: 10, SeqNum: 1}
+	oldPacket.Payload = oldCipher.Encrypt(oldPacket.SessionID, oldPacket.SeqNum, oldPacket.MarshalHeader(), []byte("old"))
+
+	reached := make(chan struct{})
+	release := make(chan struct{})
+	mgr.beforeFrameReplayCommit = func() {
+		close(reached)
+		<-release
+	}
+	result := make(chan bool, 1)
+	go func() { result <- mgr.AcceptFrame(10, oldPacket, 0) }()
+	<-reached
+
+	if _, ok := mgr.StopBySession(10); !ok {
+		t.Fatal("StopBySession failed")
+	}
+	restarted, err := mgr.Start(1, 10, 20, "alice", 800, 600)
+	if err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+	close(release)
+	if <-result {
+		t.Fatal("stale authentication advanced replacement share")
+	}
+	mgr.beforeFrameReplayCommit = nil
+
+	newCipher, err := gospeakCrypto.NewVoiceCipher(restarted.EncryptionKey)
+	if err != nil {
+		t.Fatalf("NewVoiceCipher(restarted): %v", err)
+	}
+	newPacket := &protocol.ScreenPacket{SessionID: 10, SeqNum: 1}
+	newPacket.Payload = newCipher.Encrypt(newPacket.SessionID, newPacket.SeqNum, newPacket.MarshalHeader(), []byte("new"))
+	if !mgr.AcceptFrame(10, newPacket, 0) {
+		t.Fatal("replacement share sequence was poisoned")
+	}
+}
+
+func TestScreenShareManagerAcceptFrameConcurrentDuplicateOnce(t *testing.T) {
+	mgr := NewScreenShareManager()
+	started, err := mgr.Start(1, 10, 20, "alice", 800, 600)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	cipher, err := gospeakCrypto.NewVoiceCipher(started.EncryptionKey)
+	if err != nil {
+		t.Fatalf("NewVoiceCipher: %v", err)
+	}
+	pkt := &protocol.ScreenPacket{SessionID: 10, SeqNum: 1}
+	pkt.Payload = cipher.Encrypt(pkt.SessionID, pkt.SeqNum, pkt.MarshalHeader(), []byte("frame"))
+
+	var accepted atomic.Int32
+	var workers sync.WaitGroup
+	for range 64 {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			if mgr.AcceptFrame(10, pkt, 0) {
+				accepted.Add(1)
+			}
+		}()
+	}
+	workers.Wait()
+	if got := accepted.Load(); got != 1 {
+		t.Fatalf("concurrent frame accepts = %d, want exactly 1", got)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	gospeakCrypto "github.com/NicolasHaas/gospeak/pkg/crypto"
 	"github.com/NicolasHaas/gospeak/pkg/datastore"
 	"github.com/NicolasHaas/gospeak/pkg/protocol"
 )
@@ -79,6 +80,8 @@ type Server struct {
 	screenMu        sync.RWMutex
 	screenConns     map[uint32]*screenClientConn
 	voiceKey        []byte // shared AES-128 key for all voice encryption
+	voiceCipher     *gospeakCrypto.VoiceCipher
+	voiceReplayHook func()
 	authLimiter     *authRateLimiter
 	bootstrapMu     sync.Mutex
 	preAuthMu       sync.Mutex

--- a/pkg/server/session.go
+++ b/pkg/server/session.go
@@ -19,6 +19,7 @@ import (
 type SessionManager struct {
 	mu               sync.RWMutex
 	sessions         map[uint32]*model.Session // sessionID -> session
+	voiceReplay      map[uint32]*protocol.ReplayWindow
 	nextSessionID    uint32
 	issuedSessionIDs uint64
 	sessionIDSeeded  bool
@@ -45,7 +46,8 @@ type SessionSnapshot struct {
 // NewSessionManager creates a new session manager.
 func NewSessionManager() *SessionManager {
 	return &SessionManager{
-		sessions: make(map[uint32]*model.Session),
+		sessions:    make(map[uint32]*model.Session),
+		voiceReplay: make(map[uint32]*protocol.ReplayWindow),
 	}
 }
 
@@ -165,11 +167,44 @@ func (sm *SessionManager) ValidateScreenAuth(sessionID uint32, token string) boo
 	return ok && s.ScreenAuthToken == token
 }
 
-// Remove removes a session.
+// Remove removes a session and its replay state.
 func (sm *SessionManager) Remove(id uint32) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	delete(sm.sessions, id)
+	delete(sm.voiceReplay, id)
+}
+
+// AcceptVoiceSequence atomically rechecks an authenticated packet's endpoint
+// and records its sequence for an active, unmuted session. Authentication must
+// happen before this call so forged high sequences cannot advance the window.
+func (sm *SessionManager) AcceptVoiceSequence(id uint32, expectedAddr *net.UDPAddr, sequence uint32) (SessionSnapshot, bool) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	s, ok := sm.sessions[id]
+	if !ok || s.Muted || !udpAddrEqual(s.UDPAddr, expectedAddr) {
+		return SessionSnapshot{}, false
+	}
+	window := sm.voiceReplay[id]
+	if window == nil {
+		window = &protocol.ReplayWindow{}
+		sm.voiceReplay[id] = window
+	}
+	if !window.Accept(sequence) {
+		return SessionSnapshot{}, false
+	}
+	return SessionSnapshot{
+		ID:              s.ID,
+		UserID:          s.UserID,
+		Username:        s.Username,
+		Role:            s.Role,
+		ChannelScope:    s.ChannelScope,
+		ChannelID:       s.ChannelID,
+		ScreenAuthToken: s.ScreenAuthToken,
+		UDPAddr:         cloneUDPAddr(s.UDPAddr),
+		Muted:           s.Muted,
+		Deafened:        s.Deafened,
+	}, true
 }
 
 // RegisterUDPAddr authenticates and atomically updates a session's UDP endpoint.

--- a/pkg/server/voice.go
+++ b/pkg/server/voice.go
@@ -61,8 +61,8 @@ func (s *Server) StartVoice() error {
 	return nil
 }
 
-// voiceLoop reads UDP voice packets and forwards them to channel members.
-// This is an SFU (Selective Forwarding Unit) - no decryption, no mixing.
+// voiceLoop authenticates UDP voice packets and forwards their original
+// ciphertext to channel members. It never decodes or mixes media plaintext.
 func (s *Server) voiceLoop(conn *net.UDPConn) {
 	buf := make([]byte, protocol.VoiceHeaderSize+protocol.MaxVoicePayload)
 
@@ -105,35 +105,10 @@ func (s *Server) voiceLoop(conn *net.UDPConn) {
 			continue
 		}
 
-		// Look up sender session
-		session, ok := s.sessions.GetSnapshot(pkt.SessionID)
+		actualChannel, ok := s.acceptVoicePacket(pkt, remoteAddr)
 		if !ok {
 			s.metrics.VoicePacketsDropped.Add(1)
-			continue // unknown session, discard
-		}
-
-		// Voice is accepted only after a control-authenticated registration proof.
-		if !udpAddrEqual(session.UDPAddr, remoteAddr) {
-			s.metrics.VoicePacketsDropped.Add(1)
-			continue // unregistered or mismatched source
-		}
-
-		// Don't forward if muted
-		if session.Muted {
-			s.metrics.VoicePacketsDropped.Add(1)
 			continue
-		}
-
-		// Verify the sender is actually in the claimed channel (prevent channel spoofing)
-		actualChannel := s.channels.ChannelOf(pkt.SessionID)
-		if actualChannel <= 0 {
-			s.metrics.VoicePacketsDropped.Add(1)
-			continue // not in a channel, discard
-		}
-		packetChannel := uint64(actualChannel) //nolint:gosec // positivity is checked immediately above
-		if packetChannel != pkt.ChannelID {
-			s.metrics.VoicePacketsDropped.Add(1)
-			continue // claimed channel does not match membership
 		}
 
 		// Track per-session voice debug stats
@@ -147,7 +122,7 @@ func (s *Server) voiceLoop(conn *net.UDPConn) {
 		channelID := actualChannel
 		members := s.channels.Members(channelID)
 
-		rawPacket := buf[:n] // forward raw bytes, no decryption
+		rawPacket := buf[:n] // forward the original authenticated ciphertext unchanged
 
 		for _, memberSID := range members {
 			if memberSID == pkt.SessionID {
@@ -174,6 +149,43 @@ func (s *Server) voiceLoop(conn *net.UDPConn) {
 			}
 		}
 	}
+}
+
+// acceptVoicePacket verifies endpoint ownership and packet authenticity before
+// recording its sequence. It returns the sender's current channel when the
+// packet is safe to relay.
+func (s *Server) acceptVoicePacket(pkt *protocol.VoicePacket, remoteAddr *net.UDPAddr) (int64, bool) {
+	if pkt == nil || s.voiceCipher == nil {
+		return 0, false
+	}
+	session, ok := s.sessions.GetSnapshot(pkt.SessionID)
+	if !ok || session.Muted || session.ChannelID <= 0 || !udpAddrEqual(session.UDPAddr, remoteAddr) {
+		return 0, false
+	}
+	packetChannel := uint64(session.ChannelID) //nolint:gosec // positivity is checked immediately above
+	if packetChannel != pkt.ChannelID {
+		return 0, false
+	}
+	if _, err := s.voiceCipher.Decrypt(pkt.SessionID, pkt.SeqNum, pkt.MarshalHeader(), pkt.Payload); err != nil {
+		return 0, false
+	}
+	if hook := s.voiceReplayHook; hook != nil {
+		hook()
+	}
+	acceptedSession, ok := s.sessions.AcceptVoiceSequence(pkt.SessionID, remoteAddr, pkt.SeqNum)
+	if !ok {
+		return 0, false
+	}
+
+	actualChannel := s.channels.ChannelOf(pkt.SessionID)
+	if actualChannel <= 0 || actualChannel != acceptedSession.ChannelID {
+		return 0, false
+	}
+	packetChannel = uint64(actualChannel) //nolint:gosec // positivity is checked immediately above
+	if packetChannel != pkt.ChannelID {
+		return 0, false
+	}
+	return actualChannel, true
 }
 
 func (s *Server) handleVoiceRegistration(data []byte, remoteAddr *net.UDPAddr, now time.Time) bool {

--- a/pkg/server/voice_test.go
+++ b/pkg/server/voice_test.go
@@ -3,9 +3,12 @@ package server
 import (
 	"bytes"
 	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	gospeakCrypto "github.com/NicolasHaas/gospeak/pkg/crypto"
 	"github.com/NicolasHaas/gospeak/pkg/model"
 	"github.com/NicolasHaas/gospeak/pkg/protocol"
 )
@@ -72,5 +75,156 @@ func TestVoiceRegistrationRejectsReplayAndRateLimitsRebind(t *testing.T) {
 	}
 	if !srv.handleVoiceRegistration(registration2, rebound, now.Add(voiceRebindInterval)) {
 		t.Fatal("authenticated endpoint rebind after rate limit was rejected")
+	}
+}
+
+func TestSessionManagerAcceptVoiceSequenceIsAtomicAndLifecycleBound(t *testing.T) {
+	manager := NewSessionManager()
+	session := mustCreateSession(t, manager, 1, "speaker", model.RoleUser)
+	remote := &net.UDPAddr{IP: net.ParseIP("192.0.2.10"), Port: 40000}
+	manager.mu.Lock()
+	manager.sessions[session.ID].UDPAddr = cloneUDPAddr(remote)
+	manager.mu.Unlock()
+
+	var accepted atomic.Int32
+	var workers sync.WaitGroup
+	for range 64 {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			if _, ok := manager.AcceptVoiceSequence(session.ID, remote, 7); ok {
+				accepted.Add(1)
+			}
+		}()
+	}
+	workers.Wait()
+	if got := accepted.Load(); got != 1 {
+		t.Fatalf("concurrent accepts = %d, want exactly 1", got)
+	}
+
+	manager.Remove(session.ID)
+	if _, ok := manager.AcceptVoiceSequence(session.ID, remote, 8); ok {
+		t.Fatal("sequence accepted after session removal")
+	}
+	if _, ok := manager.voiceReplay[session.ID]; ok {
+		t.Fatal("session removal retained replay state")
+	}
+}
+
+func TestAcceptVoicePacketRejectsEndpointRebindAfterAuthentication(t *testing.T) {
+	srv, _, _ := newTestServer(t)
+	key := bytes.Repeat([]byte{0x42}, 16)
+	cipher, err := gospeakCrypto.NewVoiceCipher(key)
+	if err != nil {
+		t.Fatalf("NewVoiceCipher: %v", err)
+	}
+	srv.voiceCipher = cipher
+
+	session := mustCreateSession(t, srv.sessions, 1, "speaker", model.RoleUser)
+	oldEndpoint := &net.UDPAddr{IP: net.ParseIP("192.0.2.10"), Port: 40000}
+	newEndpoint := &net.UDPAddr{IP: net.ParseIP("192.0.2.10"), Port: 40001}
+	registeredAt := time.Now()
+	registration1, err := protocol.MarshalVoiceRegistration(session.ID, 1, session.VoiceRegistrationKey)
+	if err != nil {
+		t.Fatalf("MarshalVoiceRegistration(1): %v", err)
+	}
+	if !srv.handleVoiceRegistration(registration1, oldEndpoint, registeredAt) {
+		t.Fatal("initial registration failed")
+	}
+	const channelID int64 = 7
+	srv.channels.Join(session.ID, channelID)
+	srv.sessions.SetChannel(session.ID, channelID)
+	packet := &protocol.VoicePacket{SessionID: session.ID, SeqNum: 1, ChannelID: uint64(channelID)}
+	packet.Payload = cipher.Encrypt(packet.SessionID, packet.SeqNum, packet.MarshalHeader(), []byte("opus"))
+
+	reached := make(chan struct{})
+	release := make(chan struct{})
+	srv.voiceReplayHook = func() {
+		close(reached)
+		<-release
+	}
+	result := make(chan bool, 1)
+	go func() {
+		_, ok := srv.acceptVoicePacket(packet, oldEndpoint)
+		result <- ok
+	}()
+	select {
+	case <-reached:
+	case <-time.After(time.Second):
+		t.Fatal("packet did not reach post-authentication boundary")
+	}
+
+	registration2, err := protocol.MarshalVoiceRegistration(session.ID, 2, session.VoiceRegistrationKey)
+	if err != nil {
+		t.Fatalf("MarshalVoiceRegistration(2): %v", err)
+	}
+	if !srv.handleVoiceRegistration(registration2, newEndpoint, registeredAt.Add(voiceRebindInterval)) {
+		t.Fatal("authenticated endpoint rebind failed")
+	}
+	close(release)
+	select {
+	case ok := <-result:
+		if ok {
+			t.Fatal("packet from retired endpoint committed after rebind")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stale endpoint packet did not return")
+	}
+	srv.voiceReplayHook = nil
+
+	if _, ok := srv.acceptVoicePacket(packet, newEndpoint); !ok {
+		t.Fatal("stale endpoint packet poisoned replay state")
+	}
+}
+
+func TestAcceptVoicePacketAuthenticatesBeforeReplayWindow(t *testing.T) {
+	srv, _, _ := newTestServer(t)
+	key := bytes.Repeat([]byte{0x42}, 16)
+	cipher, err := gospeakCrypto.NewVoiceCipher(key)
+	if err != nil {
+		t.Fatalf("NewVoiceCipher: %v", err)
+	}
+	srv.voiceCipher = cipher
+
+	session := mustCreateSession(t, srv.sessions, 1, "speaker", model.RoleUser)
+	remote := &net.UDPAddr{IP: net.ParseIP("192.0.2.10"), Port: 40000}
+	registration, err := protocol.MarshalVoiceRegistration(session.ID, 1, session.VoiceRegistrationKey)
+	if err != nil {
+		t.Fatalf("MarshalVoiceRegistration: %v", err)
+	}
+	if !srv.handleVoiceRegistration(registration, remote, time.Now()) {
+		t.Fatal("voice registration failed")
+	}
+	const channelID int64 = 7
+	srv.channels.Join(session.ID, channelID)
+	srv.sessions.SetChannel(session.ID, channelID)
+
+	packet := func(sequence uint32) *protocol.VoicePacket {
+		pkt := &protocol.VoicePacket{
+			SessionID: session.ID,
+			SeqNum:    sequence,
+			Timestamp: sequence * 960,
+			ChannelID: uint64(channelID),
+		}
+		pkt.Payload = cipher.Encrypt(pkt.SessionID, pkt.SeqNum, pkt.MarshalHeader(), []byte("opus"))
+		return pkt
+	}
+
+	for _, sequence := range []uint32{10, 12, 11} {
+		if got, ok := srv.acceptVoicePacket(packet(sequence), remote); !ok || got != channelID {
+			t.Fatalf("acceptVoicePacket(%d) = (%d, %v), want (%d, true)", sequence, got, ok, channelID)
+		}
+	}
+	if _, ok := srv.acceptVoicePacket(packet(10), remote); ok {
+		t.Fatal("replayed voice packet was accepted")
+	}
+
+	forged := packet(1000)
+	forged.Payload[0] ^= 0xff
+	if _, ok := srv.acceptVoicePacket(forged, remote); ok {
+		t.Fatal("forged voice packet was accepted")
+	}
+	if _, ok := srv.acceptVoicePacket(packet(13), remote); !ok {
+		t.Fatal("forged high sequence poisoned replay state")
 	}
 }


### PR DESCRIPTION
## Summary

This PR adds replay protection for encrypted voice and screen-sharing traffic. This prevents attackers from capturing valid encrypted voice or screen-sharing packets and sending them again later.

- Authenticates media packets before updating replay state
- Adds a bounded replay window for reordered UDP voice packets
- Enforces strictly increasing screen-frame sequences
- Binds replay state to session and screen-share lifecycles
- Prevents forged packets from poisoning replay state
- Adds deterministic tests for duplicates, reordering, stale packets, endpoint rebinding, key rotation, sequence exhaustion, and concurrent delivery