### PR TITLE
fix(server): renew automatic TLS certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Existing bookmark files remain compatible. They gain a `trusted_server_pins` sec
 | `-open` | `false` | Allow connections without a token |
 | `-screen-share` | `false` | Enable per-channel screen sharing |
 | `-channels-file` | | YAML file for initial channel setup |
-| `-cert` / `-key` | *(empty)* | Custom matching TLS pair, including self-signed certificates; provide both. When both are empty, GoSpeak loads or creates `server.crt` and `server.key` in `-data` |
+| `-cert` / `-key` | *(empty)* | Custom matching TLS pair, including self-signed certificates; provide both. When both are empty, GoSpeak loads or creates `server.crt` and `server.key` in `-data`. On the first new TLS connection within 30 days of expiry, it renews the automatic certificate without changing the private key or TOFU identity |
 | `-metrics` | *(empty)* | Prometheus `/metrics` and `/healthz` HTTP bind address; opt in with a trusted bind such as `127.0.0.1:9602` |
 | `-export-users` | `false` | Export all users as YAML and exit |
 | `-export-channels` | `false` | Export all channels as YAML and exit |

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -74,7 +74,7 @@ These flags map directly to `gospeak-server` and are all supported options.
 | `-voice` | `:9601` | UDP voice plane bind address |
 | `-db` | `gospeak.db` | SQLite database file path |
 | `-cert` | *(empty)* | Custom TLS certificate, including self-signed; must be used with `-key` |
-| `-key` | *(empty)* | Matching TLS private key; must be used with `-cert`. When both flags are empty, a self-signed pair is loaded or generated in `-data` |
+| `-key` | *(empty)* | Matching TLS private key; must be used with `-cert`. When both flags are empty, a self-signed pair is loaded or generated in `-data`; the first new TLS connection within 30 days of expiry renews the certificate without rotating the key |
 | `-data` | `.` | Data directory for generated files (certs, DB, etc.) |
 | `-open` | `false` | Allow users to join without a token |
 | `-screen` | `:9603` | TCP/TLS screen-share relay bind address |

--- a/docs/building.md
+++ b/docs/building.md
@@ -110,7 +110,7 @@ docker run -p 9600:9600 -p 9601:9601/udp \
 | `-db` | `gospeak.db` | SQLite database path |
 | `-data` | `.` | Directory for auto-generated TLS certs |
 | `-cert` | *(empty)* | Custom TLS certificate, including self-signed; requires `-key` |
-| `-key` | *(empty)* | Matching private key; requires `-cert`. Empty pair enables automatic self-signed mode in `-data` |
+| `-key` | *(empty)* | Matching private key; requires `-cert`. Empty pair enables automatic self-signed mode in `-data`; the first new TLS connection within 30 days of expiry renews the certificate without rotating the key |
 | `-open` | `false` | Allow first-time connections without an invite token (personal token still required on reconnect) |
 | `-screen` | `:9603` | TCP/TLS screen-share relay bind address |
 | `-screen-share` | `false` | Enable per-channel screen sharing |

--- a/docs/security.md
+++ b/docs/security.md
@@ -52,10 +52,12 @@ graph TB
 
 - The control plane uses **TLS 1.3** (the latest version) for all TCP connections
 - On first run, the server automatically generates a **self-signed ECDSA P-256 certificate** when both `-cert` and `-key` are empty
-- Certificate is valid for 1 year, with SAN for `localhost`, `127.0.0.1`, and `::1`
+- The automatic certificate is valid for 1 year, with SAN for `localhost`, `127.0.0.1`, and `::1`
+- The first new TLS connection within 30 days of expiry renews it, even if the server has stayed up continuously. Renewal keeps the existing private key, so saved TOFU fingerprints remain valid. If renewal fails while the cached certificate is still valid, GoSpeak serves that certificate and retries on a later connection; it fails closed after expiry
+- Files at the automatic paths must contain GoSpeak's self-signed ECDSA P-256 material. Configure CA-issued, RSA, or otherwise operator-managed pairs explicitly with `-cert` and `-key`
 - Custom matching certificate/key pairs, including self-signed pairs, can be provided via `-cert` and `-key`
-- Certificate handling fails closed: partial configuration, missing files, malformed PEM, mismatched keys, or damaged automatic files stop startup without overwriting existing material
-- Automatically generated files are published without replacing existing paths; the private key is created with mode `0600`
+- Certificate handling fails closed: partial configuration, missing files, malformed PEM, mismatched keys, expired or not-yet-valid custom certificates, and damaged or foreign automatic files stop startup without overwriting existing material
+- Initial automatic files are published without replacing existing paths; the private key is created with mode `0600`. Renewal syncs a same-directory temporary certificate before replacing only `server.crt` and leaves `server.key` unchanged. Unix uses an atomic rename plus directory sync; Windows uses `MoveFileEx` with replace-existing and write-through flags
 - Clients first try normal system-PKI and hostname verification. A certificate that is not publicly trusted is rejected until the user verifies and explicitly accepts its SHA-256 SubjectPublicKeyInfo fingerprint
 - Accepted TOFU pins are stored by normalized control address in the bookmark file. Subsequent control connections require the same public key; screen connections require the exact identity established by the control connection
 - A changed TOFU pin is treated as a possible MITM and blocks the connection. Replacing it requires an explicit re-trust confirmation that displays both fingerprints

--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -343,14 +343,9 @@ func (s *Server) StartControl(st datastore.DataProviderFactory) error {
 		s.listenerMu.Unlock()
 	}()
 
-	cert, err := loadOrGenerateTLS(s.cfg)
+	tlsCfg, err := newServerTLSConfig(s.cfg)
 	if err != nil {
 		return fmt.Errorf("server: tls: %w", err)
-	}
-
-	tlsCfg := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS13,
 	}
 
 	ln, err := tls.Listen("tcp", s.cfg.ControlAddr, tlsCfg)

--- a/pkg/server/replacefile_unix.go
+++ b/pkg/server/replacefile_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package server
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+func replaceTLSFile(source, destination string) error {
+	if err := os.Rename(source, destination); err != nil {
+		return err
+	}
+	directory, err := os.Open(filepath.Dir(destination))
+	if err != nil {
+		return err
+	}
+	syncErr := directory.Sync()
+	closeErr := directory.Close()
+	return errors.Join(syncErr, closeErr)
+}

--- a/pkg/server/replacefile_windows.go
+++ b/pkg/server/replacefile_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package server
+
+import "golang.org/x/sys/windows"
+
+func replaceTLSFile(source, destination string) error {
+	sourcePointer, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	destinationPointer, err := windows.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(
+		sourcePointer,
+		destinationPointer,
+		windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH,
+	)
+}

--- a/pkg/server/screen.go
+++ b/pkg/server/screen.go
@@ -31,14 +31,9 @@ func (s *Server) StartScreen() error {
 		s.listenerMu.Unlock()
 	}()
 
-	cert, err := loadOrGenerateTLS(s.cfg)
+	tlsCfg, err := newServerTLSConfig(s.cfg)
 	if err != nil {
 		return fmt.Errorf("server: screen tls: %w", err)
-	}
-
-	tlsCfg := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS13,
 	}
 
 	ln, err := tls.Listen("tcp", s.cfg.ScreenAddr, tlsCfg)

--- a/pkg/server/tls.go
+++ b/pkg/server/tls.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -14,25 +15,110 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 )
 
 const (
-	generatedCertName = "server.crt"
-	generatedKeyName  = "server.key"
+	generatedCertName        = "server.crt"
+	generatedKeyName         = "server.key"
+	automaticCertValidity    = 365 * 24 * time.Hour
+	automaticCertRenewBefore = 30 * 24 * time.Hour
 )
 
-// loadOrGenerateTLS loads an explicitly configured pair, reuses an existing
-// automatic pair, or generates a self-signed pair only when neither automatic
-// file exists. Existing certificate material is never overwritten.
+// loadOrGenerateTLS loads an explicitly configured pair, reuses or renews an
+// existing automatic pair, or generates a self-signed pair when neither
+// automatic file exists. Custom certificate material is never modified.
 func loadOrGenerateTLS(cfg Config) (tls.Certificate, error) {
+	return loadOrGenerateTLSAt(cfg, time.Now())
+}
+
+type tlsCertificateSource struct {
+	mu        sync.Mutex
+	cfg       Config
+	automatic bool
+	cert      *tls.Certificate
+	leaf      *x509.Certificate
+	load      func(Config, time.Time) (tls.Certificate, error)
+}
+
+func newServerTLSConfig(cfg Config) (*tls.Config, error) {
+	source, err := newTLSCertificateSourceAt(cfg, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		MinVersion:     tls.VersionTLS13,
+		GetCertificate: source.getCertificate,
+	}, nil
+}
+
+func newTLSCertificateSourceAt(cfg Config, now time.Time) (*tlsCertificateSource, error) {
+	cert, err := loadOrGenerateTLSAt(cfg, now)
+	if err != nil {
+		return nil, err
+	}
+	leaf, err := certificateLeaf(cert)
+	if err != nil {
+		return nil, fmt.Errorf("parse loaded TLS certificate: %w", err)
+	}
+	return &tlsCertificateSource{
+		cfg:       cfg,
+		automatic: cfg.CertFile == "" && cfg.KeyFile == "",
+		cert:      &cert,
+		leaf:      leaf,
+		load:      loadOrGenerateTLSAt,
+	}, nil
+}
+
+func (s *tlsCertificateSource) getCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return s.getCertificateAt(time.Now())
+}
+
+func (s *tlsCertificateSource) getCertificateAt(now time.Time) (*tls.Certificate, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.automatic {
+		if now.Before(s.leaf.NotBefore) || now.After(s.leaf.NotAfter) {
+			return nil, fmt.Errorf("configured TLS certificate is not valid at %s", now.Format(time.RFC3339))
+		}
+		return s.cert, nil
+	}
+	if s.leaf.NotAfter.After(now.Add(automaticCertRenewBefore)) {
+		return s.cert, nil
+	}
+	cert, err := s.load(s.cfg, now)
+	if err != nil {
+		if _, validityErr := validCertificateLeaf(*s.cert, now); validityErr == nil {
+			slog.Warn("automatic TLS certificate renewal failed; continuing with valid cached certificate", "err", err, "expires", s.leaf.NotAfter)
+			return s.cert, nil
+		}
+		return nil, fmt.Errorf("renew automatic TLS certificate after cached certificate became invalid: %w", err)
+	}
+	leaf, err := certificateLeaf(cert)
+	if err != nil {
+		return nil, fmt.Errorf("parse renewed TLS certificate: %w", err)
+	}
+	s.cert = &cert
+	s.leaf = leaf
+	return s.cert, nil
+}
+
+func loadOrGenerateTLSAt(cfg Config, now time.Time) (tls.Certificate, error) {
 	hasCustomCert := cfg.CertFile != ""
 	hasCustomKey := cfg.KeyFile != ""
 	if hasCustomCert != hasCustomKey {
 		return tls.Certificate{}, fmt.Errorf("TLS certificate and key must be configured together")
 	}
 	if hasCustomCert {
-		return loadTLSKeyPair(cfg.CertFile, cfg.KeyFile, "configured")
+		cert, err := loadTLSKeyPair(cfg.CertFile, cfg.KeyFile, "configured")
+		if err != nil {
+			return tls.Certificate{}, err
+		}
+		if _, err := validCertificateLeaf(cert, now); err != nil {
+			return tls.Certificate{}, fmt.Errorf("validate configured TLS certificate %q: %w", cfg.CertFile, err)
+		}
+		return cert, nil
 	}
 
 	dataDir := cfg.DataDir
@@ -53,13 +139,30 @@ func loadOrGenerateTLS(cfg Config) (tls.Certificate, error) {
 		return tls.Certificate{}, fmt.Errorf("automatic TLS certificate state is incomplete: both %q and %q must exist or neither may exist", certPath, keyPath)
 	}
 	if certExists {
-		return loadTLSKeyPair(certPath, keyPath, "automatic")
+		cert, err := loadTLSKeyPair(certPath, keyPath, "automatic")
+		if err != nil {
+			return tls.Certificate{}, err
+		}
+		leaf, err := certificateLeaf(cert)
+		if err != nil {
+			return tls.Certificate{}, fmt.Errorf("parse automatic TLS certificate %q: %w", certPath, err)
+		}
+		if _, err := validateAutomaticCertificate(cert, leaf, certPath, keyPath); err != nil {
+			return tls.Certificate{}, err
+		}
+		if now.Before(leaf.NotBefore) {
+			return tls.Certificate{}, fmt.Errorf("automatic TLS certificate %q is not valid before %s", certPath, leaf.NotBefore.Format(time.RFC3339))
+		}
+		if leaf.NotAfter.After(now.Add(automaticCertRenewBefore)) {
+			return cert, nil
+		}
+		return renewAutomaticTLS(certPath, keyPath, cert, leaf, now)
 	}
 
 	if err := os.MkdirAll(dataDir, 0o700); err != nil {
 		return tls.Certificate{}, fmt.Errorf("create TLS data directory: %w", err)
 	}
-	return generateSelfSignedTLS(certPath, keyPath)
+	return generateSelfSignedTLS(certPath, keyPath, now)
 }
 
 func loadTLSKeyPair(certPath, keyPath, source string) (tls.Certificate, error) {
@@ -69,6 +172,31 @@ func loadTLSKeyPair(certPath, keyPath, source string) (tls.Certificate, error) {
 	}
 	slog.Info("loaded TLS certificate", "cert", certPath, "source", source)
 	return cert, nil
+}
+
+func certificateLeaf(cert tls.Certificate) (*x509.Certificate, error) {
+	if len(cert.Certificate) == 0 {
+		return nil, fmt.Errorf("certificate chain is empty")
+	}
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil, fmt.Errorf("parse leaf: %w", err)
+	}
+	return leaf, nil
+}
+
+func validCertificateLeaf(cert tls.Certificate, now time.Time) (*x509.Certificate, error) {
+	leaf, err := certificateLeaf(cert)
+	if err != nil {
+		return nil, err
+	}
+	if now.Before(leaf.NotBefore) {
+		return nil, fmt.Errorf("certificate is not valid before %s", leaf.NotBefore.Format(time.RFC3339))
+	}
+	if now.After(leaf.NotAfter) {
+		return nil, fmt.Errorf("certificate expired at %s", leaf.NotAfter.Format(time.RFC3339))
+	}
+	return leaf, nil
 }
 
 func pathExists(path string) (bool, error) {
@@ -82,36 +210,20 @@ func pathExists(path string) (bool, error) {
 	return false, err
 }
 
-func generateSelfSignedTLS(certPath, keyPath string) (tls.Certificate, error) {
+func generateSelfSignedTLS(certPath, keyPath string, now time.Time) (tls.Certificate, error) {
 	slog.Info("generating self-signed TLS certificate")
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("generate TLS key: %w", err)
 	}
-	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	certPEM, err := selfSignedCertificatePEM(priv, now)
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("generate TLS certificate serial: %w", err)
-	}
-	now := time.Now()
-	template := x509.Certificate{
-		SerialNumber: serialNumber,
-		Subject:      pkix.Name{Organization: []string{"GoSpeak Server"}},
-		NotBefore:    now.Add(-time.Minute),
-		NotAfter:     now.Add(365 * 24 * time.Hour),
-		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		DNSNames:     []string{"localhost"},
-		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
-	}
-	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
-	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("create TLS certificate: %w", err)
+		return tls.Certificate{}, err
 	}
 	privDER, err := x509.MarshalECPrivateKey(priv)
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("marshal TLS key: %w", err)
 	}
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: privDER})
 	cert, err := tls.X509KeyPair(certPEM, keyPEM)
 	if err != nil {
@@ -122,6 +234,89 @@ func generateSelfSignedTLS(certPath, keyPath string) (tls.Certificate, error) {
 	}
 	slog.Info("TLS certificate generated", "cert", certPath, "key", keyPath)
 	return cert, nil
+}
+
+func selfSignedCertificatePEM(priv *ecdsa.PrivateKey, now time.Time) ([]byte, error) {
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("generate TLS certificate serial: %w", err)
+	}
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject:      pkix.Name{Organization: []string{"GoSpeak Server"}},
+		NotBefore:    now.Add(-time.Minute),
+		NotAfter:     now.Add(automaticCertValidity),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, fmt.Errorf("create TLS certificate: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), nil
+}
+
+func renewAutomaticTLS(certPath, keyPath string, cert tls.Certificate, leaf *x509.Certificate, now time.Time) (tls.Certificate, error) {
+	return renewAutomaticTLSWithPublisher(certPath, keyPath, cert, leaf, now, replaceTLSCertificate)
+}
+
+func renewAutomaticTLSWithPublisher(
+	certPath, keyPath string,
+	cert tls.Certificate,
+	leaf *x509.Certificate,
+	now time.Time,
+	publish func(string, []byte) error,
+) (tls.Certificate, error) {
+	privateKey, err := validateAutomaticCertificate(cert, leaf, certPath, keyPath)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	certPEM, err := selfSignedCertificatePEM(privateKey, now)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("renew automatic TLS certificate: %w", err)
+	}
+	keyPEM, err := os.ReadFile(keyPath) //nolint:gosec // fixed automatic path selected from server DataDir
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("read automatic TLS key for renewal: %w", err)
+	}
+	renewed, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("validate renewed automatic TLS pair: %w", err)
+	}
+	if err := publish(certPath, certPEM); err != nil {
+		return tls.Certificate{}, err
+	}
+	slog.Info("renewed automatic TLS certificate", "cert", certPath, "key", keyPath, "identity_preserved", true)
+	return renewed, nil
+}
+
+func validateAutomaticCertificate(
+	cert tls.Certificate,
+	leaf *x509.Certificate,
+	certPath, keyPath string,
+) (*ecdsa.PrivateKey, error) {
+	if !bytes.Equal(leaf.RawSubject, leaf.RawIssuer) || leaf.CheckSignature(leaf.SignatureAlgorithm, leaf.RawTBSCertificate, leaf.Signature) != nil {
+		return nil, fmt.Errorf("automatic TLS certificate %q is not self-signed; configure managed certificates explicitly with -cert and -key", certPath)
+	}
+	privateKey, ok := cert.PrivateKey.(*ecdsa.PrivateKey)
+	if !ok || privateKey.Curve != elliptic.P256() {
+		return nil, fmt.Errorf("automatic TLS key %q is not an ECDSA P-256 key", keyPath)
+	}
+	return privateKey, nil
+}
+
+func replaceTLSCertificate(certPath string, certPEM []byte) error {
+	temp, err := prepareTLSFile(certPath, certPEM, 0o644)
+	if err != nil {
+		return fmt.Errorf("prepare renewed TLS certificate: %w", err)
+	}
+	defer func() { _ = os.Remove(temp) }()
+	if err := replaceTLSFile(temp, certPath); err != nil {
+		return fmt.Errorf("publish renewed TLS certificate: %w", err)
+	}
+	return nil
 }
 
 func publishTLSKeyPair(certPath, keyPath string, certPEM, keyPEM []byte) error {

--- a/pkg/server/tls_test.go
+++ b/pkg/server/tls_test.go
@@ -3,12 +3,21 @@ package server
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
 	"net"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 )
@@ -66,6 +75,333 @@ func TestLoadOrGenerateTLSAutoGeneratesAndReloadsSelfSignedPair(t *testing.T) {
 	}
 	if len(matches) != 0 {
 		t.Fatalf("temporary certificate files remain: %v", matches)
+	}
+}
+
+func TestLoadOrGenerateTLSRenewsAutomaticCertificateWithoutRotatingIdentity(t *testing.T) {
+	now := time.Date(2032, time.March, 14, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name      string
+		notBefore time.Time
+		notAfter  time.Time
+	}{
+		{
+			name:      "near expiry",
+			notBefore: now.Add(-24 * time.Hour),
+			notAfter:  now.Add(24 * time.Hour),
+		},
+		{
+			name:      "renewal boundary",
+			notBefore: now.Add(-24 * time.Hour),
+			notAfter:  now.Add(automaticCertRenewBefore),
+		},
+		{
+			name:      "expired",
+			notBefore: now.Add(-48 * time.Hour),
+			notAfter:  now.Add(-24 * time.Hour),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfg := DefaultConfig()
+			cfg.DataDir = dir
+			original, err := loadOrGenerateTLSAt(cfg, now.Add(-100*24*time.Hour))
+			if err != nil {
+				t.Fatalf("generate automatic pair: %v", err)
+			}
+			originalLeaf := mustParseLeaf(t, original)
+			certPath := filepath.Join(dir, generatedCertName)
+			keyPath := filepath.Join(dir, generatedKeyName)
+			keyBefore := mustReadFile(t, keyPath)
+			writeSelfSignedCertificate(t, certPath, keyBefore, tc.notBefore, tc.notAfter)
+			staleCert := mustReadFile(t, certPath)
+
+			renewed, err := loadOrGenerateTLSAt(cfg, now)
+			if err != nil {
+				t.Fatalf("renew automatic pair: %v", err)
+			}
+			renewedLeaf := mustParseLeaf(t, renewed)
+			if bytes.Equal(staleCert, mustReadFile(t, certPath)) {
+				t.Fatal("automatic certificate was not renewed")
+			}
+			if !bytes.Equal(originalLeaf.RawSubjectPublicKeyInfo, renewedLeaf.RawSubjectPublicKeyInfo) {
+				t.Fatal("automatic renewal rotated the pinned server identity")
+			}
+			if renewedLeaf.NotAfter.Sub(now) < 300*24*time.Hour {
+				t.Fatalf("renewed certificate expires too soon: %v", renewedLeaf.NotAfter)
+			}
+			requireFileEquals(t, keyPath, keyBefore)
+			requireTrustedSelfSignedHandshakeAt(t, renewed, now)
+		})
+	}
+}
+
+func TestTLSCertificateSourceRenewsWhileServerIsRunning(t *testing.T) {
+	startedAt := time.Date(2032, time.March, 14, 12, 0, 0, 0, time.UTC)
+	renewAt := startedAt.Add(340 * 24 * time.Hour)
+	dir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.DataDir = dir
+	source, err := newTLSCertificateSourceAt(cfg, startedAt)
+	if err != nil {
+		t.Fatalf("create TLS certificate source: %v", err)
+	}
+	original := source.cert
+	originalLeaf := mustParseLeaf(t, *original)
+	keyPath := filepath.Join(dir, generatedKeyName)
+	keyBefore := mustReadFile(t, keyPath)
+
+	renewed, err := source.getCertificateAt(renewAt)
+	if err != nil {
+		t.Fatalf("get certificate in renewal window: %v", err)
+	}
+	if bytes.Equal(original.Certificate[0], renewed.Certificate[0]) {
+		t.Fatal("running certificate source kept the expiring certificate")
+	}
+	renewedLeaf := mustParseLeaf(t, *renewed)
+	if !bytes.Equal(originalLeaf.RawSubjectPublicKeyInfo, renewedLeaf.RawSubjectPublicKeyInfo) {
+		t.Fatal("running renewal rotated the pinned server identity")
+	}
+	requireFileEquals(t, keyPath, keyBefore)
+	requireTrustedSelfSignedHandshakeAt(t, *renewed, renewAt)
+
+	reloaded, err := source.getCertificateAt(renewAt.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("get renewed certificate: %v", err)
+	}
+	if reloaded != renewed {
+		t.Fatal("certificate source did not cache the renewed certificate")
+	}
+}
+
+func TestTLSCertificateSourceRejectsCustomCertificateAfterExpiry(t *testing.T) {
+	startedAt := time.Date(2032, time.March, 14, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	autoCfg := DefaultConfig()
+	autoCfg.DataDir = dir
+	if _, err := loadOrGenerateTLSAt(autoCfg, startedAt); err != nil {
+		t.Fatalf("generate custom source pair: %v", err)
+	}
+	certPath := filepath.Join(dir, generatedCertName)
+	keyPath := filepath.Join(dir, generatedKeyName)
+	keyBefore := mustReadFile(t, keyPath)
+	writeSelfSignedCertificate(t, certPath, keyBefore, startedAt.Add(-time.Hour), startedAt.Add(time.Hour))
+	cfg := DefaultConfig()
+	cfg.CertFile = certPath
+	cfg.KeyFile = keyPath
+	source, err := newTLSCertificateSourceAt(cfg, startedAt)
+	if err != nil {
+		t.Fatalf("create custom TLS certificate source: %v", err)
+	}
+
+	if _, err := source.getCertificateAt(startedAt.Add(2 * time.Hour)); err == nil {
+		t.Fatal("running certificate source served an expired custom certificate")
+	}
+}
+
+func TestTLSCertificateSourceServesValidCachedCertificateWhenRenewalFails(t *testing.T) {
+	startedAt := time.Date(2032, time.March, 14, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.DataDir = dir
+	source, err := newTLSCertificateSourceAt(cfg, startedAt)
+	if err != nil {
+		t.Fatalf("create TLS certificate source: %v", err)
+	}
+	cached := source.cert
+	wantErr := errors.New("injected renewal failure")
+	source.load = func(Config, time.Time) (tls.Certificate, error) {
+		return tls.Certificate{}, wantErr
+	}
+
+	got, err := source.getCertificateAt(startedAt.Add(340 * 24 * time.Hour))
+	if err != nil {
+		t.Fatalf("serve valid cached certificate: %v", err)
+	}
+	if got != cached {
+		t.Fatal("renewal failure replaced the valid cached certificate")
+	}
+	if _, err := source.getCertificateAt(startedAt.Add(366 * 24 * time.Hour)); !errors.Is(err, wantErr) {
+		t.Fatalf("expired cached certificate error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestTLSCertificateSourcesRenewConcurrently(t *testing.T) {
+	startedAt := time.Date(2032, time.March, 14, 12, 0, 0, 0, time.UTC)
+	renewAt := startedAt.Add(340 * 24 * time.Hour)
+	dir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.DataDir = dir
+	first, err := newTLSCertificateSourceAt(cfg, startedAt)
+	if err != nil {
+		t.Fatalf("create first TLS certificate source: %v", err)
+	}
+	second, err := newTLSCertificateSourceAt(cfg, startedAt)
+	if err != nil {
+		t.Fatalf("create second TLS certificate source: %v", err)
+	}
+	originalLeaf := mustParseLeaf(t, *first.cert)
+	keyPath := filepath.Join(dir, generatedKeyName)
+	keyBefore := mustReadFile(t, keyPath)
+
+	start := make(chan struct{})
+	results := make(chan *tls.Certificate, 2)
+	errorsCh := make(chan error, 2)
+	var wg sync.WaitGroup
+	for _, source := range []*tlsCertificateSource{first, second} {
+		wg.Add(1)
+		go func(source *tlsCertificateSource) {
+			defer wg.Done()
+			<-start
+			certificate, err := source.getCertificateAt(renewAt)
+			results <- certificate
+			errorsCh <- err
+		}(source)
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errorsCh)
+	for err := range errorsCh {
+		if err != nil {
+			t.Fatalf("concurrent renewal: %v", err)
+		}
+	}
+	for certificate := range results {
+		leaf := mustParseLeaf(t, *certificate)
+		if !bytes.Equal(originalLeaf.RawSubjectPublicKeyInfo, leaf.RawSubjectPublicKeyInfo) {
+			t.Fatal("concurrent renewal rotated the pinned server identity")
+		}
+		requireTrustedSelfSignedHandshakeAt(t, *certificate, renewAt)
+	}
+	requireFileEquals(t, keyPath, keyBefore)
+	final, err := loadOrGenerateTLSAt(cfg, renewAt)
+	if err != nil {
+		t.Fatalf("load final concurrently renewed pair: %v", err)
+	}
+	finalLeaf := mustParseLeaf(t, final)
+	if !bytes.Equal(originalLeaf.RawSubjectPublicKeyInfo, finalLeaf.RawSubjectPublicKeyInfo) {
+		t.Fatal("final concurrently renewed pair changed identity")
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, ".server.crt.tmp-*"))
+	if err != nil {
+		t.Fatalf("Glob temporary files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary renewal files remain: %v", matches)
+	}
+}
+
+func TestLoadOrGenerateTLSHandlesCustomValidityWithoutModification(t *testing.T) {
+	now := time.Date(2032, time.March, 14, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name      string
+		notBefore time.Time
+		notAfter  time.Time
+		wantErr   bool
+	}{
+		{
+			name:      "near expiry remains operator managed",
+			notBefore: now.Add(-24 * time.Hour),
+			notAfter:  now.Add(24 * time.Hour),
+		},
+		{
+			name:      "expired fails closed",
+			notBefore: now.Add(-48 * time.Hour),
+			notAfter:  now.Add(-24 * time.Hour),
+			wantErr:   true,
+		},
+		{
+			name:      "not yet valid fails closed",
+			notBefore: now.Add(24 * time.Hour),
+			notAfter:  now.Add(366 * 24 * time.Hour),
+			wantErr:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			autoCfg := DefaultConfig()
+			autoCfg.DataDir = dir
+			if _, err := loadOrGenerateTLSAt(autoCfg, now.Add(-100*24*time.Hour)); err != nil {
+				t.Fatalf("generate source pair: %v", err)
+			}
+			certPath := filepath.Join(dir, generatedCertName)
+			keyPath := filepath.Join(dir, generatedKeyName)
+			keyBefore := mustReadFile(t, keyPath)
+			writeSelfSignedCertificate(t, certPath, keyBefore, tc.notBefore, tc.notAfter)
+			certBefore := mustReadFile(t, certPath)
+
+			cfg := DefaultConfig()
+			cfg.CertFile = certPath
+			cfg.KeyFile = keyPath
+			_, err := loadOrGenerateTLSAt(cfg, now)
+			if tc.wantErr && err == nil {
+				t.Fatal("invalid custom certificate pair succeeded")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("valid custom certificate pair failed: %v", err)
+			}
+			requireFileEquals(t, certPath, certBefore)
+			requireFileEquals(t, keyPath, keyBefore)
+		})
+	}
+}
+
+func TestLoadOrGenerateTLSFailedRenewalPreservesAutomaticPair(t *testing.T) {
+	now := time.Date(2032, time.March, 14, 12, 0, 0, 0, time.UTC)
+	dir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.DataDir = dir
+	if _, err := loadOrGenerateTLSAt(cfg, now.Add(-100*24*time.Hour)); err != nil {
+		t.Fatalf("generate automatic pair: %v", err)
+	}
+	certPath := filepath.Join(dir, generatedCertName)
+	keyPath := filepath.Join(dir, generatedKeyName)
+	keyBefore := mustReadFile(t, keyPath)
+	writeSelfSignedCertificate(t, certPath, keyBefore, now.Add(-24*time.Hour), now.Add(24*time.Hour))
+	certBefore := mustReadFile(t, certPath)
+	stale, err := loadTLSKeyPair(certPath, keyPath, "automatic")
+	if err != nil {
+		t.Fatalf("load stale automatic pair: %v", err)
+	}
+	leaf := mustParseLeaf(t, stale)
+	wantErr := errors.New("injected publish failure")
+	if _, err := renewAutomaticTLSWithPublisher(
+		certPath,
+		keyPath,
+		stale,
+		leaf,
+		now,
+		func(string, []byte) error { return wantErr },
+	); !errors.Is(err, wantErr) {
+		t.Fatalf("renewal error = %v, want %v", err, wantErr)
+	}
+	requireFileEquals(t, certPath, certBefore)
+	requireFileEquals(t, keyPath, keyBefore)
+}
+
+func TestReplaceTLSCertificateCleansTemporaryFileAfterPublishFailure(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, generatedCertName)
+	if err := os.Mkdir(certPath, 0o700); err != nil {
+		t.Fatalf("Mkdir destination: %v", err)
+	}
+	if err := replaceTLSCertificate(certPath, []byte("renewed certificate")); err == nil {
+		t.Fatal("replacement over a directory unexpectedly succeeded")
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, ".server.crt.tmp-*"))
+	if err != nil {
+		t.Fatalf("Glob temporary files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary renewal files remain: %v", matches)
+	}
+	info, err := os.Stat(certPath)
+	if err != nil {
+		t.Fatalf("Stat destination: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("failed replacement modified its destination")
 	}
 }
 
@@ -218,6 +554,80 @@ func TestLoadOrGenerateTLSPreservesBrokenAutoFiles(t *testing.T) {
 	}
 }
 
+func TestLoadOrGenerateTLSRejectsForeignAutomaticPairWithoutModification(t *testing.T) {
+	now := time.Date(2032, time.March, 14, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name  string
+		write func(*testing.T, string, string, time.Time)
+	}{
+		{name: "RSA self-signed pair", write: writeRSASelfSignedPair},
+		{name: "CA-issued ECDSA pair", write: writeCAIssuedECDSAPair},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			certPath := filepath.Join(dir, generatedCertName)
+			keyPath := filepath.Join(dir, generatedKeyName)
+			tc.write(t, certPath, keyPath, now)
+			certBefore := mustReadFile(t, certPath)
+			keyBefore := mustReadFile(t, keyPath)
+			cfg := DefaultConfig()
+			cfg.DataDir = dir
+
+			if _, err := loadOrGenerateTLSAt(cfg, now); err == nil {
+				t.Fatal("foreign automatic pair succeeded")
+			}
+			requireFileEquals(t, certPath, certBefore)
+			requireFileEquals(t, keyPath, keyBefore)
+		})
+	}
+}
+
+func TestLoadOrGenerateTLSPreservesInvalidCompleteAutoPair(t *testing.T) {
+	now := time.Date(2032, time.March, 14, 12, 0, 0, 0, time.UTC)
+
+	t.Run("malformed key", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := DefaultConfig()
+		cfg.DataDir = dir
+		if _, err := loadOrGenerateTLSAt(cfg, now); err != nil {
+			t.Fatalf("generate automatic pair: %v", err)
+		}
+		certPath := filepath.Join(dir, generatedCertName)
+		keyPath := filepath.Join(dir, generatedKeyName)
+		certBefore := mustReadFile(t, certPath)
+		keyBefore := []byte("broken existing automatic key\n")
+		if err := os.WriteFile(keyPath, keyBefore, 0o600); err != nil {
+			t.Fatalf("WriteFile key: %v", err)
+		}
+
+		if _, err := loadOrGenerateTLSAt(cfg, now); err == nil {
+			t.Fatal("malformed automatic pair succeeded")
+		}
+		requireFileEquals(t, certPath, certBefore)
+		requireFileEquals(t, keyPath, keyBefore)
+	})
+
+	t.Run("not yet valid", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := DefaultConfig()
+		cfg.DataDir = dir
+		if _, err := loadOrGenerateTLSAt(cfg, now); err != nil {
+			t.Fatalf("generate automatic pair: %v", err)
+		}
+		certPath := filepath.Join(dir, generatedCertName)
+		keyPath := filepath.Join(dir, generatedKeyName)
+		keyBefore := mustReadFile(t, keyPath)
+		writeSelfSignedCertificate(t, certPath, keyBefore, now.Add(24*time.Hour), now.Add(366*24*time.Hour))
+		certBefore := mustReadFile(t, certPath)
+
+		if _, err := loadOrGenerateTLSAt(cfg, now); err == nil {
+			t.Fatal("not-yet-valid automatic certificate succeeded")
+		}
+		requireFileEquals(t, certPath, certBefore)
+		requireFileEquals(t, keyPath, keyBefore)
+	})
+}
+
 func mustReadFile(t *testing.T, path string) []byte {
 	t.Helper()
 	data, err := os.ReadFile(path) //nolint:gosec // tests pass only paths inside t.TempDir
@@ -225,6 +635,131 @@ func mustReadFile(t *testing.T, path string) []byte {
 		t.Fatalf("ReadFile %s: %v", path, err)
 	}
 	return data
+}
+
+func mustParseLeaf(t *testing.T, certificate tls.Certificate) *x509.Certificate {
+	t.Helper()
+	if len(certificate.Certificate) == 0 {
+		t.Fatal("certificate chain is empty")
+	}
+	leaf, err := x509.ParseCertificate(certificate.Certificate[0])
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+	return leaf
+}
+
+func writeRSASelfSignedPair(t *testing.T, certPath, keyPath string, now time.Time) {
+	t.Helper()
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	template := testServerCertificateTemplate(t, now)
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	writePEMFile(t, certPath, "CERTIFICATE", der, 0o600)
+	writePEMFile(t, keyPath, "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(privateKey), 0o600)
+}
+
+func writeCAIssuedECDSAPair(t *testing.T, certPath, keyPath string, now time.Time) {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey CA: %v", err)
+	}
+	caTemplate := testServerCertificateTemplate(t, now)
+	caTemplate.IsCA = true
+	caTemplate.BasicConstraintsValid = true
+	caTemplate.KeyUsage = x509.KeyUsageCertSign
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate CA: %v", err)
+	}
+	caCertificate, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("ParseCertificate CA: %v", err)
+	}
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey leaf: %v", err)
+	}
+	leafTemplate := testServerCertificateTemplate(t, now)
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, caCertificate, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate leaf: %v", err)
+	}
+	privateKeyDER, err := x509.MarshalECPrivateKey(leafKey)
+	if err != nil {
+		t.Fatalf("MarshalECPrivateKey: %v", err)
+	}
+	writePEMFile(t, certPath, "CERTIFICATE", leafDER, 0o600)
+	writePEMFile(t, keyPath, "EC PRIVATE KEY", privateKeyDER, 0o600)
+}
+
+func testServerCertificateTemplate(t *testing.T, now time.Time) *x509.Certificate {
+	t.Helper()
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("generate serial: %v", err)
+	}
+	return &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{Organization: []string{"Foreign TLS Material"}},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(300 * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+	}
+}
+
+func writePEMFile(t *testing.T, path, blockType string, der []byte, mode os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der}), mode); err != nil {
+		t.Fatalf("WriteFile %s: %v", path, err)
+	}
+}
+
+func writeSelfSignedCertificate(t *testing.T, certPath string, keyPEM []byte, notBefore, notAfter time.Time) {
+	t.Helper()
+	block, _ := pem.Decode(keyPEM)
+	if block == nil {
+		t.Fatal("Decode private key PEM: no block")
+	}
+	privateKey, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("ParseECPrivateKey: %v", err)
+	}
+	writeCertificateForKey(t, certPath, privateKey, notBefore, notAfter)
+}
+
+func writeCertificateForKey(t *testing.T, certPath string, privateKey *ecdsa.PrivateKey, notBefore, notAfter time.Time) {
+	t.Helper()
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("generate serial: %v", err)
+	}
+	template := x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{Organization: []string{"GoSpeak Server"}},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile certificate: %v", err)
+	}
 }
 
 func requireFileEquals(t *testing.T, path string, want []byte) {
@@ -235,6 +770,10 @@ func requireFileEquals(t *testing.T, path string, want []byte) {
 }
 
 func requireTrustedSelfSignedHandshake(t *testing.T, certificate tls.Certificate) {
+	requireTrustedSelfSignedHandshakeAt(t, certificate, time.Now())
+}
+
+func requireTrustedSelfSignedHandshakeAt(t *testing.T, certificate tls.Certificate, now time.Time) {
 	t.Helper()
 	leaf, err := x509.ParseCertificate(certificate.Certificate[0])
 	if err != nil {
@@ -259,6 +798,7 @@ func requireTrustedSelfSignedHandshake(t *testing.T, certificate tls.Certificate
 		RootCAs:    roots,
 		ServerName: "localhost",
 		MinVersion: tls.VersionTLS13,
+		Time:       func() time.Time { return now },
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Summary

- renew automatic certificates on new TLS connections within 30 days of expiry
- keep serving a valid cached certificate if renewal temporarily fails
- preserve the private key and SPKI fingerprint
- reject foreign or damaged material at automatic certificate paths
- use durable certificate replacement on Unix and Windows