### PR TITLE
fix(client): preserve TLS trust across planes

### DIFF
--- a/pkg/client/control.go
+++ b/pkg/client/control.go
@@ -23,11 +23,11 @@ type EventHandler func(msg *pb.ControlMessage)
 
 // ControlClient manages the TCP/TLS control plane connection.
 type ControlClient struct {
-	conn           net.Conn
-	serverIdentity string
-	mu             sync.Mutex
-	handler        EventHandler
-	done           chan struct{}
+	conn        net.Conn
+	serverTrust tlsTrustPolicy
+	mu          sync.Mutex
+	handler     EventHandler
+	done        chan struct{}
 }
 
 // NewControlClient connects to the server's control plane via TLS.
@@ -55,9 +55,9 @@ func NewControlClientContext(ctx context.Context, addr, expectedPin string) (*Co
 	}
 
 	return &ControlClient{
-		conn:           conn,
-		serverIdentity: SPKIFingerprint(tlsConn.ConnectionState().PeerCertificates[0]),
-		done:           make(chan struct{}),
+		conn:        conn,
+		serverTrust: tlsTrustPolicyForConnection(expectedPin, tlsConn.ConnectionState().PeerCertificates[0]),
+		done:        make(chan struct{}),
 	}, nil
 }
 

--- a/pkg/client/engine.go
+++ b/pkg/client/engine.go
@@ -410,7 +410,7 @@ func (e *Engine) Connect(controlAddr, voiceAddr, token, username, serverPin stri
 		if resolveErr != nil {
 			return fail(fmt.Errorf("resolve screen address: %w", resolveErr))
 		}
-		screen, screenErr := NewScreenClientContext(g.ctx, screenAddr, authResp.SessionID, authResp.ScreenAuthToken, ctrl.serverIdentity)
+		screen, screenErr := newScreenClientContextWithTrust(g.ctx, screenAddr, authResp.SessionID, authResp.ScreenAuthToken, ctrl.serverTrust)
 		if screenErr != nil {
 			return fail(fmt.Errorf("connect screen plane: %w", screenErr))
 		}

--- a/pkg/client/screen.go
+++ b/pkg/client/screen.go
@@ -28,7 +28,11 @@ func NewScreenClient(addr string, sessionID uint32, authToken, serverIdentity st
 }
 
 func NewScreenClientContext(ctx context.Context, addr string, sessionID uint32, authToken, serverIdentity string) (*ScreenClient, error) {
-	tlsCfg, err := tlsConfig(addr, serverIdentity)
+	return newScreenClientContextWithTrust(ctx, addr, sessionID, authToken, tlsTrustPolicyForPin(serverIdentity))
+}
+
+func newScreenClientContextWithTrust(ctx context.Context, addr string, sessionID uint32, authToken string, trust tlsTrustPolicy) (*ScreenClient, error) {
+	tlsCfg, err := newTLSConfigWithTrust(addr, trust, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/tlstrust.go
+++ b/pkg/client/tlstrust.go
@@ -33,6 +33,32 @@ func (e *ServerIdentityChangedError) Error() string {
 	return fmt.Sprintf("server identity changed for %s (expected %s, received %s)", e.Addr, e.Expected, e.Received)
 }
 
+type tlsTrustMode uint8
+
+const (
+	tlsTrustSystemPKI tlsTrustMode = iota
+	tlsTrustTOFU
+)
+
+type tlsTrustPolicy struct {
+	mode tlsTrustMode
+	pin  string
+}
+
+func tlsTrustPolicyForPin(expectedPin string) tlsTrustPolicy {
+	if expectedPin == "" {
+		return tlsTrustPolicy{mode: tlsTrustSystemPKI}
+	}
+	return tlsTrustPolicy{mode: tlsTrustTOFU, pin: expectedPin}
+}
+
+func tlsTrustPolicyForConnection(expectedPin string, peer *x509.Certificate) tlsTrustPolicy {
+	if expectedPin == "" {
+		return tlsTrustPolicy{mode: tlsTrustSystemPKI}
+	}
+	return tlsTrustPolicy{mode: tlsTrustTOFU, pin: SPKIFingerprint(peer)}
+}
+
 // SPKIFingerprint returns a stable SHA-256 fingerprint of a certificate's
 // SubjectPublicKeyInfo. Pinning the public key tolerates certificate renewal
 // with the same key while detecting an unexpected server identity.
@@ -42,6 +68,10 @@ func SPKIFingerprint(cert *x509.Certificate) string {
 }
 
 func newTLSConfig(addr, expectedPin string, roots *x509.CertPool) (*tls.Config, error) {
+	return newTLSConfigWithTrust(addr, tlsTrustPolicyForPin(expectedPin), roots)
+}
+
+func newTLSConfigWithTrust(addr string, trust tlsTrustPolicy, roots *x509.CertPool) (*tls.Config, error) {
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		return nil, fmt.Errorf("client: invalid TLS address %q: %w", addr, err)
@@ -61,9 +91,9 @@ func newTLSConfig(addr, expectedPin string, roots *x509.CertPool) (*tls.Config, 
 		leaf := state.PeerCertificates[0]
 		fingerprint := SPKIFingerprint(leaf)
 
-		if expectedPin != "" {
-			if fingerprint != expectedPin {
-				return &ServerIdentityChangedError{Addr: addr, Expected: expectedPin, Received: fingerprint}
+		if trust.mode == tlsTrustTOFU {
+			if fingerprint != trust.pin {
+				return &ServerIdentityChangedError{Addr: addr, Expected: trust.pin, Received: fingerprint}
 			}
 			pinnedRoots := x509.NewCertPool()
 			pinnedRoots.AddCert(leaf)

--- a/pkg/client/tlstrust_test.go
+++ b/pkg/client/tlstrust_test.go
@@ -85,6 +85,48 @@ func TestTLSConfigRejectsExpiredPinnedCertificate(t *testing.T) {
 	}
 }
 
+func TestCrossPlaneTLSSystemPKIUsesScreenHostnameVerification(t *testing.T) {
+	root, rootKey := newTestCertificate(t, nil, nil, true, "root", time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	controlLeaf, _ := newTestCertificate(t, root, rootKey, false, "server.test", time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	screenLeaf, _ := newTestCertificate(t, root, rootKey, false, "server.test", time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	roots := x509.NewCertPool()
+	roots.AddCert(root)
+
+	trust := tlsTrustPolicyForConnection("", controlLeaf)
+	cfg, err := newTLSConfigWithTrust("server.test:9603", trust, roots)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.VerifyConnection(connectionState(screenLeaf, root)); err != nil {
+		t.Fatalf("screen VerifyConnection() = %v, want system-PKI certificate accepted", err)
+	}
+
+	wrongHostLeaf, _ := newTestCertificate(t, root, rootKey, false, "other.test", time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	if err := cfg.VerifyConnection(connectionState(wrongHostLeaf, root)); err == nil {
+		t.Fatal("screen VerifyConnection() = nil, want hostname mismatch rejected")
+	}
+}
+
+func TestCrossPlaneTLSTOFUPreservesConfirmedPin(t *testing.T) {
+	controlLeaf, _ := newTestCertificate(t, nil, nil, true, "private.test", time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	changedLeaf, _ := newTestCertificate(t, nil, nil, true, "private.test", time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+
+	trust := tlsTrustPolicyForConnection(SPKIFingerprint(controlLeaf), controlLeaf)
+	cfg, err := newTLSConfigWithTrust("private.test:9603", trust, x509.NewCertPool())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.VerifyConnection(connectionState(controlLeaf)); err != nil {
+		t.Fatalf("screen VerifyConnection() = %v, want confirmed TOFU pin accepted", err)
+	}
+
+	err = cfg.VerifyConnection(connectionState(changedLeaf))
+	var changed *ServerIdentityChangedError
+	if !errors.As(err, &changed) {
+		t.Fatalf("screen VerifyConnection() error = %v, want ServerIdentityChangedError", err)
+	}
+}
+
 func connectionState(certs ...*x509.Certificate) tls.ConnectionState {
 	return tls.ConnectionState{PeerCertificates: certs}
 }


### PR DESCRIPTION
## Summary
- preserve system PKI and hostname verification when opening the screen connection
- use SPKI pinning only when the control connection was trusted through TOFU
- reject changed TOFU pins and screen certificate hostname mismatches
- add deterministic PKI and TOFU tests across both connections
- keep the change client-only and wire-compatible