### PR TITLE
fix(server): preserve pre-auth capacity across clients

### DIFF
--- a/pkg/server/preauth_test.go
+++ b/pkg/server/preauth_test.go
@@ -11,6 +11,13 @@ type testAddr string
 func (a testAddr) Network() string { return "tcp" }
 func (a testAddr) String() string  { return string(a) }
 
+type remoteAddrConn struct {
+	net.Conn
+	remote net.Addr
+}
+
+func (c remoteAddrConn) RemoteAddr() net.Addr { return c.remote }
+
 func TestAuthRateLimiterNormalizesSourcePorts(t *testing.T) {
 	limiter := newAuthRateLimiter(2, time.Minute)
 	first := authRateLimitKey(testAddr("192.0.2.10:41000"))
@@ -124,6 +131,94 @@ func TestPreAuthConnectionsAreBoundedAndClosedOnShutdown(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPreAuthAdmissionPreservesCapacityAcrossClientIPs(t *testing.T) {
+	for _, plane := range []preAuthPlane{preAuthControl, preAuthScreen} {
+		t.Run(string(plane), func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.MaxPreAuthConnections = 10
+			srv := New(cfg, Dependencies{})
+			t.Cleanup(srv.Shutdown)
+
+			connections := make([]net.Conn, 0, cfg.MaxPreAuthConnections*2)
+			admit := func(ip string) bool {
+				serverConn, clientConn := net.Pipe()
+				connections = append(connections, clientConn)
+				conn := remoteAddrConn{Conn: serverConn, remote: testAddr(net.JoinHostPort(ip, "41000"))}
+				if !srv.beginPreAuth(conn, plane) {
+					_ = serverConn.Close()
+					return false
+				}
+				connections = append(connections, conn)
+				return true
+			}
+			t.Cleanup(func() {
+				for _, conn := range connections {
+					_ = conn.Close()
+				}
+			})
+
+			attackerAccepted := 0
+			for range 9 {
+				if admit("192.0.2.10") {
+					attackerAccepted++
+				}
+			}
+			if attackerAccepted != 8 {
+				t.Errorf("connections admitted for one IP = %d, want 8", attackerAccepted)
+			}
+			if !admit("198.51.100.20") {
+				t.Error("connection from a second IP rejected despite reserved global capacity")
+			}
+			if !admit("203.0.113.30") {
+				t.Error("connection up to the global capacity rejected")
+			}
+			if admit("203.0.113.31") {
+				t.Error("connection above the global capacity accepted")
+			}
+		})
+	}
+}
+
+func TestPreAuthPerIPCapacityIsReleased(t *testing.T) {
+	cfg := DefaultConfig()
+	srv := New(cfg, Dependencies{})
+	t.Cleanup(srv.Shutdown)
+
+	connections := make([]net.Conn, 0, maxPreAuthConnectionsPerIP*2+2)
+	newConn := func() remoteAddrConn {
+		serverConn, clientConn := net.Pipe()
+		connections = append(connections, clientConn)
+		return remoteAddrConn{Conn: serverConn, remote: testAddr("192.0.2.10:41000")}
+	}
+	t.Cleanup(func() {
+		for _, conn := range connections {
+			_ = conn.Close()
+		}
+	})
+
+	admitted := make([]remoteAddrConn, 0, maxPreAuthConnectionsPerIP)
+	for range maxPreAuthConnectionsPerIP {
+		conn := newConn()
+		if !srv.beginPreAuth(conn, preAuthControl) {
+			t.Fatal("connection below the per-IP capacity rejected")
+		}
+		connections = append(connections, conn)
+		admitted = append(admitted, conn)
+	}
+	rejected := newConn()
+	if srv.beginPreAuth(rejected, preAuthControl) {
+		t.Fatal("connection above the per-IP capacity accepted")
+	}
+	_ = rejected.Close()
+
+	srv.finishPreAuth(admitted[0])
+	replacement := newConn()
+	if !srv.beginPreAuth(replacement, preAuthControl) {
+		t.Fatal("authentication did not release per-IP pre-auth capacity")
+	}
+	connections = append(connections, replacement)
 }
 
 func TestAuthenticatedConnectionReleasesPreAuthSlotAndClosesOnShutdown(t *testing.T) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -87,6 +87,7 @@ type Server struct {
 	preAuthMu       sync.Mutex
 	acceptedConns   map[net.Conn]trackedConn
 	preAuthCount    map[preAuthPlane]int
+	preAuthByIP     map[preAuthPlane]map[string]int
 
 	// Per-session voice debug counters (reset each debug interval; only used when debug is enabled)
 	voiceDebugEnabled bool
@@ -118,6 +119,7 @@ func New(cfg Config, deps Dependencies) *Server {
 		authLimiter:   newAuthRateLimiter(authRateLimitAttempts, authRateLimitWindow),
 		acceptedConns: make(map[net.Conn]trackedConn),
 		preAuthCount:  make(map[preAuthPlane]int),
+		preAuthByIP:   make(map[preAuthPlane]map[string]int),
 		ctx:           ctx,
 		cancel:        cancel,
 	}
@@ -165,13 +167,18 @@ func (s *Server) trackHTTPHandler(handler http.Handler) http.Handler {
 type preAuthPlane string
 
 type trackedConn struct {
-	plane   preAuthPlane
-	preAuth bool
+	plane        preAuthPlane
+	preAuth      bool
+	admissionKey string
 }
 
 const (
 	preAuthControl preAuthPlane = "control"
 	preAuthScreen  preAuthPlane = "screen"
+
+	// Leave most of the default global capacity available to other source IPs
+	// while allowing several concurrent users behind one NAT.
+	maxPreAuthConnectionsPerIP = 8
 )
 
 func (s *Server) beginPreAuth(conn net.Conn, plane preAuthPlane) bool {
@@ -180,12 +187,27 @@ func (s *Server) beginPreAuth(conn net.Conn, plane preAuthPlane) bool {
 	if _, ok := s.acceptedConns[conn]; ok {
 		return true
 	}
-	if s.ctx.Err() != nil || s.preAuthCount[plane] >= s.cfg.MaxPreAuthConnections {
+	admissionKey := authRateLimitKey(conn.RemoteAddr())
+	if s.ctx.Err() != nil ||
+		s.preAuthCount[plane] >= s.cfg.MaxPreAuthConnections ||
+		s.preAuthByIP[plane][admissionKey] >= maxPreAuthConnectionsPerIP {
 		return false
 	}
-	s.acceptedConns[conn] = trackedConn{plane: plane, preAuth: true}
+	if s.preAuthByIP[plane] == nil {
+		s.preAuthByIP[plane] = make(map[string]int)
+	}
+	s.acceptedConns[conn] = trackedConn{plane: plane, preAuth: true, admissionKey: admissionKey}
 	s.preAuthCount[plane]++
+	s.preAuthByIP[plane][admissionKey]++
 	return true
+}
+
+func (s *Server) releasePreAuth(tracked trackedConn) {
+	s.preAuthCount[tracked.plane]--
+	s.preAuthByIP[tracked.plane][tracked.admissionKey]--
+	if s.preAuthByIP[tracked.plane][tracked.admissionKey] == 0 {
+		delete(s.preAuthByIP[tracked.plane], tracked.admissionKey)
+	}
 }
 
 func (s *Server) finishPreAuth(conn net.Conn) {
@@ -193,7 +215,7 @@ func (s *Server) finishPreAuth(conn net.Conn) {
 	if tracked, ok := s.acceptedConns[conn]; ok && tracked.preAuth {
 		tracked.preAuth = false
 		s.acceptedConns[conn] = tracked
-		s.preAuthCount[tracked.plane]--
+		s.releasePreAuth(tracked)
 	}
 	s.preAuthMu.Unlock()
 }
@@ -203,7 +225,7 @@ func (s *Server) forgetAcceptedConn(conn net.Conn) {
 	if tracked, ok := s.acceptedConns[conn]; ok {
 		delete(s.acceptedConns, conn)
 		if tracked.preAuth {
-			s.preAuthCount[tracked.plane]--
+			s.releasePreAuth(tracked)
 		}
 	}
 	s.preAuthMu.Unlock()
@@ -217,6 +239,7 @@ func (s *Server) closeAcceptedConns() {
 	}
 	s.acceptedConns = make(map[net.Conn]trackedConn)
 	s.preAuthCount = make(map[preAuthPlane]int)
+	s.preAuthByIP = make(map[preAuthPlane]map[string]int)
 	s.preAuthMu.Unlock()
 	for _, conn := range conns {
 		_ = conn.Close()


### PR DESCRIPTION
## Summary
- limit each normalized source IP to eight simultaneous pre-auth connections per network plane
- retain the global 64-connection limit for both control and screen traffic
- release global and per-IP capacity after authentication, disconnect, or shutdown
- add deterministic tests for abusive sources, healthy clients, global saturation, and capacity release