### PR TITLE
feat(server): add security capacity observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,15 @@ docker compose -f compose.yaml -f compose.monitoring.yaml up -d
 ```
 
 Grafana is then available only on `127.0.0.1:3000`. Prometheus is not published
-on the host.
+on the host. The bundled dashboard shows current and startup-lifetime high-water
+utilization for pre-auth admission, authentication, and account provisioning.
+Authentication usage is failed attempts plus in-flight checks against the
+30-attempt, one-minute source window; provisioning usage is successful creations
+plus in-flight reservations against the 120-account, one-hour source window.
+The rejection chart distinguishes source exhaustion, tracker capacity, and
+in-flight window transitions without exposing source identities as labels. The
+75% yellow and 90% red thresholds are dashboard guidance, not configured alerts;
+high-water values reset when the server restarts.
 
 On first run, GoSpeak writes an admin bootstrap credential to
 `bootstrap-admin.token` in the data directory. For this Compose setup, read it

--- a/docs/grafana-dashboard.json
+++ b/docs/grafana-dashboard.json
@@ -360,6 +360,212 @@
         },
         "overrides": []
       }
+    },
+    {
+      "type": "row",
+      "title": "Capacity and abuse",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "gauge",
+      "title": "Pre-auth global utilization",
+      "gridPos": { "h": 7, "w": 6, "x": 0, "y": 33 },
+      "targets": [
+        {
+          "expr": "100 * gospeak_preauth_connections / gospeak_preauth_connection_limit",
+          "legendFormat": "{{plane}} current",
+          "refId": "A"
+        },
+        {
+          "expr": "100 * gospeak_preauth_connections_high_water / gospeak_preauth_connection_limit",
+          "legendFormat": "{{plane}} high water",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 75 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "gauge",
+      "title": "Busiest pre-auth source",
+      "gridPos": { "h": 7, "w": 6, "x": 6, "y": 33 },
+      "targets": [
+        {
+          "expr": "100 * gospeak_preauth_source_max_connections / gospeak_preauth_source_connection_limit",
+          "legendFormat": "{{plane}} current",
+          "refId": "A"
+        },
+        {
+          "expr": "100 * gospeak_preauth_source_max_connections_high_water / gospeak_preauth_source_connection_limit",
+          "legendFormat": "{{plane}} high water",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 75 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "gauge",
+      "title": "Authentication budget",
+      "gridPos": { "h": 7, "w": 6, "x": 12, "y": 33 },
+      "targets": [
+        {
+          "expr": "100 * gospeak_auth_rate_limit_source_max_usage / gospeak_auth_rate_limit_source_limit",
+          "legendFormat": "current busiest source",
+          "refId": "A"
+        },
+        {
+          "expr": "100 * gospeak_auth_rate_limit_source_high_water_usage / gospeak_auth_rate_limit_source_limit",
+          "legendFormat": "high water",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 75 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "gauge",
+      "title": "Account provisioning budget",
+      "gridPos": { "h": 7, "w": 6, "x": 18, "y": 33 },
+      "targets": [
+        {
+          "expr": "100 * gospeak_account_provisioning_source_max_usage / gospeak_account_provisioning_source_limit",
+          "legendFormat": "current busiest source",
+          "refId": "A"
+        },
+        {
+          "expr": "100 * gospeak_account_provisioning_source_high_water_usage / gospeak_account_provisioning_source_limit",
+          "legendFormat": "high water",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 75 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Capacity rejections / min",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "targets": [
+        {
+          "expr": "sum by (plane, reason) (rate(gospeak_preauth_rejections_total[5m])) * 60",
+          "legendFormat": "pre-auth {{plane}} {{reason}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (reason) (rate(gospeak_auth_rate_limit_rejections_total[5m])) * 60",
+          "legendFormat": "authentication {{reason}}",
+          "refId": "B"
+        },
+        {
+          "expr": "sum by (reason) (rate(gospeak_account_provisioning_rejections_total[5m])) * 60",
+          "legendFormat": "account provisioning {{reason}}",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Tracked source keys and capacity",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "targets": [
+        {
+          "expr": "gospeak_preauth_active_sources",
+          "legendFormat": "pre-auth {{plane}}",
+          "refId": "A"
+        },
+        {
+          "expr": "gospeak_auth_rate_limit_active_sources",
+          "legendFormat": "authentication",
+          "refId": "B"
+        },
+        {
+          "expr": "gospeak_account_provisioning_active_sources",
+          "legendFormat": "account provisioning",
+          "refId": "C"
+        },
+        {
+          "expr": "gospeak_auth_rate_limit_tracker_limit",
+          "legendFormat": "authentication capacity",
+          "refId": "D"
+        },
+        {
+          "expr": "gospeak_account_provisioning_tracker_limit",
+          "legendFormat": "account provisioning capacity",
+          "refId": "E"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "fillOpacity": 10 }
+        },
+        "overrides": []
+      }
     }
   ],
   "schemaVersion": 39,
@@ -370,5 +576,5 @@
   "timezone": "browser",
   "title": "GoSpeak Server",
   "uid": "gospeak-server",
-  "version": 2
+  "version": 3
 }

--- a/pkg/server/account_provisioning_test.go
+++ b/pkg/server/account_provisioning_test.go
@@ -40,6 +40,29 @@ func authenticateControl(t *testing.T, srv *Server, st datastore.DataProviderFac
 	return response
 }
 
+func expectControlRejectedBeforeAuth(t *testing.T, srv *Server, st datastore.DataProviderFactory) {
+	t.Helper()
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		srv.handleControlConn(newControlHandler(srv, st), serverConn, st)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		_ = clientConn.Close()
+		t.Fatal("control handler did not reject before authentication")
+	}
+	var one [1]byte
+	if _, err := clientConn.Read(one[:]); err == nil {
+		_ = clientConn.Close()
+		t.Fatal("rejected control connection remained readable")
+	}
+	_ = clientConn.Close()
+}
+
 func TestInviteProvisioningRollsBackUseWhenUsernameIsTaken(t *testing.T) {
 	srv, st, _ := newTestServer(t)
 	if _, err := st.NonTx().CreateUser("taken", model.RoleUser); err != nil {
@@ -128,6 +151,68 @@ func TestAuthenticationFailuresDoNotRevealUsernameState(t *testing.T) {
 	}
 }
 
+func TestAuthenticationNonSourceRejectionsAreCountedThroughControlPath(t *testing.T) {
+	t.Run("tracker capacity", func(t *testing.T) {
+		srv, st, _ := newTestServer(t)
+		srv.authLimiter = newAuthRateLimiter(3, time.Minute)
+		srv.authLimiter.maxEntries = 1
+		if !srv.authLimiter.Allow("occupied") {
+			t.Fatal("failed to occupy authentication tracker")
+		}
+
+		expectControlRejectedBeforeAuth(t, srv, st)
+		if got := srv.metrics.AuthRateLimitTrackerRejections.Load(); got != 1 {
+			t.Fatalf("authentication tracker rejections = %d, want 1", got)
+		}
+		if got := srv.metrics.AuthRateLimitSourceRejections.Load() + srv.metrics.AuthRateLimitWindowRejections.Load(); got != 0 {
+			t.Fatalf("other authentication rejection counters = %d, want 0", got)
+		}
+	})
+
+	t.Run("window transition", func(t *testing.T) {
+		srv, st, _ := newTestServer(t)
+		now := time.Unix(1_700_000_000, 0)
+		srv.authLimiter = newAuthRateLimiter(3, time.Minute)
+		srv.authLimiter.now = func() time.Time { return now }
+		if !srv.authLimiter.Allow("pipe") {
+			t.Fatal("failed to reserve authentication window")
+		}
+		now = now.Add(time.Minute)
+
+		expectControlRejectedBeforeAuth(t, srv, st)
+		if got := srv.metrics.AuthRateLimitWindowRejections.Load(); got != 1 {
+			t.Fatalf("authentication window rejections = %d, want 1", got)
+		}
+		if got := srv.metrics.AuthRateLimitSourceRejections.Load() + srv.metrics.AuthRateLimitTrackerRejections.Load(); got != 0 {
+			t.Fatalf("other authentication rejection counters = %d, want 0", got)
+		}
+	})
+}
+
+func TestOpenModeProvisioningTrackerRejectionIsCountedThroughControlPath(t *testing.T) {
+	srv, st, _ := newTestServer(t)
+	srv.cfg.AllowNoToken = true
+	srv.accountProvisionLimiter = newAccountProvisionLimiter(2, time.Hour)
+	srv.accountProvisionLimiter.maxEntries = 1
+	if !srv.accountProvisionLimiter.Reserve("occupied") {
+		t.Fatal("failed to occupy provisioning tracker")
+	}
+
+	response := authenticateControl(t, srv, st, "blocked", "")
+	if response.ErrorResponse == nil || response.ErrorResponse.Message != "authentication failed" {
+		t.Fatalf("provisioning tracker rejection response = %#v", response)
+	}
+	if got := srv.metrics.AccountProvisionTrackerRejections.Load(); got != 1 {
+		t.Fatalf("account provisioning tracker rejections = %d, want 1", got)
+	}
+	if got := srv.metrics.AccountProvisionSourceRejections.Load() + srv.metrics.AccountProvisionWindowRejections.Load(); got != 0 {
+		t.Fatalf("other account provisioning rejection counters = %d, want 0", got)
+	}
+	if user, err := st.NonTx().GetUserByUsername("blocked"); err != nil || user != nil {
+		t.Fatalf("tracker-rejected account persisted: user=%#v err=%v", user, err)
+	}
+}
+
 func TestOpenModeAccountProvisioningBudgetIsEnforced(t *testing.T) {
 	srv, st, _ := newTestServer(t)
 	srv.cfg.AllowNoToken = true
@@ -143,5 +228,11 @@ func TestOpenModeAccountProvisioningBudgetIsEnforced(t *testing.T) {
 	}
 	if user, err := st.NonTx().GetUserByUsername("second"); err != nil || user != nil {
 		t.Fatalf("rate-limited account persisted: user=%#v err=%v", user, err)
+	}
+	if got := srv.metrics.AccountProvisionSourceRejections.Load(); got != 1 {
+		t.Fatalf("account provisioning rejection metric = %d, want 1", got)
+	}
+	if got := srv.metrics.AccountProvisionSourceHighWater.Load(); got != 1 {
+		t.Fatalf("account provisioning source high-water mark = %d, want 1", got)
 	}
 }

--- a/pkg/server/capacity_observability.go
+++ b/pkg/server/capacity_observability.go
@@ -1,0 +1,207 @@
+package server
+
+import (
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"time"
+)
+
+const capacityLogInterval = 10 * time.Second
+
+type capacityUsageSnapshot struct {
+	maxUsage      int
+	activeSources int
+	sourceLimit   int
+	trackerLimit  int
+}
+
+type preAuthCapacitySnapshot struct {
+	current       map[preAuthPlane]int
+	maxBySource   map[preAuthPlane]int
+	activeSources map[preAuthPlane]int
+}
+
+func storeHighWater(mark *atomic.Int64, value int) {
+	candidate := int64(value)
+	for current := mark.Load(); candidate > current; current = mark.Load() {
+		if mark.CompareAndSwap(current, candidate) {
+			return
+		}
+	}
+}
+
+func (s *Server) observePreAuthUsage(plane preAuthPlane, current, sourceCurrent int) {
+	if plane == preAuthControl {
+		storeHighWater(&s.metrics.PreAuthControlHighWater, current)
+		storeHighWater(&s.metrics.PreAuthControlSourceHighWater, sourceCurrent)
+		return
+	}
+	storeHighWater(&s.metrics.PreAuthScreenHighWater, current)
+	storeHighWater(&s.metrics.PreAuthScreenSourceHighWater, sourceCurrent)
+}
+
+func (s *Server) preAuthCapacitySnapshot() preAuthCapacitySnapshot {
+	s.preAuthMu.Lock()
+	defer s.preAuthMu.Unlock()
+
+	snapshot := preAuthCapacitySnapshot{
+		current:       make(map[preAuthPlane]int, 2),
+		maxBySource:   make(map[preAuthPlane]int, 2),
+		activeSources: make(map[preAuthPlane]int, 2),
+	}
+	for _, plane := range []preAuthPlane{preAuthControl, preAuthScreen} {
+		snapshot.current[plane] = s.preAuthCount[plane]
+		snapshot.activeSources[plane] = len(s.preAuthByIP[plane])
+		for _, count := range s.preAuthByIP[plane] {
+			if count > snapshot.maxBySource[plane] {
+				snapshot.maxBySource[plane] = count
+			}
+		}
+	}
+	return snapshot
+}
+
+func (rl *authRateLimiter) usageSnapshot() capacityUsageSnapshot {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := rl.now()
+	snapshot := capacityUsageSnapshot{
+		sourceLimit:  rl.maxAttempts,
+		trackerLimit: rl.maxEntries,
+	}
+	for _, entry := range rl.entries {
+		if !now.Before(entry.resetAt) && entry.inFlight == 0 {
+			continue
+		}
+		snapshot.activeSources++
+		if usage := entry.count + entry.inFlight; usage > snapshot.maxUsage {
+			snapshot.maxUsage = usage
+		}
+	}
+	return snapshot
+}
+
+func (rl *accountProvisionLimiter) usageSnapshot() capacityUsageSnapshot {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := rl.now()
+	snapshot := capacityUsageSnapshot{
+		sourceLimit:  rl.maxSuccess,
+		trackerLimit: rl.maxEntries,
+	}
+	for _, entry := range rl.entries {
+		if !now.Before(entry.resetAt) && entry.inFlight == 0 {
+			continue
+		}
+		snapshot.activeSources++
+		if usage := entry.successes + entry.inFlight; usage > snapshot.maxUsage {
+			snapshot.maxUsage = usage
+		}
+	}
+	return snapshot
+}
+
+func (s *Server) allowAuthWithObservability(key string) (allowed bool, reason string, current, limit int) {
+	s.authLimiter.mu.Lock()
+	defer s.authLimiter.mu.Unlock()
+	allowed, reason, current, limit = s.authLimiter.allowWithDetailsLocked(key)
+	if allowed {
+		storeHighWater(&s.metrics.AuthRateLimitSourceHighWater, current)
+	}
+	return
+}
+
+func (s *Server) reserveAccountWithObservability(key string) (reserved bool, reason string, current, limit int) {
+	s.accountProvisionLimiter.mu.Lock()
+	defer s.accountProvisionLimiter.mu.Unlock()
+	reserved, reason, current, limit = s.accountProvisionLimiter.reserveWithDetailsLocked(key)
+	if reserved {
+		storeHighWater(&s.metrics.AccountProvisionSourceHighWater, current)
+	}
+	return
+}
+
+func (s *Server) recordAuthRateLimitRejection(remote, reason string, current, limit int) {
+	switch reason {
+	case "source":
+		s.metrics.AuthRateLimitSourceRejections.Add(1)
+	case "tracker_capacity":
+		s.metrics.AuthRateLimitTrackerRejections.Add(1)
+	case "window_transition":
+		s.metrics.AuthRateLimitWindowRejections.Add(1)
+	default:
+		return
+	}
+	s.logCapacityLimit("auth", "", reason, remote, current, limit)
+}
+
+func (s *Server) recordAccountProvisionRejection(remote, reason string, current, limit int) {
+	switch reason {
+	case "source":
+		s.metrics.AccountProvisionSourceRejections.Add(1)
+	case "tracker_capacity":
+		s.metrics.AccountProvisionTrackerRejections.Add(1)
+	case "window_transition":
+		s.metrics.AccountProvisionWindowRejections.Add(1)
+	default:
+		return
+	}
+	s.logCapacityLimit("account_provisioning", "", reason, remote, current, limit)
+}
+
+func (s *Server) recordPreAuthRejection(plane preAuthPlane, reason, remote string, current, limit int) {
+	switch {
+	case plane == preAuthControl && reason == "global":
+		s.metrics.PreAuthControlGlobalRejections.Add(1)
+	case plane == preAuthControl && reason == "source":
+		s.metrics.PreAuthControlSourceRejections.Add(1)
+	case plane == preAuthScreen && reason == "global":
+		s.metrics.PreAuthScreenGlobalRejections.Add(1)
+	case plane == preAuthScreen && reason == "source":
+		s.metrics.PreAuthScreenSourceRejections.Add(1)
+	default:
+		return
+	}
+	s.logCapacityLimit("preauth", string(plane), reason, remote, current, limit)
+}
+
+// logCapacityLimit logs the first rejection immediately and then at most once
+// per interval for each bounded kind/plane/reason tuple. Metrics still count
+// every rejection, so an attacker cannot amplify logs by repeatedly hitting a
+// limit.
+func (s *Server) logCapacityLimit(kind, plane, reason, remote string, current, limit int) {
+	now := time.Now()
+	if s.capacityLogNow != nil {
+		now = s.capacityLogNow()
+	}
+	key := fmt.Sprintf("%s|%s|%s", kind, plane, reason)
+
+	s.capacityLogMu.Lock()
+	last := s.capacityLogLast[key]
+	elapsed := now.Sub(last)
+	if !last.IsZero() && elapsed >= 0 && elapsed < capacityLogInterval {
+		s.capacityLogDrop[key]++
+		s.capacityLogMu.Unlock()
+		return
+	}
+	suppressed := s.capacityLogDrop[key]
+	s.capacityLogLast[key] = now
+	s.capacityLogDrop[key] = 0
+	s.capacityLogMu.Unlock()
+
+	attrs := []any{
+		"kind", kind,
+		"reason", reason,
+		"remote", remote,
+		"current", current,
+		"limit", limit,
+		"suppressed", suppressed,
+	}
+	if plane != "" {
+		attrs = append(attrs, "plane", plane)
+	}
+	slog.Warn("capacity limit reached", attrs...)
+}

--- a/pkg/server/capacity_observability_test.go
+++ b/pkg/server/capacity_observability_test.go
@@ -1,0 +1,343 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPreAuthCapacityMetricsTrackOccupancyAndRejections(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxPreAuthConnections = 2
+	srv := New(cfg, Dependencies{})
+
+	newConn := func(address string) remoteAddrConn {
+		server, client := net.Pipe()
+		t.Cleanup(func() {
+			_ = server.Close()
+			_ = client.Close()
+		})
+		return remoteAddrConn{Conn: server, remote: testAddr(address)}
+	}
+
+	first := newConn("192.0.2.10:41000")
+	second := newConn("192.0.2.10:41001")
+	if !srv.beginPreAuth(first, preAuthControl) || !srv.beginPreAuth(second, preAuthControl) {
+		t.Fatal("connections below global pre-auth limit were rejected")
+	}
+
+	snapshot := srv.preAuthCapacitySnapshot()
+	if got := snapshot.current[preAuthControl]; got != 2 {
+		t.Fatalf("current control occupancy = %d, want 2", got)
+	}
+	if got := snapshot.maxBySource[preAuthControl]; got != 2 {
+		t.Fatalf("busiest control source occupancy = %d, want 2", got)
+	}
+	if got := srv.metrics.PreAuthControlHighWater.Load(); got != 2 {
+		t.Fatalf("control occupancy high-water mark = %d, want 2", got)
+	}
+	if got := srv.metrics.PreAuthControlSourceHighWater.Load(); got != 2 {
+		t.Fatalf("control source high-water mark = %d, want 2", got)
+	}
+
+	globalRejected := newConn("198.51.100.20:42000")
+	if srv.admitPreAuthConn(globalRejected, preAuthControl) {
+		t.Fatal("connection above global pre-auth limit was accepted")
+	}
+	if got := srv.metrics.PreAuthControlGlobalRejections.Load(); got != 1 {
+		t.Fatalf("control global pre-auth rejections = %d, want 1", got)
+	}
+
+	srv.forgetAcceptedConn(first)
+	snapshot = srv.preAuthCapacitySnapshot()
+	if got := snapshot.current[preAuthControl]; got != 1 {
+		t.Fatalf("control pre-auth occupancy after release = %d, want 1", got)
+	}
+	if got := snapshot.maxBySource[preAuthControl]; got != 1 {
+		t.Fatalf("control busiest-source occupancy after release = %d, want 1", got)
+	}
+	if got := srv.metrics.PreAuthControlHighWater.Load(); got != 2 {
+		t.Fatalf("control occupancy high-water mark after release = %d, want 2", got)
+	}
+}
+
+func TestPreAuthRejectionCounterMatrix(t *testing.T) {
+	tests := []struct {
+		name    string
+		plane   preAuthPlane
+		reason  string
+		counter func(*Metrics) int64
+	}{
+		{name: "control global", plane: preAuthControl, reason: "global", counter: func(m *Metrics) int64 { return m.PreAuthControlGlobalRejections.Load() }},
+		{name: "control source", plane: preAuthControl, reason: "source", counter: func(m *Metrics) int64 { return m.PreAuthControlSourceRejections.Load() }},
+		{name: "screen global", plane: preAuthScreen, reason: "global", counter: func(m *Metrics) int64 { return m.PreAuthScreenGlobalRejections.Load() }},
+		{name: "screen source", plane: preAuthScreen, reason: "source", counter: func(m *Metrics) int64 { return m.PreAuthScreenSourceRejections.Load() }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			fill := 1
+			if tt.reason == "global" {
+				cfg.MaxPreAuthConnections = 1
+			} else {
+				cfg.MaxPreAuthConnections = maxPreAuthConnectionsPerIP + 1
+				fill = maxPreAuthConnectionsPerIP
+			}
+			srv := New(cfg, Dependencies{})
+
+			newConn := func(address string) remoteAddrConn {
+				server, client := net.Pipe()
+				t.Cleanup(func() {
+					_ = server.Close()
+					_ = client.Close()
+				})
+				return remoteAddrConn{Conn: server, remote: testAddr(address)}
+			}
+			for i := range fill {
+				conn := newConn(fmt.Sprintf("192.0.2.10:%d", 41000+i))
+				if !srv.beginPreAuth(conn, tt.plane) {
+					t.Fatalf("setup connection %d rejected", i+1)
+				}
+			}
+			rejectedAddress := "192.0.2.10:49999"
+			if tt.reason == "global" {
+				rejectedAddress = "198.51.100.20:49999"
+			}
+			if srv.admitPreAuthConn(newConn(rejectedAddress), tt.plane) {
+				t.Fatalf("%s rejection was accepted", tt.reason)
+			}
+			if got := tt.counter(srv.metrics); got != 1 {
+				t.Fatalf("%s/%s rejection counter = %d, want 1", tt.plane, tt.reason, got)
+			}
+		})
+	}
+}
+
+func TestPreAuthSourceLimitIsCountedAndLoggedWithoutLogFlooding(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxPreAuthConnections = maxPreAuthConnectionsPerIP + 2
+	srv := New(cfg, Dependencies{})
+
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	now := time.Unix(1_700_000_000, 0)
+	srv.capacityLogNow = func() time.Time { return now }
+
+	for i := range maxPreAuthConnectionsPerIP {
+		server, client := net.Pipe()
+		t.Cleanup(func() {
+			_ = server.Close()
+			_ = client.Close()
+		})
+		conn := remoteAddrConn{Conn: server, remote: testAddr(fmt.Sprintf("192.0.2.10:%d", 41000+i))}
+		if !srv.beginPreAuth(conn, preAuthScreen) {
+			t.Fatalf("screen pre-auth connection %d below source limit was rejected", i+1)
+		}
+	}
+
+	for range 2 {
+		server, client := net.Pipe()
+		t.Cleanup(func() {
+			_ = server.Close()
+			_ = client.Close()
+		})
+		rejected := remoteAddrConn{Conn: server, remote: testAddr("192.0.2.10:49999")}
+		if srv.admitPreAuthConn(rejected, preAuthScreen) {
+			t.Fatal("screen pre-auth connection above source limit was accepted")
+		}
+	}
+
+	if got := srv.metrics.PreAuthScreenSourceRejections.Load(); got != 2 {
+		t.Fatalf("screen source pre-auth rejections = %d, want 2", got)
+	}
+	if got := strings.Count(logs.String(), "capacity limit reached"); got != 1 {
+		t.Fatalf("capacity limit log entries = %d, want 1; logs=%q", got, logs.String())
+	}
+	for _, field := range []string{"kind=preauth", "plane=screen", "reason=source", "current=8", "limit=8"} {
+		if !strings.Contains(logs.String(), field) {
+			t.Fatalf("capacity log missing %q: %s", field, logs.String())
+		}
+	}
+
+	now = now.Add(capacityLogInterval)
+	server, client := net.Pipe()
+	t.Cleanup(func() {
+		_ = server.Close()
+		_ = client.Close()
+	})
+	rejected := remoteAddrConn{Conn: server, remote: testAddr("192.0.2.10:49998")}
+	if srv.admitPreAuthConn(rejected, preAuthScreen) {
+		t.Fatal("screen pre-auth connection above source limit was accepted after log interval")
+	}
+	if !strings.Contains(logs.String(), "suppressed=1") {
+		t.Fatalf("next capacity log did not report suppressed events: %s", logs.String())
+	}
+}
+
+func TestLimiterUsageSnapshotsIgnoreSourceIdentity(t *testing.T) {
+	auth := newAuthRateLimiter(3, time.Minute)
+	if !auth.Allow("192.0.2.10") {
+		t.Fatal("first auth reservation rejected")
+	}
+	auth.RecordFailure("192.0.2.10")
+	if !auth.Allow("192.0.2.10") {
+		t.Fatal("second auth reservation rejected")
+	}
+	if !auth.Allow("198.51.100.20") {
+		t.Fatal("independent auth reservation rejected")
+	}
+	authSnapshot := auth.usageSnapshot()
+	if authSnapshot.maxUsage != 2 || authSnapshot.activeSources != 2 {
+		t.Fatalf("auth usage snapshot = %+v, want max 2 across 2 sources", authSnapshot)
+	}
+
+	provision := newAccountProvisionLimiter(4, time.Hour)
+	for range 3 {
+		if !provision.Reserve("192.0.2.10") {
+			t.Fatal("provisioning reservation rejected")
+		}
+		provision.Commit("192.0.2.10")
+	}
+	provisionSnapshot := provision.usageSnapshot()
+	if provisionSnapshot.maxUsage != 3 || provisionSnapshot.activeSources != 1 {
+		t.Fatalf("provisioning usage snapshot = %+v, want max 3 across 1 source", provisionSnapshot)
+	}
+}
+
+func TestAuthenticationLimitRejectionIsCounted(t *testing.T) {
+	srv := New(DefaultConfig(), Dependencies{})
+	srv.authLimiter = newAuthRateLimiter(1, time.Minute)
+	const key = "192.0.2.10"
+	allowed, _, _, _ := srv.allowAuthWithObservability(key)
+	if !allowed {
+		t.Fatal("first authentication reservation rejected")
+	}
+	srv.authLimiter.RecordFailure(key)
+	allowed, reason, current, limit := srv.allowAuthWithObservability(key)
+	if allowed {
+		t.Fatal("authentication above source budget was accepted")
+	}
+	if reason != "source" || current != 1 || limit != 1 {
+		t.Fatalf("authentication rejection details = (%q, %d, %d), want (source, 1, 1)", reason, current, limit)
+	}
+	srv.recordAuthRateLimitRejection("192.0.2.10:41000", reason, current, limit)
+	if got := srv.metrics.AuthRateLimitSourceRejections.Load(); got != 1 {
+		t.Fatalf("authentication rate-limit rejections = %d, want 1", got)
+	}
+	if got := srv.metrics.AuthRateLimitSourceHighWater.Load(); got != 1 {
+		t.Fatalf("authentication source high-water mark = %d, want 1", got)
+	}
+}
+
+func TestBoundedLimiterRejectionReasonsAreCounted(t *testing.T) {
+	t.Run("authentication tracker capacity", func(t *testing.T) {
+		srv := New(DefaultConfig(), Dependencies{})
+		srv.authLimiter = newAuthRateLimiter(3, time.Minute)
+		srv.authLimiter.maxEntries = 1
+		if allowed, _, _, _ := srv.authLimiter.AllowWithDetails("192.0.2.10"); !allowed {
+			t.Fatal("first authentication source rejected")
+		}
+		allowed, reason, current, limit := srv.authLimiter.AllowWithDetails("198.51.100.20")
+		if allowed || reason != "tracker_capacity" || current != 1 || limit != 1 {
+			t.Fatalf("tracker rejection = (%t, %q, %d, %d), want (false, tracker_capacity, 1, 1)", allowed, reason, current, limit)
+		}
+		srv.recordAuthRateLimitRejection("198.51.100.20:41000", reason, current, limit)
+		if got := srv.metrics.AuthRateLimitTrackerRejections.Load(); got != 1 {
+			t.Fatalf("authentication tracker rejections = %d, want 1", got)
+		}
+	})
+
+	t.Run("provisioning window transition", func(t *testing.T) {
+		srv := New(DefaultConfig(), Dependencies{})
+		now := time.Unix(1_700_000_000, 0)
+		srv.accountProvisionLimiter = newAccountProvisionLimiter(2, time.Hour)
+		srv.accountProvisionLimiter.now = func() time.Time { return now }
+		if reserved, _, _, _ := srv.accountProvisionLimiter.ReserveWithDetails("192.0.2.10"); !reserved {
+			t.Fatal("first provisioning reservation rejected")
+		}
+		now = now.Add(time.Hour)
+		reserved, reason, current, limit := srv.accountProvisionLimiter.ReserveWithDetails("192.0.2.10")
+		if reserved || reason != "window_transition" || current != 1 || limit != 2 {
+			t.Fatalf("window rejection = (%t, %q, %d, %d), want (false, window_transition, 1, 2)", reserved, reason, current, limit)
+		}
+		srv.recordAccountProvisionRejection("192.0.2.10:41000", reason, current, limit)
+		if got := srv.metrics.AccountProvisionWindowRejections.Load(); got != 1 {
+			t.Fatalf("account provisioning window rejections = %d, want 1", got)
+		}
+	})
+}
+
+func TestMetricsEndpointExposesCapacityWithoutSourceLabels(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxPreAuthConnections = 2
+	srv := New(cfg, Dependencies{})
+	srv.authLimiter = newAuthRateLimiter(3, time.Minute)
+	srv.authLimiter.maxEntries = 7
+	srv.accountProvisionLimiter = newAccountProvisionLimiter(4, time.Hour)
+	srv.accountProvisionLimiter.maxEntries = 9
+
+	server, client := net.Pipe()
+	t.Cleanup(func() {
+		_ = server.Close()
+		_ = client.Close()
+	})
+	conn := remoteAddrConn{Conn: server, remote: testAddr("192.0.2.10:41000")}
+	if !srv.beginPreAuth(conn, preAuthControl) {
+		t.Fatal("pre-auth connection rejected")
+	}
+
+	authAllowed, _, _, _ := srv.allowAuthWithObservability("192.0.2.10")
+	if !authAllowed {
+		t.Fatal("auth reservation rejected")
+	}
+	srv.authLimiter.RecordFailure("192.0.2.10")
+	provisionReserved, _, _, _ := srv.reserveAccountWithObservability("192.0.2.10")
+	if !provisionReserved {
+		t.Fatal("provisioning reservation rejected")
+	}
+	srv.accountProvisionLimiter.Commit("192.0.2.10")
+
+	recorder := httptest.NewRecorder()
+	srv.handleMetrics(recorder, httptest.NewRequestWithContext(context.Background(), "GET", "/metrics", nil))
+	body := recorder.Body.String()
+	for _, line := range []string{
+		`gospeak_preauth_connections{plane="control"} 1`,
+		`gospeak_preauth_connections_high_water{plane="control"} 1`,
+		`gospeak_preauth_connection_limit{plane="control"} 2`,
+		`gospeak_preauth_source_max_connections{plane="control"} 1`,
+		`gospeak_preauth_source_max_connections_high_water{plane="control"} 1`,
+		`gospeak_preauth_source_connection_limit{plane="control"} 8`,
+		`gospeak_preauth_rejections_total{plane="control",reason="global"} 0`,
+		`gospeak_auth_rate_limit_source_max_usage 1`,
+		`gospeak_auth_rate_limit_source_high_water_usage 1`,
+		`gospeak_auth_rate_limit_source_limit 3`,
+		`gospeak_auth_rate_limit_tracker_limit 7`,
+		`gospeak_auth_rate_limit_rejections_total{reason="source"} 0`,
+		`gospeak_auth_rate_limit_rejections_total{reason="tracker_capacity"} 0`,
+		`gospeak_auth_rate_limit_rejections_total{reason="window_transition"} 0`,
+		`gospeak_account_provisioning_source_max_usage 1`,
+		`gospeak_account_provisioning_source_high_water_usage 1`,
+		`gospeak_account_provisioning_source_limit 4`,
+		`gospeak_account_provisioning_tracker_limit 9`,
+		`gospeak_account_provisioning_rejections_total{reason="source"} 0`,
+		`gospeak_account_provisioning_rejections_total{reason="tracker_capacity"} 0`,
+		`gospeak_account_provisioning_rejections_total{reason="window_transition"} 0`,
+	} {
+		if !strings.Contains(body, line+"\n") {
+			t.Fatalf("metrics output missing %q:\n%s", line, body)
+		}
+	}
+	if strings.Contains(body, "192.0.2.10") {
+		t.Fatalf("metrics output exposed source identity:\n%s", body)
+	}
+}

--- a/pkg/server/control.go
+++ b/pkg/server/control.go
@@ -178,14 +178,22 @@ func newAuthRateLimiter(maxAttempts int, window time.Duration) *authRateLimiter 
 }
 
 func (rl *authRateLimiter) Allow(key string) bool {
+	allowed, _, _, _ := rl.AllowWithDetails(key)
+	return allowed
+}
+
+func (rl *authRateLimiter) AllowWithDetails(key string) (allowed bool, reason string, current, limit int) {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
+	return rl.allowWithDetailsLocked(key)
+}
 
+func (rl *authRateLimiter) allowWithDetailsLocked(key string) (allowed bool, reason string, current, limit int) {
 	now := rl.now()
 	entry, ok := rl.entries[key]
 	if ok && !now.Before(entry.resetAt) {
 		if entry.inFlight > 0 {
-			return false
+			return false, "window_transition", entry.count + entry.inFlight, rl.maxAttempts
 		}
 		delete(rl.entries, key)
 		entry = nil
@@ -199,17 +207,17 @@ func (rl *authRateLimiter) Allow(key string) bool {
 				}
 			}
 			if len(rl.entries) >= rl.maxEntries {
-				return false
+				return false, "tracker_capacity", len(rl.entries), rl.maxEntries
 			}
 		}
 		entry = &authEntry{resetAt: now.Add(rl.window)}
 		rl.entries[key] = entry
 	}
 	if entry.count+entry.inFlight >= rl.maxAttempts {
-		return false
+		return false, "source", entry.count + entry.inFlight, rl.maxAttempts
 	}
 	entry.inFlight++
-	return true
+	return true, "", entry.count + entry.inFlight, rl.maxAttempts
 }
 
 func (rl *authRateLimiter) RecordFailure(key string) {
@@ -262,13 +270,22 @@ func newAccountProvisionLimiter(maxSuccess int, window time.Duration) *accountPr
 }
 
 func (rl *accountProvisionLimiter) Reserve(key string) bool {
+	reserved, _, _, _ := rl.ReserveWithDetails(key)
+	return reserved
+}
+
+func (rl *accountProvisionLimiter) ReserveWithDetails(key string) (reserved bool, reason string, current, limit int) {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
+	return rl.reserveWithDetailsLocked(key)
+}
+
+func (rl *accountProvisionLimiter) reserveWithDetailsLocked(key string) (reserved bool, reason string, current, limit int) {
 	now := rl.now()
 	entry, ok := rl.entries[key]
 	if ok && !now.Before(entry.resetAt) {
 		if entry.inFlight > 0 {
-			return false
+			return false, "window_transition", entry.successes + entry.inFlight, rl.maxSuccess
 		}
 		delete(rl.entries, key)
 		entry = nil
@@ -282,17 +299,17 @@ func (rl *accountProvisionLimiter) Reserve(key string) bool {
 				}
 			}
 			if len(rl.entries) >= rl.maxEntries {
-				return false
+				return false, "tracker_capacity", len(rl.entries), rl.maxEntries
 			}
 		}
 		entry = &accountProvisionEntry{resetAt: now.Add(rl.window)}
 		rl.entries[key] = entry
 	}
 	if entry.successes+entry.inFlight >= rl.maxSuccess {
-		return false
+		return false, "source", entry.successes + entry.inFlight, rl.maxSuccess
 	}
 	entry.inFlight++
-	return true
+	return true, "", entry.successes + entry.inFlight, rl.maxSuccess
 }
 
 func (rl *accountProvisionLimiter) Release(key string) {
@@ -474,9 +491,7 @@ func (s *Server) StartControl(st datastore.DataProviderFactory) error {
 					continue
 				}
 			}
-			if !s.beginPreAuth(conn, preAuthControl) {
-				slog.Warn("control pre-auth connection limit reached", "remote", conn.RemoteAddr())
-				_ = conn.Close()
+			if !s.admitPreAuthConn(conn, preAuthControl) {
 				continue
 			}
 			acceptedConn := conn
@@ -541,8 +556,9 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 	slog.Debug("new control connection", "remote", remoteAddr)
 
 	// Rate limit failed authentication attempts per remote IP.
-	if !s.authLimiter.Allow(rateLimitKey) {
-		slog.Warn("rate limited", "remote", remoteAddr)
+	authAllowed, authReason, authUsage, authLimit := s.allowAuthWithObservability(rateLimitKey)
+	if !authAllowed {
+		s.recordAuthRateLimitRejection(remoteAddr, authReason, authUsage, authLimit)
 		return
 	}
 	authenticated := false
@@ -626,9 +642,10 @@ func (s *Server) handleControlConn(handler *ControlHandler, conn net.Conn, st da
 		}
 
 		if !bootstrapProvisioned {
-			if !s.accountProvisionLimiter.Reserve(rateLimitKey) {
+			provisionReserved, provisionReason, provisionUsage, provisionLimit := s.reserveAccountWithObservability(rateLimitKey)
+			if !provisionReserved {
 				s.metrics.FailedAuths.Add(1)
-				slog.Warn("account provisioning rate limited", "remote", remoteAddr)
+				s.recordAccountProvisionRejection(remoteAddr, provisionReason, provisionUsage, provisionLimit)
 				sendError(conn, 2, "authentication failed")
 				return
 			}

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -19,6 +19,26 @@ type Metrics struct {
 	SuccessfulAuths   atomic.Int64 // successful authentication attempts
 	TotalDisconnects  atomic.Int64 // total client disconnects (clean + unclean)
 
+	// Capacity-limit counters and startup-lifetime high-water marks. Current
+	// occupancy and configured limits are read from owning server state when
+	// Prometheus scrapes.
+	PreAuthControlGlobalRejections    atomic.Int64
+	PreAuthControlSourceRejections    atomic.Int64
+	PreAuthScreenGlobalRejections     atomic.Int64
+	PreAuthScreenSourceRejections     atomic.Int64
+	PreAuthControlHighWater           atomic.Int64
+	PreAuthControlSourceHighWater     atomic.Int64
+	PreAuthScreenHighWater            atomic.Int64
+	PreAuthScreenSourceHighWater      atomic.Int64
+	AuthRateLimitSourceRejections     atomic.Int64
+	AuthRateLimitTrackerRejections    atomic.Int64
+	AuthRateLimitWindowRejections     atomic.Int64
+	AuthRateLimitSourceHighWater      atomic.Int64
+	AccountProvisionSourceRejections  atomic.Int64
+	AccountProvisionTrackerRejections atomic.Int64
+	AccountProvisionWindowRejections  atomic.Int64
+	AccountProvisionSourceHighWater   atomic.Int64
+
 	// Voice counters
 	VoicePacketsIn      atomic.Int64 // total UDP voice packets received
 	VoicePacketsOut     atomic.Int64 // total UDP voice packets forwarded
@@ -66,6 +86,23 @@ type MetricsSnapshot struct {
 	FailedAuths       int64 `json:"failed_auths"`
 	TotalDisconnects  int64 `json:"total_disconnects"`
 
+	PreAuthControlGlobalRejections    int64 `json:"preauth_control_global_rejections"`
+	PreAuthControlSourceRejections    int64 `json:"preauth_control_source_rejections"`
+	PreAuthScreenGlobalRejections     int64 `json:"preauth_screen_global_rejections"`
+	PreAuthScreenSourceRejections     int64 `json:"preauth_screen_source_rejections"`
+	PreAuthControlHighWater           int64 `json:"preauth_control_high_water"`
+	PreAuthControlSourceHighWater     int64 `json:"preauth_control_source_high_water"`
+	PreAuthScreenHighWater            int64 `json:"preauth_screen_high_water"`
+	PreAuthScreenSourceHighWater      int64 `json:"preauth_screen_source_high_water"`
+	AuthRateLimitSourceRejections     int64 `json:"auth_rate_limit_source_rejections"`
+	AuthRateLimitTrackerRejections    int64 `json:"auth_rate_limit_tracker_rejections"`
+	AuthRateLimitWindowRejections     int64 `json:"auth_rate_limit_window_rejections"`
+	AuthRateLimitSourceHighWater      int64 `json:"auth_rate_limit_source_high_water"`
+	AccountProvisionSourceRejections  int64 `json:"account_provision_source_rejections"`
+	AccountProvisionTrackerRejections int64 `json:"account_provision_tracker_rejections"`
+	AccountProvisionWindowRejections  int64 `json:"account_provision_window_rejections"`
+	AccountProvisionSourceHighWater   int64 `json:"account_provision_source_high_water"`
+
 	VoicePacketsIn      int64 `json:"voice_packets_in"`
 	VoicePacketsOut     int64 `json:"voice_packets_out"`
 	VoicePacketsDropped int64 `json:"voice_packets_dropped"`
@@ -94,31 +131,47 @@ type MetricsSnapshot struct {
 func (m *Metrics) Snapshot() MetricsSnapshot {
 	uptime := time.Since(m.startTime)
 	return MetricsSnapshot{
-		Uptime:                 uptime.Truncate(time.Second).String(),
-		UptimeSeconds:          int64(uptime.Seconds()),
-		ActiveConnections:      m.ActiveConnections.Load(),
-		TotalConnections:       m.TotalConnections.Load(),
-		SuccessfulAuths:        m.SuccessfulAuths.Load(),
-		FailedAuths:            m.FailedAuths.Load(),
-		TotalDisconnects:       m.TotalDisconnects.Load(),
-		VoicePacketsIn:         m.VoicePacketsIn.Load(),
-		VoicePacketsOut:        m.VoicePacketsOut.Load(),
-		VoicePacketsDropped:    m.VoicePacketsDropped.Load(),
-		VoiceBytesIn:           m.VoiceBytesIn.Load(),
-		VoiceBytesOut:          m.VoiceBytesOut.Load(),
-		ChatMessagesSent:       m.ChatMessagesSent.Load(),
-		ScreenSharesStarted:    m.ScreenSharesStarted.Load(),
-		ScreenSharesStopped:    m.ScreenSharesStopped.Load(),
-		ScreenShareFramesIn:    m.ScreenShareFramesIn.Load(),
-		ScreenShareFramesOut:   m.ScreenShareFramesOut.Load(),
-		ScreenShareBytesIn:     m.ScreenShareBytesIn.Load(),
-		ScreenShareBytesOut:    m.ScreenShareBytesOut.Load(),
-		ScreenShareSubscribers: m.ScreenShareSubscribers.Load(),
-		ChannelsCreated:        m.ChannelsCreated.Load(),
-		ChannelsDeleted:        m.ChannelsDeleted.Load(),
-		TokensCreated:          m.TokensCreated.Load(),
-		KickCount:              m.KickCount.Load(),
-		BanCount:               m.BanCount.Load(),
+		Uptime:                            uptime.Truncate(time.Second).String(),
+		UptimeSeconds:                     int64(uptime.Seconds()),
+		ActiveConnections:                 m.ActiveConnections.Load(),
+		TotalConnections:                  m.TotalConnections.Load(),
+		SuccessfulAuths:                   m.SuccessfulAuths.Load(),
+		FailedAuths:                       m.FailedAuths.Load(),
+		TotalDisconnects:                  m.TotalDisconnects.Load(),
+		PreAuthControlGlobalRejections:    m.PreAuthControlGlobalRejections.Load(),
+		PreAuthControlSourceRejections:    m.PreAuthControlSourceRejections.Load(),
+		PreAuthScreenGlobalRejections:     m.PreAuthScreenGlobalRejections.Load(),
+		PreAuthScreenSourceRejections:     m.PreAuthScreenSourceRejections.Load(),
+		PreAuthControlHighWater:           m.PreAuthControlHighWater.Load(),
+		PreAuthControlSourceHighWater:     m.PreAuthControlSourceHighWater.Load(),
+		PreAuthScreenHighWater:            m.PreAuthScreenHighWater.Load(),
+		PreAuthScreenSourceHighWater:      m.PreAuthScreenSourceHighWater.Load(),
+		AuthRateLimitSourceRejections:     m.AuthRateLimitSourceRejections.Load(),
+		AuthRateLimitTrackerRejections:    m.AuthRateLimitTrackerRejections.Load(),
+		AuthRateLimitWindowRejections:     m.AuthRateLimitWindowRejections.Load(),
+		AuthRateLimitSourceHighWater:      m.AuthRateLimitSourceHighWater.Load(),
+		AccountProvisionSourceRejections:  m.AccountProvisionSourceRejections.Load(),
+		AccountProvisionTrackerRejections: m.AccountProvisionTrackerRejections.Load(),
+		AccountProvisionWindowRejections:  m.AccountProvisionWindowRejections.Load(),
+		AccountProvisionSourceHighWater:   m.AccountProvisionSourceHighWater.Load(),
+		VoicePacketsIn:                    m.VoicePacketsIn.Load(),
+		VoicePacketsOut:                   m.VoicePacketsOut.Load(),
+		VoicePacketsDropped:               m.VoicePacketsDropped.Load(),
+		VoiceBytesIn:                      m.VoiceBytesIn.Load(),
+		VoiceBytesOut:                     m.VoiceBytesOut.Load(),
+		ChatMessagesSent:                  m.ChatMessagesSent.Load(),
+		ScreenSharesStarted:               m.ScreenSharesStarted.Load(),
+		ScreenSharesStopped:               m.ScreenSharesStopped.Load(),
+		ScreenShareFramesIn:               m.ScreenShareFramesIn.Load(),
+		ScreenShareFramesOut:              m.ScreenShareFramesOut.Load(),
+		ScreenShareBytesIn:                m.ScreenShareBytesIn.Load(),
+		ScreenShareBytesOut:               m.ScreenShareBytesOut.Load(),
+		ScreenShareSubscribers:            m.ScreenShareSubscribers.Load(),
+		ChannelsCreated:                   m.ChannelsCreated.Load(),
+		ChannelsDeleted:                   m.ChannelsDeleted.Load(),
+		TokensCreated:                     m.TokensCreated.Load(),
+		KickCount:                         m.KickCount.Load(),
+		BanCount:                          m.BanCount.Load(),
 	}
 }
 

--- a/pkg/server/metrics_http.go
+++ b/pkg/server/metrics_http.go
@@ -80,6 +80,11 @@ func (s *Server) startMetricsHTTP() error {
 func (s *Server) handleMetrics(w http.ResponseWriter, _ *http.Request) {
 	m := s.metrics
 	uptime := time.Since(m.startTime).Seconds()
+	preAuth := s.preAuthCapacitySnapshot()
+	authUsage := s.authLimiter.usageSnapshot()
+	provisionUsage := s.accountProvisionLimiter.usageSnapshot()
+	authHighWater := max(m.AuthRateLimitSourceHighWater.Load(), int64(authUsage.maxUsage))
+	provisionHighWater := max(m.AccountProvisionSourceHighWater.Load(), int64(provisionUsage.maxUsage))
 
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 
@@ -95,6 +100,13 @@ func (s *Server) handleMetrics(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprintf(w, "# TYPE %s %s\n", name, mtype)
 		_, _ = fmt.Fprintf(w, "%s %f\n", name, value)
 	}
+	writeLabeled := func(name, labels string, value int64) {
+		_, _ = fmt.Fprintf(w, "%s{%s} %d\n", name, labels, value)
+	}
+	writeHeader := func(name, help, mtype string) {
+		_, _ = fmt.Fprintf(w, "# HELP %s %s\n", name, help)
+		_, _ = fmt.Fprintf(w, "# TYPE %s %s\n", name, mtype)
+	}
 
 	writeFloat("gospeak_uptime_seconds", "Server uptime in seconds.", "gauge", uptime)
 
@@ -109,6 +121,60 @@ func (s *Server) handleMetrics(w http.ResponseWriter, _ *http.Request) {
 		m.SuccessfulAuths.Load())
 	write("gospeak_auth_failed_total", "Failed authentication attempts.", "counter",
 		m.FailedAuths.Load())
+
+	writeHeader("gospeak_preauth_connections", "Current unauthenticated TCP connections by plane.", "gauge")
+	writeHeader("gospeak_preauth_connections_high_water", "Highest unauthenticated connection occupancy since server start by plane.", "gauge")
+	writeHeader("gospeak_preauth_connection_limit", "Configured global unauthenticated connection limit by plane.", "gauge")
+	writeHeader("gospeak_preauth_active_sources", "Current source keys with unauthenticated connections by plane.", "gauge")
+	writeHeader("gospeak_preauth_source_max_connections", "Current highest unauthenticated connection occupancy for one source key by plane.", "gauge")
+	writeHeader("gospeak_preauth_source_max_connections_high_water", "Highest single-source unauthenticated connection occupancy since server start by plane.", "gauge")
+	writeHeader("gospeak_preauth_source_connection_limit", "Configured unauthenticated connection limit for one source key by plane.", "gauge")
+	writeHeader("gospeak_preauth_rejections_total", "Unauthenticated connections rejected at a capacity limit.", "counter")
+	for _, plane := range []preAuthPlane{preAuthControl, preAuthScreen} {
+		planeLabel := fmt.Sprintf(`plane=%q`, plane)
+		writeLabeled("gospeak_preauth_connections", planeLabel, int64(preAuth.current[plane]))
+		writeLabeled("gospeak_preauth_connection_limit", planeLabel, int64(s.cfg.MaxPreAuthConnections))
+		writeLabeled("gospeak_preauth_active_sources", planeLabel, int64(preAuth.activeSources[plane]))
+		writeLabeled("gospeak_preauth_source_max_connections", planeLabel, int64(preAuth.maxBySource[plane]))
+		writeLabeled("gospeak_preauth_source_connection_limit", planeLabel, maxPreAuthConnectionsPerIP)
+
+		var globalRejections, sourceRejections, globalHighWater, sourceHighWater int64
+		if plane == preAuthControl {
+			globalRejections = m.PreAuthControlGlobalRejections.Load()
+			sourceRejections = m.PreAuthControlSourceRejections.Load()
+			globalHighWater = m.PreAuthControlHighWater.Load()
+			sourceHighWater = m.PreAuthControlSourceHighWater.Load()
+		} else {
+			globalRejections = m.PreAuthScreenGlobalRejections.Load()
+			sourceRejections = m.PreAuthScreenSourceRejections.Load()
+			globalHighWater = m.PreAuthScreenHighWater.Load()
+			sourceHighWater = m.PreAuthScreenSourceHighWater.Load()
+		}
+		writeLabeled("gospeak_preauth_connections_high_water", planeLabel, globalHighWater)
+		writeLabeled("gospeak_preauth_source_max_connections_high_water", planeLabel, sourceHighWater)
+		writeLabeled("gospeak_preauth_rejections_total", planeLabel+`,reason="global"`, globalRejections)
+		writeLabeled("gospeak_preauth_rejections_total", planeLabel+`,reason="source"`, sourceRejections)
+	}
+
+	write("gospeak_auth_rate_limit_source_max_usage", "Current highest authentication budget usage for one source key.", "gauge", int64(authUsage.maxUsage))
+	write("gospeak_auth_rate_limit_source_high_water_usage", "Highest single-source authentication budget usage since server start.", "gauge", authHighWater)
+	write("gospeak_auth_rate_limit_active_sources", "Current source keys tracked by the authentication limiter.", "gauge", int64(authUsage.activeSources))
+	write("gospeak_auth_rate_limit_source_limit", "Configured authentication attempt limit for one source key.", "gauge", int64(authUsage.sourceLimit))
+	write("gospeak_auth_rate_limit_tracker_limit", "Configured maximum source keys tracked by the authentication limiter.", "gauge", int64(authUsage.trackerLimit))
+	writeHeader("gospeak_auth_rate_limit_rejections_total", "Authentication attempts rejected by the rate limiter.", "counter")
+	writeLabeled("gospeak_auth_rate_limit_rejections_total", `reason="source"`, m.AuthRateLimitSourceRejections.Load())
+	writeLabeled("gospeak_auth_rate_limit_rejections_total", `reason="tracker_capacity"`, m.AuthRateLimitTrackerRejections.Load())
+	writeLabeled("gospeak_auth_rate_limit_rejections_total", `reason="window_transition"`, m.AuthRateLimitWindowRejections.Load())
+
+	write("gospeak_account_provisioning_source_max_usage", "Current highest account provisioning budget usage for one source key.", "gauge", int64(provisionUsage.maxUsage))
+	write("gospeak_account_provisioning_source_high_water_usage", "Highest single-source account provisioning budget usage since server start.", "gauge", provisionHighWater)
+	write("gospeak_account_provisioning_active_sources", "Current source keys tracked by the account provisioning limiter.", "gauge", int64(provisionUsage.activeSources))
+	write("gospeak_account_provisioning_source_limit", "Configured successful account provisioning limit for one source key.", "gauge", int64(provisionUsage.sourceLimit))
+	write("gospeak_account_provisioning_tracker_limit", "Configured maximum source keys tracked by the account provisioning limiter.", "gauge", int64(provisionUsage.trackerLimit))
+	writeHeader("gospeak_account_provisioning_rejections_total", "Account provisioning attempts rejected by the limiter.", "counter")
+	writeLabeled("gospeak_account_provisioning_rejections_total", `reason="source"`, m.AccountProvisionSourceRejections.Load())
+	writeLabeled("gospeak_account_provisioning_rejections_total", `reason="tracker_capacity"`, m.AccountProvisionTrackerRejections.Load())
+	writeLabeled("gospeak_account_provisioning_rejections_total", `reason="window_transition"`, m.AccountProvisionWindowRejections.Load())
 
 	write("gospeak_voice_packets_in_total", "Total UDP voice packets received.", "counter",
 		m.VoicePacketsIn.Load())

--- a/pkg/server/screen.go
+++ b/pkg/server/screen.go
@@ -57,9 +57,7 @@ func (s *Server) StartScreen() error {
 					continue
 				}
 			}
-			if !s.beginPreAuth(conn, preAuthScreen) {
-				slog.Warn("screen pre-auth connection limit reached", "remote", conn.RemoteAddr())
-				_ = conn.Close()
+			if !s.admitPreAuthConn(conn, preAuthScreen) {
 				continue
 			}
 			acceptedConn := conn

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -89,6 +89,10 @@ type Server struct {
 	acceptedConns           map[net.Conn]trackedConn
 	preAuthCount            map[preAuthPlane]int
 	preAuthByIP             map[preAuthPlane]map[string]int
+	capacityLogMu           sync.Mutex
+	capacityLogLast         map[string]time.Time
+	capacityLogDrop         map[string]int64
+	capacityLogNow          func() time.Time
 
 	// Per-session voice debug counters (reset each debug interval; only used when debug is enabled)
 	voiceDebugEnabled bool
@@ -122,6 +126,9 @@ func New(cfg Config, deps Dependencies) *Server {
 		acceptedConns:           make(map[net.Conn]trackedConn),
 		preAuthCount:            make(map[preAuthPlane]int),
 		preAuthByIP:             make(map[preAuthPlane]map[string]int),
+		capacityLogLast:         make(map[string]time.Time),
+		capacityLogDrop:         make(map[string]int64),
+		capacityLogNow:          time.Now,
 		ctx:                     ctx,
 		cancel:                  cancel,
 	}
@@ -185,14 +192,26 @@ const (
 
 func (s *Server) beginPreAuth(conn net.Conn, plane preAuthPlane) bool {
 	s.preAuthMu.Lock()
-	defer s.preAuthMu.Unlock()
 	if _, ok := s.acceptedConns[conn]; ok {
+		s.preAuthMu.Unlock()
 		return true
 	}
+	if s.ctx.Err() != nil {
+		s.preAuthMu.Unlock()
+		return false
+	}
+
 	admissionKey := authRateLimitKey(conn.RemoteAddr())
-	if s.ctx.Err() != nil ||
-		s.preAuthCount[plane] >= s.cfg.MaxPreAuthConnections ||
-		s.preAuthByIP[plane][admissionKey] >= maxPreAuthConnectionsPerIP {
+	globalCurrent := s.preAuthCount[plane]
+	if globalCurrent >= s.cfg.MaxPreAuthConnections {
+		s.preAuthMu.Unlock()
+		s.recordPreAuthRejection(plane, "global", conn.RemoteAddr().String(), globalCurrent, s.cfg.MaxPreAuthConnections)
+		return false
+	}
+	sourceCurrent := s.preAuthByIP[plane][admissionKey]
+	if sourceCurrent >= maxPreAuthConnectionsPerIP {
+		s.preAuthMu.Unlock()
+		s.recordPreAuthRejection(plane, "source", conn.RemoteAddr().String(), sourceCurrent, maxPreAuthConnectionsPerIP)
 		return false
 	}
 	if s.preAuthByIP[plane] == nil {
@@ -201,6 +220,10 @@ func (s *Server) beginPreAuth(conn net.Conn, plane preAuthPlane) bool {
 	s.acceptedConns[conn] = trackedConn{plane: plane, preAuth: true, admissionKey: admissionKey}
 	s.preAuthCount[plane]++
 	s.preAuthByIP[plane][admissionKey]++
+	current := s.preAuthCount[plane]
+	sourceCurrent = s.preAuthByIP[plane][admissionKey]
+	s.observePreAuthUsage(plane, current, sourceCurrent)
+	s.preAuthMu.Unlock()
 	return true
 }
 
@@ -210,6 +233,14 @@ func (s *Server) releasePreAuth(tracked trackedConn) {
 	if s.preAuthByIP[tracked.plane][tracked.admissionKey] == 0 {
 		delete(s.preAuthByIP[tracked.plane], tracked.admissionKey)
 	}
+}
+
+func (s *Server) admitPreAuthConn(conn net.Conn, plane preAuthPlane) bool {
+	if s.beginPreAuth(conn, plane) {
+		return true
+	}
+	_ = conn.Close()
+	return false
 }
 
 func (s *Server) finishPreAuth(conn net.Conn) {


### PR DESCRIPTION
## Summary
- expose current usage, configured limits, and startup high-water marks for pre-auth admission, authentication, and account provisioning
- count rejections by bounded reason and add rate-limited structured warnings when limits are reached
- add a Grafana capacity section without exposing source addresses as Prometheus labels
- cover every plane/rejection combination and the authentication and provisioning control paths with deterministic tests