### PR TITLE
test(client): use platform config directory semantics

### DIFF
--- a/pkg/client/settings_test.go
+++ b/pkg/client/settings_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -28,8 +29,23 @@ func TestLoadSettingsMigratesLegacyFileToUserConfig(t *testing.T) {
 }
 
 func TestConfigFilePathUsesUserConfigDirectory(t *testing.T) {
-	configHome := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", configHome)
+	root := t.TempDir()
+	var configHome string
+	switch runtime.GOOS {
+	case "windows":
+		t.Setenv("AppData", root)
+		configHome = root
+	case "darwin", "ios":
+		t.Setenv("HOME", root)
+		configHome = filepath.Join(root, "Library", "Application Support")
+	case "plan9":
+		t.Setenv("home", root)
+		configHome = filepath.Join(root, "lib")
+	default:
+		t.Setenv("XDG_CONFIG_HOME", root)
+		configHome = root
+	}
+
 	got, err := configFilePath("settings.yaml")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- use HOME/Library/Application Support when testing the config path on macOS
- use the matching os.UserConfigDir environment semantics on Windows and other Unix systems
